### PR TITLE
Ndlano/issues#1076 show language markup text

### DIFF
--- a/src/components/SlateEditor/schema.jsx
+++ b/src/components/SlateEditor/schema.jsx
@@ -150,6 +150,8 @@ export const renderNode = props => {
       return <blockquote {...attributes}>{children}</blockquote>;
     case 'div':
       return <div {...attributes}>{children}</div>;
+    case 'span':
+      return <span {...attributes}>{children}</span>;
     default:
       return null;
   }

--- a/src/util/__tests__/__snapshots__/slateHelpers-test.js.snap
+++ b/src/util/__tests__/__snapshots__/slateHelpers-test.js.snap
@@ -1623,6 +1623,66 @@ Object {
 }
 `;
 
+exports[`deserializing a span with attributes 1`] = `
+Object {
+  "document": Object {
+    "data": Object {},
+    "kind": "document",
+    "nodes": Array [
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "kind": "block",
+        "nodes": Array [
+          Object {
+            "kind": "text",
+            "leaves": Array [
+              Object {
+                "kind": "leaf",
+                "marks": Array [],
+                "text": "",
+              },
+            ],
+          },
+          Object {
+            "data": Object {
+              "lang": "en",
+            },
+            "isVoid": false,
+            "kind": "inline",
+            "nodes": Array [
+              Object {
+                "kind": "text",
+                "leaves": Array [
+                  Object {
+                    "kind": "leaf",
+                    "marks": Array [],
+                    "text": "Hyper Text Markup Language",
+                  },
+                ],
+              },
+            ],
+            "type": "span",
+          },
+          Object {
+            "kind": "text",
+            "leaves": Array [
+              Object {
+                "kind": "leaf",
+                "marks": Array [],
+                "text": "",
+              },
+            ],
+          },
+        ],
+        "type": "paragraph",
+      },
+    ],
+  },
+  "kind": "value",
+}
+`;
+
 exports[`deserializing alphabetical list 1`] = `
 Object {
   "document": Object {
@@ -2511,6 +2571,8 @@ exports[`serialize footnote 1`] = `
 `;
 
 exports[`serializing a normal div block 1`] = `"<div><p>A paragraph</p></div>"`;
+
+exports[`serializing a span with attributes 1`] = `"<p><span lang=\\"en\\">Hyper Text Markup Language</span></p>"`;
 
 exports[`serializing br 1`] = `"<br/>"`;
 

--- a/src/util/__tests__/slateHelpers-test.js
+++ b/src/util/__tests__/slateHelpers-test.js
@@ -23,6 +23,7 @@ import {
   quoteValue,
   brValue,
   normalDivValue,
+  spanWithAttributesValue,
 } from './slateMockValues';
 import {
   footnoteRule,
@@ -31,6 +32,7 @@ import {
   divRule,
   toJSON,
   blockRules,
+  inlineRules,
   orderListRules,
   unorderListRules,
   tableRules,
@@ -100,6 +102,27 @@ test('serializing a normal div block', () => {
     parseHtml: fragment,
   });
   const value = Value.fromJSON(normalDivValue);
+  const serialized = serializer.serialize(value);
+  expect(serialized).toMatchSnapshot();
+});
+
+test('deserializing a span with attributes', () => {
+  const serializer = new Html({
+    rules: [inlineRules],
+    parseHtml: fragment,
+  });
+  const span = '<span lang="en">Hyper Text Markup Language</span>';
+  const deserialized = serializer.deserialize(span);
+  expect(toJSON(deserialized)).toMatchSnapshot();
+});
+
+test('serializing a span with attributes', () => {
+  const serializer = new Html({
+    rules: [paragraphRule, inlineRules],
+    parseHtml: fragment,
+  });
+
+  const value = Value.fromJSON(spanWithAttributesValue);
   const serialized = serializer.serialize(value);
   expect(serialized).toMatchSnapshot();
 });

--- a/src/util/__tests__/slateMockValues.js
+++ b/src/util/__tests__/slateMockValues.js
@@ -708,3 +708,61 @@ export const brValue = {
   },
   kind: 'value',
 };
+
+export const spanWithAttributesValue = {
+  document: {
+    data: {},
+    kind: 'document',
+    nodes: [
+      {
+        data: {},
+        isVoid: false,
+        kind: 'block',
+        nodes: [
+          {
+            kind: 'text',
+            leaves: [
+              {
+                kind: 'leaf',
+                marks: [],
+                text: '',
+              },
+            ],
+          },
+          {
+            data: {
+              lang: 'en',
+            },
+            isVoid: false,
+            kind: 'inline',
+            nodes: [
+              {
+                kind: 'text',
+                leaves: [
+                  {
+                    kind: 'leaf',
+                    marks: [],
+                    text: 'Hyper Text Markup Language',
+                  },
+                ],
+              },
+            ],
+            type: 'span',
+          },
+          {
+            kind: 'text',
+            leaves: [
+              {
+                kind: 'leaf',
+                marks: [],
+                text: '',
+              },
+            ],
+          },
+        ],
+        type: 'paragraph',
+      },
+    ],
+  },
+  kind: 'value',
+};

--- a/src/util/embedTagHelpers.js
+++ b/src/util/embedTagHelpers.js
@@ -10,6 +10,7 @@ import isObject from 'lodash/fp/isObject';
 import { isEmpty } from '../components/validators';
 
 export const reduceElementDataAttributes = el => {
+  if (!el.attributes) return null;
   const attrs = [].slice.call(el.attributes);
   const obj = attrs.reduce(
     (all, attr) =>
@@ -42,6 +43,11 @@ export const createEmbedProps = obj =>
   Object.keys(obj)
     .filter(key => obj[key] !== undefined && !isObject(obj[key]))
     .reduce((acc, key) => ({ ...acc, [`data-${key}`]: obj[key] }), {});
+
+export const createProps = obj =>
+  Object.keys(obj)
+    .filter(key => obj[key] !== undefined && !isObject(obj[key]))
+    .reduce((acc, key) => ({ ...acc, [key]: obj[key] }), {});
 
 export const parseEmbedTag = embedTag => {
   if (embedTag === '') {

--- a/src/util/slateHelpers.js
+++ b/src/util/slateHelpers.js
@@ -7,9 +7,11 @@
  */
 
 import React from 'react';
+import isEmpty from 'lodash/fp/isEmpty';
 import {
   reduceElementDataAttributes,
   createEmbedProps,
+  createProps,
   reduceChildElements,
 } from './embedTagHelpers';
 
@@ -26,6 +28,10 @@ export const BLOCK_TAGS = {
   h5: 'heading-two',
   h6: 'heading-two',
   br: 'br',
+};
+
+export const INLINE_TAGS = {
+  span: 'span',
 };
 
 export const TABLE_TAGS = {
@@ -322,6 +328,33 @@ export const blockRules = {
   },
 };
 
+export const inlineRules = {
+  deserialize(el, next) {
+    const inline = INLINE_TAGS[el.tagName.toLowerCase()];
+    const attributes = reduceElementDataAttributes(el);
+
+    if (!inline) return;
+    if (inline === 'span' && isEmpty(attributes)) return; // Keep only spans with attributes
+    return {
+      kind: 'inline',
+      type: inline,
+      data: attributes,
+      nodes: next(el.childNodes),
+    };
+  },
+  serialize(object, children) {
+    if (object.kind !== 'inline') return;
+    const data = object.data.toJS();
+    const props = createProps({
+      ...data,
+    });
+    switch (object.type) {
+      case 'span':
+        return <span {...props}>{children}</span>;
+    }
+  },
+};
+
 export const tableRules = {
   deserialize(el, next) {
     const tableTag = TABLE_TAGS[el.tagName.toLowerCase()];
@@ -396,6 +429,7 @@ const RULES = [
     },
   },
   blockRules,
+  inlineRules,
   {
     deserialize(el, next) {
       const mark = MARK_TAGS[el.tagName.toLowerCase()];

--- a/src/util/slateHelpers.js
+++ b/src/util/slateHelpers.js
@@ -345,9 +345,7 @@ export const inlineRules = {
   serialize(object, children) {
     if (object.kind !== 'inline') return;
     const data = object.data.toJS();
-    const props = createProps({
-      ...data,
-    });
+    const props = createProps(data);
     switch (object.type) {
       case 'span':
         return <span {...props}>{children}</span>;


### PR DESCRIPTION
Resolves https://github.com/NDLANO/Issues/issues/1076
Currently only keeping the data. No design on how to modify it.

Test article: `/subject-matter/learning-resource/667/edit/nb`

Test procedure
- [x] Check that span with attribute `lang: en` appears in slate node tree
- [x] Check that span with attribute `lang: en` is kept after saving article.