### PR TITLE
feat: Added support for new embeds

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -27,7 +27,7 @@ export const ARTICLE_EXTERNAL = 'external-learning-resources';
 export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'H5P', url: ['h5p'] },
   { name: 'YouTube', url: ['youtube.com', 'youtu.be'], height: '486px' },
-  { name: 'NRK', url: ['www.nrk.no'] },
+  { name: 'NRK', url: ['static.nrk.no'], height: '398px' },
   { name: 'Vimeo', url: ['vimeo.no', 'vimeopro.com'], height: '486px' },
   { name: 'Norgesfilm', url: ['ndla.filmiundervisning.no'] },
   { name: 'TED', url: ['ted.com'] },
@@ -37,4 +37,12 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'SlideShare', url: ['www.slideshare.net'], height: '500px' },
   { name: 'Scribd', url: ['scribd.com'] },
   { name: 'Kahoot', url: ['embed.kahoot.it'] },
+  {
+    name: 'Livestream',
+    url: ['livestream.com', 'new.livestream.com'],
+    height: '398px',
+  },
+  { name: 'Issuu', url: ['e.issuu.com'] },
+  { name: 'Geogebra', url: ['www.geogebra.org'] },
+  { name: 'IMDB', url: ['www.imdb.com'], height: '378px' },
 ];

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -116,6 +116,11 @@ const frameSrc = (() => {
     'https://khanacademy.org/',
     '*.khanacademy.org/',
     'https://*.auth0.com',
+    'https://livestream.com',
+    'https://*.livestream.com',
+    'https://www.imdb.com',
+    'https://e.issuu.com',
+    'https://www.geogebra.org',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [


### PR DESCRIPTION
Resolves https://github.com/NDLANO/Issues/issues/1469

- Adds support for Livestream, Issuu, Geogebra, IMDB and static.nrk.no

**Test Procedure**
- [ ] Check that copy and paste urls from sources, and saving them works properly

*Known issues:*
- e.issuu.com and static.nrk.no  is not added to backend valdiation
- www.imdb.com needs a specific embed url to work, and also precise parameters for height/width in order to render correctly (could be solved through oembed-proxy)
- Normal nrk.no urls still does not work (needs special implementation)