### PR TITLE
fix: upper case H5P name fix

### DIFF
--- a/src/components/DisplayEmbedTag/DisplayExternal.jsx
+++ b/src/components/DisplayEmbedTag/DisplayExternal.jsx
@@ -167,14 +167,15 @@ export class DisplayExternal extends Component {
             {...editorClasses('button', 'red')}>
             <Cross />
           </Button>
-          {providerName === 'h5p' && (
-            <Button
-              stripped
-              onClick={this.toggleEditH5p}
-              {...editorClasses('button', 'green')}>
-              <Pencil />
-            </Button>
-          )}
+          {providerName &&
+            providerName.toLowerCase() === 'h5p' && (
+              <Button
+                stripped
+                onClick={this.toggleEditH5p}
+                {...editorClasses('button', 'green')}>
+                <Pencil />
+              </Button>
+            )}
         </div>
         {renderProvider}
         {!renderProvider && (


### PR DESCRIPTION
`providerName` for H5P-s changed case in response

Test procedure:
- Check that edit button (pencil) appears on articles with H5P
- Check that edit button (pencil) appears when adding new H5Ps to articles