### PR TITLE
#1788: Tell auth0 to always show account selection on authorize()

### DIFF
--- a/src/util/authHelpers.js
+++ b/src/util/authHelpers.js
@@ -194,6 +194,7 @@ export function loginPersonalAccessToken(type) {
   auth.authorize({
     connection: type,
     state: localStorage.getItem('lastPath'),
+    prompt: 'login', // Tells auth0 to always show account selection screen on authorize.
   });
 }
 


### PR DESCRIPTION
Check: 
- [ ] Logging in when already signed in to one google account should still show google account selection screen.