### PR TITLE
Fixes learningpath frontend domain url in prod #1369

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -41,7 +41,7 @@ const learningpathFrontendDomain = () => {
     case 'local':
       return 'http://localhost:30017';
     case 'prod':
-      return 'https://beta.sti.ndla.no';
+      return 'https://stier.ndla.no';
     default:
       return `https://learningpath-frontend.${ndlaEnvironment}.api.ndla.no`;
   }


### PR DESCRIPTION
- [ ] Clicking on the learning path button in the top menu should lead to `stier.ndla.no` in prod environment.