### PR TITLE
Always add empty paragraph after embeds

### DIFF
--- a/src/components/SlateEditor/plugins/embed/index.js
+++ b/src/components/SlateEditor/plugins/embed/index.js
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import SlateFigure from './SlateFigure';
+import defaultBlocks from '../../utils/defaultBlocks';
 
 export default function createEmbedPlugin(locale) {
   const schema = {
@@ -15,6 +16,26 @@ export default function createEmbedPlugin(locale) {
       embed: {
         isVoid: true,
         data: {},
+        next: [
+          {
+            type: 'paragraph',
+          },
+          { type: 'heading-two' },
+          { type: 'heading-three' },
+        ],
+        normalize: (editor, error) => {
+          switch (error.code) {
+            case 'next_sibling_type_invalid': {
+              console.log(error.node);
+              editor
+                .moveToEndOfNode(error.child)
+                .insertBlock(defaultBlocks.defaultBlock);
+              break;
+            }
+            default:
+              break;
+          }
+        },
       },
     },
   };

--- a/src/components/SlateEditor/plugins/embed/index.js
+++ b/src/components/SlateEditor/plugins/embed/index.js
@@ -26,7 +26,6 @@ export default function createEmbedPlugin(locale) {
         normalize: (editor, error) => {
           switch (error.code) {
             case 'next_sibling_type_invalid': {
-              console.log(error.node);
               editor
                 .moveToEndOfNode(error.child)
                 .insertBlock(defaultBlocks.defaultBlock);


### PR DESCRIPTION
Fixes issue 1621 by inserting empty paragraph after embeds if next block is not a paragraph or heading