### PR TITLE
Adds other language urls in the search #1385

### DIFF
--- a/src/containers/SearchPage/components/results/SearchContent.jsx
+++ b/src/containers/SearchPage/components/results/SearchContent.jsx
@@ -16,6 +16,7 @@ import {
   resourceToLinkProps,
 } from '../../../../util/resourceHelpers';
 import { searchClasses } from '../../SearchContainer';
+import SearchContentLanguage from './SearchContentLanguage';
 
 const SearchContent = ({ content, locale }) => {
   const { contexts, metaImage } = content;
@@ -51,15 +52,25 @@ const SearchContent = ({ content, locale }) => {
         <img src={url || '/placeholder.png'} alt={alt} />
       </div>
       <div {...searchClasses('content')}>
-        {linkProps && linkProps.href ? (
-          <a {...searchClasses('link')} {...linkProps}>
-            {contentTitle}
-          </a>
-        ) : (
-          <Link {...searchClasses('link')} to={linkProps.to}>
-            {contentTitle}
-          </Link>
-        )}
+        <div {...searchClasses('header')}>
+          {linkProps && linkProps.href ? (
+            <a {...searchClasses('link')} {...linkProps}>
+              {contentTitle}
+            </a>
+          ) : (
+            <Link {...searchClasses('link')} to={linkProps.to}>
+              {contentTitle}
+            </Link>
+          )}
+          {content.supportedLanguages.map(lang => (
+            <SearchContentLanguage
+              key={`${lang}_search_content`}
+              language={lang}
+              content={content}
+              contentType={resourceType.contentType}
+            />
+          ))}
+        </div>
         <p {...searchClasses('description')}>
           {content.metaDescription.metaDescription}
         </p>

--- a/src/containers/SearchPage/components/results/SearchContentLanguage.jsx
+++ b/src/containers/SearchPage/components/results/SearchContentLanguage.jsx
@@ -38,7 +38,7 @@ const SearchContentLanguage = ({ language, content, contentType, t }) => {
 SearchContentLanguage.propTypes = {
   content: ContentResultShape,
   language: PropTypes.string.isRequired,
-  contentType: PropTypes.string.isRequired,
+  contentType: PropTypes.string,
 };
 
 export default injectT(SearchContentLanguage);

--- a/src/containers/SearchPage/components/results/SearchContentLanguage.jsx
+++ b/src/containers/SearchPage/components/results/SearchContentLanguage.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectT } from 'ndla-i18n';
+import { Link } from 'react-router-dom';
+import { resourceToLinkProps } from '../../../../util/resourceHelpers';
+import { ContentResultShape } from '../../../../shapes';
+import { searchClasses } from '../../SearchContainer';
+
+const supported = ['en', 'nb', 'nn'];
+
+const SearchContentLanguage = ({ language, content, contentType, t }) => {
+  if (!supported.includes(language) || content.title.language === language) {
+    return null;
+  }
+  const linkProps = resourceToLinkProps(content, contentType, language);
+
+  const link =
+    linkProps && linkProps.href ? (
+      <a {...searchClasses('link')} {...linkProps}>
+        {t(`language.${language}`)}
+      </a>
+    ) : (
+      <Link {...searchClasses('link')} to={linkProps.to}>
+        {t(`language.${language}`)}
+      </Link>
+    );
+  return <span {...searchClasses('other-link')}>{link}</span>;
+};
+
+SearchContentLanguage.propTypes = {
+  content: ContentResultShape,
+  language: PropTypes.string.isRequired,
+  contentType: PropTypes.string.isRequired,
+};
+
+export default injectT(SearchContentLanguage);

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -108,6 +108,7 @@ const phrases = {
     en: 'English',
     nb: 'Norwegian - Bokmål',
     nn: 'Norwegian - Nynorsk',
+    se: 'Swedish',
     unknown: 'Unknown',
     de: 'German',
     empty: 'No languages left',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -106,6 +106,7 @@ const phrases = {
     en: 'Engelsk',
     nb: 'Bokmål',
     nn: 'Nynorsk',
+    se: 'Svensk',
     unknown: 'Ukjent',
     de: 'Tysk',
     empty: 'Ingen flere språk',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -106,6 +106,7 @@ const phrases = {
     en: 'Engelsk',
     nb: 'Bokmål',
     nn: 'Nynorsk',
+    se: 'Svensk',
     unknown: 'Ukjent',
     de: 'Tysk',
     empty: 'Ingen flere språk',

--- a/src/style/search.css
+++ b/src/style/search.css
@@ -29,6 +29,12 @@
     }
   }
 
+  &__other-link:not(:last-child) {
+    &::after {
+      content: ' / ';
+    }
+  }
+
   &__content {
     display: inline-block;
     width: 90%;

--- a/src/util/resourceHelpers.js
+++ b/src/util/resourceHelpers.js
@@ -49,6 +49,7 @@ export const getResourceLanguages = t => [
   { id: 'nb', name: t('language.nb') },
   { id: 'nn', name: t('language.nn') },
   { id: 'en', name: t('language.en') },
+  { id: 'se', name: t('language.se') },
   { id: 'de', name: t('language.de') },
   { id: 'unknown', name: t('language.unknown') },
 ];
@@ -67,7 +68,7 @@ const isLearningPathResourceType = contentType =>
 export const resourceToLinkProps = (content, contentType, locale) => {
   if (isLearningPathResourceType(contentType)) {
     return {
-      href: `${config.learningpathFrontendDomain}/learningpaths/${
+      href: `${config.learningpathFrontendDomain}/${locale}/learningpaths/${
         content.id
       }/first-step`,
       target: '_blank',


### PR DESCRIPTION
Resolves 1385

This pullrequest adds alternative URLs for results in the search on different languages. The fix should support the following:
- [x] If article/learningpath has supported languages, show them as url and link correctly url with correct locale.
- [x] Should not show the language that is the main result.
- [x] Only `en`, `nb` and `nn` are shown languages (depending on the result).