### PR TITLE
Fixes bug with h5p edit button saves form #1712

### DIFF
--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -77,8 +77,8 @@ export class DisplayExternal extends Component {
         } else {
           this.setState({ error: true });
         }
-      } catch (e) {
-        handleError(e);
+      } catch (err) {
+        handleError(err);
         this.setState({ error: true });
       }
     } else {
@@ -98,7 +98,8 @@ export class DisplayExternal extends Component {
     }
   }
 
-  openEditEmbed(providerName) {
+  openEditEmbed(evt, providerName) {
+    evt.preventDefault();
     this.handleChangeVisualElement(providerName);
     this.setState({ isEditMode: true });
   }
@@ -163,7 +164,8 @@ export class DisplayExternal extends Component {
           figureType="external"
           onEdit={
             allowedProvider.name
-              ? () => this.openEditEmbed(allowedProvider.name.toLowerCase())
+              ? evt =>
+                  this.openEditEmbed(evt, allowedProvider.name.toLowerCase())
               : undefined
           }
         />

--- a/src/components/DisplayEmbed/DisplayExternalVisualElement.jsx
+++ b/src/components/DisplayEmbed/DisplayExternalVisualElement.jsx
@@ -34,9 +34,9 @@ export class DisplayExternalVisualElement extends Component {
     this.getPropsFromEmbed();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate({ embed: prevEmbed }) {
     const { embed } = this.props;
-    if (prevProps.embed.url !== embed.url) {
+    if (prevEmbed.url !== embed.url) {
       this.getPropsFromEmbed();
     }
   }


### PR DESCRIPTION
- [ ] After editing a learning resource, you should still be able to open & edit an H5P-resource.