### PR TITLE
Fix copy selection image

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "body-parser": "^1.18.3",
     "btoa": "^1.2.1",
     "bunyan": "^1.8.12",
-    "classnames": "2.2.6",
     "compression": "^1.7.3",
     "date-fns": "^1.29.0",
     "defined": "1.0.0",

--- a/src/components/SlateEditor/plugins/embed/SlateFigure.jsx
+++ b/src/components/SlateEditor/plugins/embed/SlateFigure.jsx
@@ -85,11 +85,15 @@ class SlateFigure extends React.Component {
   }
 
   render() {
-    const figureClass = editorClasses(
-      'figure',
-      this.isSelected() ? 'active' : '',
-    );
-    const { node, attributes, editor, locale } = this.props;
+    const active = this.isSelected();
+    const figureClass = editorClasses('figure', active ? 'active' : '');
+    const {
+      node,
+      attributes,
+      editor,
+      locale,
+      isSelected: isSelectedForCopy,
+    } = this.props;
 
     const embed = getSchemaEmbed(node);
 
@@ -100,6 +104,8 @@ class SlateFigure extends React.Component {
       attributes,
       submitted: this.state.submitted,
       locale,
+      isSelectedForCopy,
+      active,
     };
     switch (embed.resource) {
       case 'image':

--- a/src/components/SlateEditor/plugins/embed/SlateImage.jsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.jsx
@@ -8,10 +8,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { Figure } from '@ndla/ui';
 import Button from '@ndla/button';
-import { css } from 'react-emotion';
+import { css, cx } from 'react-emotion';
 import { findDOMNode } from 'slate-react';
 import SlateTypes from 'slate-prop-types';
 import config from '../../../../config';
@@ -83,14 +82,14 @@ class SlateImage extends React.Component {
       'lower-right-y': embed['lower-right-y'],
     };
 
-    const figureClassNames = classnames('c-figure', {
+    const figureClassNames = cx('c-figure', {
       [`u-float-${embed.size}-${embed.align}`]:
         ['left', 'right'].includes(embed.align) &&
         ['small', 'xsmall'].includes(embed.size),
       [`u-float-${embed.align}`]:
         ['left', 'right'].includes(embed.align) &&
         !['small', 'xsmall'].includes(embed.size),
-      ['isSelectedForCopy']: isSelectedForCopy && (!editModus || !active),
+      isSelectedForCopy: isSelectedForCopy && (!editModus || !active),
     });
 
     return (

--- a/src/components/SlateEditor/plugins/embed/SlateImage.jsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.jsx
@@ -66,8 +66,11 @@ class SlateImage extends React.Component {
       attributes,
       onRemoveClick,
       locale,
+      isSelectedForCopy,
+      active,
       ...rest
     } = this.props;
+    const { editModus } = this.state;
 
     const src = `${config.ndlaApiUrl}/image-api/raw/id/${embed.resource_id}`;
 
@@ -87,6 +90,7 @@ class SlateImage extends React.Component {
       [`u-float-${embed.align}`]:
         ['left', 'right'].includes(embed.align) &&
         !['small', 'xsmall'].includes(embed.size),
+      ['isSelectedForCopy']: isSelectedForCopy && (!editModus || !active),
     });
 
     return (
@@ -100,7 +104,7 @@ class SlateImage extends React.Component {
           embed={embed}
           figureType="image"
         />
-        {this.state.editModus ? (
+        {editModus ? (
           <EditImage embed={embed} closeEdit={this.toggleEditModus} {...rest} />
         ) : (
           <Button

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -85,7 +85,7 @@ a.c-button {
   margin-top: 0;
 }
 
-.c-figure.selected {
+.c-figure.isSelectedForCopy {
   box-shadow: rgb(32, 88, 143) 0 0 0 2px;
 }
 

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -85,6 +85,10 @@ a.c-button {
   margin-top: 0;
 }
 
+.c-figure.selected {
+  box-shadow: rgb(32, 88, 143) 0 0 0 2px;
+}
+
 .ReactCrop {
   margin-bottom: -6px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,7 +2761,7 @@ classnames@2.2.5, classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
-classnames@2.2.6, classnames@^2.2.6:
+classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 


### PR DESCRIPTION
Fixes copy paste behaviour by showing outline on image when selected. 
- Does not show outline when only image is active and in edit mode
- Does not fix issue that when both image and text is selected and copied, only image is pasted