### PR TITLE
fix: handles line type blocks on paste

### DIFF
--- a/src/components/SlateEditor/plugins/pasteHandler/__tests__/__snapshots__/pasteHandler-test.js.snap
+++ b/src/components/SlateEditor/plugins/pasteHandler/__tests__/__snapshots__/pasteHandler-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Paste transforms plaintext line block type to paragraph type 1`] = `
+Object {
+  "data": Object {},
+  "nodes": Array [
+    Object {
+      "leaves": Array [
+        Object {
+          "marks": Array [],
+          "object": "leaf",
+          "text": "Text from PlaintextEditor",
+        },
+      ],
+      "object": "text",
+    },
+  ],
+  "object": "block",
+  "type": "paragraph",
+}
+`;

--- a/src/components/SlateEditor/plugins/pasteHandler/__tests__/pasteHandler-test.js
+++ b/src/components/SlateEditor/plugins/pasteHandler/__tests__/pasteHandler-test.js
@@ -1,0 +1,26 @@
+import { Block } from 'slate';
+import { convertToSupportedBlockTypes } from '..';
+
+const lineBlock = {
+  data: {},
+  nodes: [
+    {
+      leaves: [
+        {
+          marks: [],
+          object: 'leaf',
+          text: 'Text from PlaintextEditor',
+        },
+      ],
+      object: 'text',
+    },
+  ],
+  object: 'block',
+  type: 'line',
+};
+
+test('Paste transforms plaintext line block type to paragraph type', () => {
+  const pastedBlock = Block.fromJSON(lineBlock);
+  const convertedBlock = convertToSupportedBlockTypes(pastedBlock);
+  expect(convertedBlock.toJSON()).toMatchSnapshot();
+});

--- a/src/components/SlateEditor/plugins/pasteHandler/index.js
+++ b/src/components/SlateEditor/plugins/pasteHandler/index.js
@@ -6,21 +6,32 @@
  *
  */
 
-import { Document } from 'slate';
+import { Document, Block } from 'slate';
 import { getEventTransfer } from 'slate-react';
+
+export function convertToSupportedBlockTypes(block) {
+  switch (block.type) {
+    case 'line':
+      return Block.create({
+        type: 'paragraph',
+        nodes: block.nodes,
+      });
+    default:
+      return block;
+  }
+}
 
 function PasteHandler() {
   return {
     schema: {},
     onPaste(event, change) {
       const { fragment, text } = getEventTransfer(event);
-
       if (!fragment) return change.insertText(text);
 
       const textNode = fragment.getLastText();
       const closestBlock = fragment.getClosestBlock(textNode.key);
       const newFragment = Document.create({
-        nodes: [closestBlock],
+        nodes: [convertToSupportedBlockTypes(closestBlock)],
         isVoid: false,
       });
       return change.insertFragment(newFragment);


### PR DESCRIPTION
resolves https://github.com/NDLANO/Issues/issues/1352

Converts to paragraph when pasting into editor content

Test case:
- [ ]  Copy and paste content from ingress to article content and save article or navigate to new