### PR TITLE
Only transform article in previewDraft

### DIFF
--- a/src/components/PreviewDraft/PreviewDraftLightbox.jsx
+++ b/src/components/PreviewDraft/PreviewDraftLightbox.jsx
@@ -20,7 +20,10 @@ import Lightbox, {
   closeLightboxCrossStyle,
 } from '../Lightbox';
 import PreviewLightboxContent from './PreviewLightboxContent';
-import { transformArticle } from '../../util/articleUtil';
+import {
+  transformArticle,
+  transformArticleToApiVersion,
+} from '../../util/articleUtil';
 import { FormActionButton } from '../../containers/Form';
 import Spinner from '../Spinner';
 
@@ -97,7 +100,7 @@ class PreviewDraftLightbox extends React.Component {
   async openPreview() {
     const { getArticle, typeOfPreview } = this.props;
 
-    const article = getArticle();
+    const article = transformArticleToApiVersion(getArticle());
 
     const secondArticleLanguage = article.supportedLanguages.find(
       l => l !== article.language,
@@ -139,7 +142,7 @@ class PreviewDraftLightbox extends React.Component {
 
   async previewLanguageArticle(language = undefined) {
     const { getArticle } = this.props;
-    const originalArticle = getArticle();
+    const originalArticle = transformArticleToApiVersion(getArticle());
     const draftOtherLanguage = await draftApi.fetchDraft(
       originalArticle.id,
       language,

--- a/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
@@ -54,7 +54,6 @@ import { validateDraft } from '../../../modules/draft/draftApi';
 import { articleConverter } from '../../../modules/draft/draft';
 import * as articleStatuses from '../../../util/constants/ArticleStatus';
 import config from '../../../config';
-import { transformArticleToApiVersion } from '../../../util/articleUtil';
 
 const parseImageUrl = metaImage => {
   if (!metaImage || !metaImage.url || metaImage.url.length === 0) {
@@ -179,7 +178,7 @@ class LearningResourceForm extends Component {
       supportedLanguages: model.supportedLanguages,
     };
 
-    return transformArticleToApiVersion(article);
+    return article;
   }
 
   async handleSubmit(evt) {

--- a/src/containers/TopicArticlePage/components/TopicArticleForm.jsx
+++ b/src/containers/TopicArticlePage/components/TopicArticleForm.jsx
@@ -53,7 +53,6 @@ import { validateDraft } from '../../../modules/draft/draftApi';
 import { articleConverter } from '../../../modules/draft/draft';
 import * as articleStatuses from '../../../util/constants/ArticleStatus';
 import AlertModal from '../../../components/AlertModal';
-import { transformArticleToApiVersion } from '../../../util/articleUtil';
 
 export const getInitialModel = (article = {}) => {
   const visualElement = parseEmbedTag(article.visualElement);
@@ -152,7 +151,7 @@ class TopicArticleForm extends Component {
       supportedLanguages: model.supportedLanguages,
     };
 
-    return transformArticleToApiVersion(article);
+    return article;
   }
 
   async handleSubmit(evt) {


### PR DESCRIPTION
revert refactoring to only use transformArticleToApiVersion in previewDraft calls. Other calls to draft-api fails if you use transformArticleToApiVersion