### PR TITLE
Implemented support for delete language version on frontend

### DIFF
--- a/src/components/HeaderWithLanguage/DeleteLanguageVersion.jsx
+++ b/src/components/HeaderWithLanguage/DeleteLanguageVersion.jsx
@@ -13,8 +13,9 @@ import { injectT } from '@ndla/i18n';
 import { withRouter } from 'react-router-dom';
 import { DeleteForever } from '@ndla/icons/editor';
 import { deleteLanguageVersion } from '../../modules/draft/draftApi';
+import { deleteLanguageVersionConcept } from '../../modules/concept/conceptApi';
 import { HistoryShape } from '../../shapes';
-import { toEditArticle } from '../../util/routeHelpers';
+import { toEditArticle, toEditConcept } from '../../util/routeHelpers';
 import AlertModal from '../AlertModal';
 import StyledFilledButton from '../StyledFilledButton';
 
@@ -42,18 +43,28 @@ class DeleteLanguageVersion extends React.Component {
     const {
       values: { id, supportedLanguages, language, articleType },
       history,
+      type,
     } = this.props;
     if (
       id &&
       supportedLanguages.length > 1 &&
       supportedLanguages.includes(language)
     ) {
-      await deleteLanguageVersion(id, language);
-      this.toggleShowDeleteWarning();
-      const otherSupportedLanguage = supportedLanguages.find(
-        lang => lang !== language,
-      );
-      history.push(toEditArticle(id, articleType, otherSupportedLanguage));
+      if (type === 'concept') {
+        await deleteLanguageVersionConcept(id, language);
+        this.toggleShowDeleteWarning();
+        const otherSupportedLanguage = supportedLanguages.find(
+          lang => lang !== language,
+        );
+        history.push(toEditConcept(id, otherSupportedLanguage));
+      } else {
+        await deleteLanguageVersion(id, language);
+        this.toggleShowDeleteWarning();
+        const otherSupportedLanguage = supportedLanguages.find(
+          lang => lang !== language,
+        );
+        history.push(toEditArticle(id, articleType, otherSupportedLanguage));
+      }
     }
   }
 
@@ -116,6 +127,7 @@ DeleteLanguageVersion.propTypes = {
   }),
   showDeleteButton: PropTypes.bool.isRequired,
   history: HistoryShape,
+  type: PropTypes.string,
 };
 
 export default withRouter(injectT(DeleteLanguageVersion));

--- a/src/components/HeaderWithLanguage/DeleteLanguageVersion.jsx
+++ b/src/components/HeaderWithLanguage/DeleteLanguageVersion.jsx
@@ -50,19 +50,17 @@ class DeleteLanguageVersion extends React.Component {
       supportedLanguages.length > 1 &&
       supportedLanguages.includes(language)
     ) {
+      this.toggleShowDeleteWarning();
+      const otherSupportedLanguage = supportedLanguages.find(
+        lang => lang !== language,
+      );
       if (type === 'concept') {
         await deleteLanguageVersionConcept(id, language);
-        this.toggleShowDeleteWarning();
-        const otherSupportedLanguage = supportedLanguages.find(
-          lang => lang !== language,
-        );
+
         history.push(toEditConcept(id, otherSupportedLanguage));
       } else {
         await deleteLanguageVersion(id, language);
-        this.toggleShowDeleteWarning();
-        const otherSupportedLanguage = supportedLanguages.find(
-          lang => lang !== language,
-        );
+
         history.push(toEditArticle(id, articleType, otherSupportedLanguage));
       }
     }

--- a/src/modules/concept/conceptApi.js
+++ b/src/modules/concept/conceptApi.js
@@ -39,3 +39,8 @@ export const updateConcept = concept =>
     method: 'PATCH',
     body: JSON.stringify(concept),
   }).then(resolveJsonOrRejectWithError);
+
+export const deleteLanguageVersionConcept = (conceptId, locale) =>
+  fetchAuthorized(`${conceptUrl}/${conceptId}?language=${locale}`, {
+    method: 'DELETE',
+  }).then(resolveJsonOrRejectWithError);


### PR DESCRIPTION
Litt midlertidig løsning, såå den burde kanskje endres sånn at det blir mer generelt og ikke tilpasset kun for article og concept.