### PR TITLE
fix: Disable upload input field if audio id exists

### DIFF
--- a/src/containers/AudioUploader/components/AudioContent.jsx
+++ b/src/containers/AudioUploader/components/AudioContent.jsx
@@ -23,11 +23,13 @@ const AudioContent = ({ t, commonFieldProps, model, audioInfo }) => (
       placeholder={t('form.title.label')}
       {...commonFieldProps}
     />
-    <InputFileField
-      label={t('form.audio.file')}
-      name="audioFile"
-      {...commonFieldProps}
-    />
+    {!model.id && (
+      <InputFileField
+        label={t('form.audio.file')}
+        name="audioFile"
+        {...commonFieldProps}
+      />
+    )}
     {model.id && <AudioPlayer audio={audioInfo} filepath={model.filepath} />}
   </Fragment>
 );


### PR DESCRIPTION
Resolves https://github.com/NDLANO/Issues/issues/1446

Test Procedure:
- [ ] Check that browse file button is available when creating new items
- [ ] Check that existing audios does not display 