### PR TITLE
Add empty space between content blocks

### DIFF
--- a/src/components/SlateEditor/plugins/aside/index.js
+++ b/src/components/SlateEditor/plugins/aside/index.js
@@ -7,8 +7,7 @@
  */
 
 import React from 'react';
-import { Block } from 'slate';
-import { defaultBlocks, textBlockValidationRules } from '../../utils';
+import { textBlockValidationRules } from '../../utils';
 import SlateAside from './SlateAside';
 
 export default function createAside() {
@@ -17,20 +16,6 @@ export default function createAside() {
       aside: textBlockValidationRules,
     },
   };
-
-  // Rule to always insert a paragraph as the last node inside if void type
-  function normalizeNode(node, editor, next) {
-    if (node.object !== 'block') return next();
-    if (node.type !== 'aside') return next();
-    if (!node.nodes.last().type) return next();
-    if (!node.nodes.last().isVoid) return next();
-
-    const block = Block.create(defaultBlocks.defaultBlock);
-    return () =>
-      editor.withoutSaving(() => {
-        editor.insertNodeByKey(node.key, node.nodes.size, block);
-      });
-  }
 
   /* eslint-disable react/prop-types */
   const renderNode = (props, editor, next) => {
@@ -46,6 +31,5 @@ export default function createAside() {
   return {
     schema,
     renderNode,
-    normalizeNode,
   };
 }

--- a/src/components/SlateEditor/plugins/bodybox/index.js
+++ b/src/components/SlateEditor/plugins/bodybox/index.js
@@ -26,20 +26,6 @@ export default function createBodyBox() {
     },
   };
 
-  // Rule to always insert a paragraph as the last node inside if void type
-  function normalizeNode(node, editor, next) {
-    if (node.object !== 'block') return next();
-    if (node.type !== 'bodybox') return next();
-    if (!node.nodes.last().type) return next();
-    if (!node.nodes.last().isVoid) return next();
-
-    const block = Block.create(defaultBlock);
-    return () =>
-      editor.withoutSaving(() => {
-        editor.insertNodeByKey(node.key, node.nodes.size, block);
-      });
-  }
-
   /* eslint-disable react/prop-types */
   const renderNode = (props, editor, next) => {
     const { node } = props;
@@ -54,6 +40,5 @@ export default function createBodyBox() {
   return {
     schema,
     renderNode,
-    normalizeNode,
   };
 }

--- a/src/components/SlateEditor/plugins/detailsbox/index.js
+++ b/src/components/SlateEditor/plugins/detailsbox/index.js
@@ -33,6 +33,13 @@ export default function createDetails() {
       // which separates summary from details.
       details: {
         last: { type: 'paragraph' },
+        next: [
+          {
+            type: 'paragraph',
+          },
+          { type: 'heading-two' },
+          { type: 'heading-three' },
+        ],
         normalize: (editor, error) => {
           switch (error.code) {
             case 'last_child_type_invalid': {
@@ -43,6 +50,21 @@ export default function createDetails() {
                   error.node.nodes.size,
                   block,
                 );
+              });
+              break;
+            }
+            case 'next_sibling_type_invalid': {
+              editor.withoutNormalizing(() => {
+                editor.wrapBlockByKey(error.child.key, 'section');
+                const wrapper = editor.value.document.getParent(
+                  error.child.key,
+                );
+                editor.insertNodeByKey(
+                  wrapper.key,
+                  1,
+                  Block.create(defaultBlocks.defaultBlock),
+                );
+                editor.unwrapBlockByKey(wrapper.key, 'section');
               });
               break;
             }

--- a/src/components/SlateEditor/plugins/file/index.js
+++ b/src/components/SlateEditor/plugins/file/index.js
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import Filelist from './Filelist';
+import defaultBlocks from '../../utils/defaultBlocks';
 
 export default () => {
   const schema = {
@@ -16,6 +17,25 @@ export default () => {
       file: {
         isVoid: true,
         data: {},
+        next: [
+          {
+            type: 'paragraph',
+          },
+          { type: 'heading-two' },
+          { type: 'heading-three' },
+        ],
+        normalize: (editor, error) => {
+          switch (error.code) {
+            case 'next_sibling_type_invalid': {
+              editor
+                .moveToEndOfNode(error.child)
+                .insertBlock(defaultBlocks.defaultBlock);
+              break;
+            }
+            default:
+              break;
+          }
+        },
       },
     },
   };

--- a/src/components/SlateEditor/plugins/related/index.js
+++ b/src/components/SlateEditor/plugins/related/index.js
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import RelatedArticleBox from './RelatedArticleBox';
+import defaultBlocks from '../../utils/defaultBlocks';
 
 export default () => {
   const schema = {
@@ -16,6 +17,25 @@ export default () => {
       related: {
         isVoid: true,
         data: {},
+        next: [
+          {
+            type: 'paragraph',
+          },
+          { type: 'heading-two' },
+          { type: 'heading-three' },
+        ],
+        normalize: (editor, error) => {
+          switch (error.code) {
+            case 'next_sibling_type_invalid': {
+              editor
+                .moveToEndOfNode(error.child)
+                .insertBlock(defaultBlocks.defaultBlock);
+              break;
+            }
+            default:
+              break;
+          }
+        },
       },
     },
   };

--- a/src/components/SlateEditor/plugins/table/schema.js
+++ b/src/components/SlateEditor/plugins/table/schema.js
@@ -8,7 +8,9 @@
  */
 
 import React from 'react';
+import { Block } from 'slate';
 import SlateTable from './SlateTable';
+import defaultBlocks from '../../utils/defaultBlocks';
 
 function normalizeNode(node, editor, next) {
   if (node.object !== 'block') return next();
@@ -36,7 +38,37 @@ function normalizeNode(node, editor, next) {
 }
 
 const schema = {
-  document: {},
+  blocks: {
+    table: {
+      next: [
+        {
+          type: 'paragraph',
+        },
+        { type: 'heading-two' },
+        { type: 'heading-three' },
+      ],
+      normalize: (editor, error) => {
+        console.log(error.child);
+        switch (error.code) {
+          case 'next_sibling_type_invalid': {
+            editor.withoutNormalizing(() => {
+              editor.wrapBlockByKey(error.child.key, 'section');
+              const wrapper = editor.value.document.getParent(error.child.key);
+              editor.insertNodeByKey(
+                wrapper.key,
+                1,
+                Block.create(defaultBlocks.defaultBlock),
+              );
+              editor.unwrapBlockByKey(wrapper.key, 'section');
+            });
+            break;
+          }
+          default:
+            break;
+        }
+      },
+    },
+  },
 };
 
 /* eslint-disable react/prop-types */

--- a/src/components/SlateEditor/utils/schemaHelpers.js
+++ b/src/components/SlateEditor/utils/schemaHelpers.js
@@ -14,6 +14,13 @@ export const textBlockValidationRules = {
   first: { type: 'paragraph' },
   nodes: [{ match: 'paragraph', min: 1 }],
   last: { type: 'paragraph' },
+  next: [
+    {
+      type: 'paragraph',
+    },
+    { type: 'heading-two' },
+    { type: 'heading-three' },
+  ],
   normalize: (editor, error) => {
     switch (error.code) {
       case 'first_child_type_invalid': {
@@ -34,6 +41,19 @@ export const textBlockValidationRules = {
         const block = Block.create(defaultBlocks.defaultBlock);
         editor.withoutSaving(() => {
           editor.insertNodeByKey(error.node.key, 0, block);
+        });
+        break;
+      }
+      case 'next_sibling_type_invalid': {
+        editor.withoutNormalizing(() => {
+          editor.wrapBlockByKey(error.child.key, 'section');
+          const wrapper = editor.value.document.getParent(error.child.key);
+          editor.insertNodeByKey(
+            wrapper.key,
+            1,
+            Block.create(defaultBlocks.defaultBlock),
+          );
+          editor.unwrapBlockByKey(wrapper.key, 'section');
         });
         break;
       }


### PR DESCRIPTION
Fixes https://trello.com/c/6ZxPgPGZ/123-bygge-innhold-nedenfra-og-opp-gir-ikke-pluss-knapp-mellom-elementene. 
Adds empty paragraph if next node is a block for table, files, body box, detail box, aside, and related. Check that: 
- [ ] you can add these content types after one another and get access to the plus sign between them