### PR TITLE
fix: silent callback auth renew causing error and logouts

### DIFF
--- a/src/server/Auth0SilentCallback.js
+++ b/src/server/Auth0SilentCallback.js
@@ -12,13 +12,13 @@ const Auth0SilentCallback = `
   <html lang="no">
     <head />
     <body>
-      <script src="https://cdn.auth0.com/js/auth0/9.3.2/auth0.min.js"></script>
+      <script src="https://cdn.auth0.com/js/auth0/9.8.0/auth0.min.js"></script>
       <script type="text/javascript">
         var webAuth = new auth0.WebAuth({
           domain: '${config.auth0Domain}',
           clientID: '${config.ndlaPersonalClientId}'
         });
-        var result = webAuth.parseHash(window.location.hash, function(err, data) {
+        var result = webAuth.parseHash({ hash: window.location.hash }, function(err, data) {
           parent.postMessage(err || data, window.location.origin);
         });
       </script>


### PR DESCRIPTION
resolves https://github.com/NDLANO/Issues/issues/1345

Auth0 error when renewing token causing client to logout.

Test case:
- [x] Insert a H5P into a new article
- [x] Edit existing H5P in article