### PR TITLE
Remove warning modal

### DIFF
--- a/src/components/SlateEditor/plugins/embed/FigureButtons.jsx
+++ b/src/components/SlateEditor/plugins/embed/FigureButtons.jsx
@@ -14,26 +14,16 @@ import { injectT } from '@ndla/i18n';
 import { Cross, Pencil, Plus } from '@ndla/icons/action';
 import { editorClasses } from './SlateFigure';
 import { EmbedShape } from '../../../../shapes';
-import WarningModal from '../../../WarningModal';
 
 export class FigureButtons extends React.Component {
   constructor() {
     super();
-    this.state = { showDeleteConfirmation: false };
-    this.toggleDelete = this.toggleDelete.bind(this);
     this.onDeleteConfirm = this.onDeleteConfirm.bind(this);
   }
 
   onDeleteConfirm(e) {
     const { onRemoveClick } = this.props;
-    this.setState({ showDeleteConfirmation: false });
     onRemoveClick(e);
-  }
-
-  toggleDelete() {
-    this.setState(prevState => ({
-      showDeleteConfirmation: !prevState.showDeleteConfirmation,
-    }));
   }
 
   render() {
@@ -64,7 +54,7 @@ export class FigureButtons extends React.Component {
         )}>
         <Button
           {...editorClasses('button', 'red')}
-          onClick={this.toggleDelete}
+          onClick={this.onDeleteConfirm}
           stripped>
           <Cross />
         </Button>
@@ -81,18 +71,6 @@ export class FigureButtons extends React.Component {
           title={url[figureType].editTitle}>
           <Pencil />
         </Link>
-        <WarningModal
-          show={this.state.showDeleteConfirmation}
-          onCancel={this.toggleDelete}
-          actions={[
-            { text: t('form.abort'), onClick: this.toggleDelete },
-            {
-              text: t('warningModal.delete'),
-              onClick: this.onDeleteConfirm,
-            },
-          ]}
-          text={t('form.content.figure.confirmDelete')}
-        />
       </div>
     );
   }

--- a/src/components/SlateEditor/plugins/embed/FigureButtons.jsx
+++ b/src/components/SlateEditor/plugins/embed/FigureButtons.jsx
@@ -15,66 +15,53 @@ import { Cross, Pencil, Plus } from '@ndla/icons/action';
 import { editorClasses } from './SlateFigure';
 import { EmbedShape } from '../../../../shapes';
 
-export class FigureButtons extends React.Component {
-  constructor() {
-    super();
-    this.onDeleteConfirm = this.onDeleteConfirm.bind(this);
-  }
+const FigureButtons = ({ embed, locale, figureType, t, onRemoveClick }) => {
+  const url = {
+    audio: {
+      path: '/media/audio-upload',
+      newTitle: t('form.addNewAudio'),
+      editTitle: t('form.editAudio'),
+    },
+    image: {
+      path: '/media/image-upload',
+      newTitle: t('form.addNewImage'),
+      editTitle: t('form.editImage'),
+    },
+  };
 
-  onDeleteConfirm(e) {
-    const { onRemoveClick } = this.props;
-    onRemoveClick(e);
-  }
-
-  render() {
-    const { embed, locale, figureType, t } = this.props;
-    const url = {
-      audio: {
-        path: '/media/audio-upload',
-        newTitle: t('form.addNewAudio'),
-        editTitle: t('form.editAudio'),
-      },
-      image: {
-        path: '/media/image-upload',
-        newTitle: t('form.addNewImage'),
-        editTitle: t('form.editImage'),
-      },
-    };
-
-    const isNotCentered =
-      embed.align === 'left' ||
-      embed.align === 'right' ||
-      embed.size === 'small' ||
-      embed.size === 'xsmall';
-    return (
-      <div
-        {...editorClasses(
-          'figure-buttons',
-          isNotCentered ? 'right-adjusted' : '',
-        )}>
-        <Button
-          {...editorClasses('button', 'red')}
-          onClick={this.onDeleteConfirm}
-          stripped>
-          <Cross />
-        </Button>
-        <Link
-          to={`${url[figureType].path}/new`}
-          target="_blank"
-          title={url[figureType].newTitle}>
-          <Plus />
-        </Link>
-        <Link
-          to={`${url[figureType].path}/${embed.resource_id}/edit/${locale}`}
-          target="_blank"
-          {...editorClasses('button', 'green')}
-          title={url[figureType].editTitle}>
-          <Pencil />
-        </Link>
-      </div>
-    );
-  }
-}
+  const isNotCentered =
+    embed.align === 'left' ||
+    embed.align === 'right' ||
+    embed.size === 'small' ||
+    embed.size === 'xsmall';
+  return (
+    <div
+      {...editorClasses(
+        'figure-buttons',
+        isNotCentered ? 'right-adjusted' : '',
+      )}>
+      <Button
+        {...editorClasses('button', 'red')}
+        onClick={onRemoveClick}
+        stripped>
+        <Cross />
+      </Button>
+      <Link
+        to={`${url[figureType].path}/new`}
+        target="_blank"
+        title={url[figureType].newTitle}>
+        <Plus />
+      </Link>
+      <Link
+        to={`${url[figureType].path}/${embed.resource_id}/edit/${locale}`}
+        target="_blank"
+        {...editorClasses('button', 'green')}
+        title={url[figureType].editTitle}>
+        <Pencil />
+      </Link>
+    </div>
+  );
+};
 
 FigureButtons.propTypes = {
   onRemoveClick: PropTypes.func.isRequired,


### PR DESCRIPTION
Knappene i WarningModal fungerer ikke når man skal slette et bilde. Foreslår uansett å fjerne WarningModal i dette tilfelle, da vi uansett kan angre med ctrl-z. Vi har heller ikke warning modal for andre slettinger i editoren. 