### PR TITLE
Fix article taxonomy saving

### DIFF
--- a/src/components/formikValidationSchema.js
+++ b/src/components/formikValidationSchema.js
@@ -92,7 +92,6 @@ const validateFormik = (values, rules, t, formType = undefined) => {
         rules[ruleKey].maxLength &&
         maxLength(value, rules[ruleKey].maxLength)
       ) {
-        console.log(value);
         errors[ruleKey] = appendError(
           errors[ruleKey],
           t('validation.maxLength', {

--- a/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
@@ -30,6 +30,7 @@ import {
   groupTopics,
 } from '../../../util/taxonomyHelpers';
 import handleError from '../../../util/handleError';
+import retriveBreadCrumbs from '../../../util/retriveBreadCrumbs';
 import TopicConnections from './taxonomy/TopicConnections';
 import FilterConnections from '../../../components/Taxonomy/filter/FilterConnections';
 import SaveButton from '../../../components/SaveButton';
@@ -296,42 +297,6 @@ class LearningResourceTaxonomy extends Component {
     }));
   };
 
-  retriveBreadCrumbs = topicPath => {
-    const {
-      structure,
-      taxonomyChoices: { allTopics },
-    } = this.state;
-    try {
-      let topicPaths = topicPath
-        .split('/')
-        .splice(1)
-        .map(url => `urn:${url}`);
-
-      const subject = structure.find(
-        structureSubject => structureSubject.id === topicPaths[0],
-      );
-      topicPaths = topicPaths.splice(1);
-      const returnPaths = [];
-
-      returnPaths.push({
-        name: subject.name,
-        id: subject.id,
-      });
-      topicPaths.forEach(pathId => {
-        const topicPath = allTopics.find(subtopic => subtopic.id === pathId);
-        returnPaths.push({
-          name: topicPath.name,
-          id: topicPath.id,
-        });
-      });
-
-      return returnPaths;
-    } catch (err) {
-      handleError(err);
-      return false;
-    }
-  };
-
   removeConnection = id => {
     const { topics, filter } = this.state.taxonomyChanges;
     const currentConnection = topics.find(topic => topic.id === id);
@@ -396,6 +361,7 @@ class LearningResourceTaxonomy extends Component {
   onCancel = () => {
     const { isDirty } = this.state;
     const { closePanel } = this.props;
+    console.log(closePanel);
     if (!isDirty) {
       closePanel();
     } else {
@@ -445,7 +411,9 @@ class LearningResourceTaxonomy extends Component {
           structure={structure}
           allTopics={allTopics}
           activeTopics={topics}
-          retriveBreadCrumbs={this.retriveBreadCrumbs}
+          retriveBreadCrumbs={topicPath =>
+            retriveBreadCrumbs({ topicPath, allTopics, structure })
+          }
           removeConnection={this.removeConnection}
           setPrimaryConnection={this.setPrimaryConnection}
           stageTaxonomyChanges={this.stageTaxonomyChanges}
@@ -463,7 +431,7 @@ class LearningResourceTaxonomy extends Component {
         <Field right>
           <FormikActionButton
             outline
-            onClick={this.oncancel}
+            onClick={this.onCancel}
             disabled={status === 'loading'}>
             {t('form.abort')}
           </FormikActionButton>

--- a/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
@@ -361,7 +361,6 @@ class LearningResourceTaxonomy extends Component {
   onCancel = () => {
     const { isDirty } = this.state;
     const { closePanel } = this.props;
-    console.log(closePanel);
     if (!isDirty) {
       closePanel();
     } else {

--- a/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceTaxonomy.jsx
@@ -62,21 +62,6 @@ class LearningResourceTaxonomy extends Component {
         topics: [],
       },
     };
-    this.retriveBreadCrumbs = this.retriveBreadCrumbs.bind(this);
-    this.stageTaxonomyChanges = this.stageTaxonomyChanges.bind(this);
-    this.removeConnection = this.removeConnection.bind(this);
-    this.setPrimaryConnection = this.setPrimaryConnection.bind(this);
-    this.getSubjectTopics = this.getSubjectTopics.bind(this);
-    this.onChangeSelectedResource = this.onChangeSelectedResource.bind(this);
-    this.updateFilter = this.updateFilter.bind(this);
-    this.updateSubject = this.updateSubject.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.fetchTaxonomy = this.fetchTaxonomy.bind(this);
-    this.fetchTaxonomyChoices = this.fetchTaxonomyChoices.bind(this);
-    this.fetchFullResouce = this.fetchFullResouce.bind(this);
-    this.silentlyRefetchResourceTopics = this.silentlyRefetchResourceTopics.bind(
-      this,
-    );
   }
 
   componentDidMount() {
@@ -84,7 +69,7 @@ class LearningResourceTaxonomy extends Component {
     this.fetchTaxonomyChoices();
   }
 
-  onChangeSelectedResource(evt) {
+  onChangeSelectedResource = evt => {
     const {
       taxonomyChoices: { availableResourceTypes },
     } = this.state;
@@ -112,9 +97,9 @@ class LearningResourceTaxonomy extends Component {
     this.stageTaxonomyChanges({
       resourceTypes,
     });
-  }
+  };
 
-  async getSubjectTopics(subjectid) {
+  getSubjectTopics = async subjectid => {
     if (
       this.state.structure.some(
         subject => subject.id === subjectid && subject.topics,
@@ -130,9 +115,9 @@ class LearningResourceTaxonomy extends Component {
     } catch (err) {
       handleError(err);
     }
-  }
+  };
 
-  setPrimaryConnection(id) {
+  setPrimaryConnection = id => {
     const { topics } = this.state.taxonomyChanges;
 
     this.stageTaxonomyChanges({
@@ -141,9 +126,9 @@ class LearningResourceTaxonomy extends Component {
         primary: topic.id === id,
       })),
     });
-  }
+  };
 
-  async fetchTaxonomy() {
+  fetchTaxonomy = async () => {
     const {
       article: { language, id },
     } = this.props;
@@ -171,9 +156,9 @@ class LearningResourceTaxonomy extends Component {
       handleError(e);
       this.setState({ status: 'error' });
     }
-  }
+  };
 
-  async fetchTaxonomyChoices() {
+  fetchTaxonomyChoices = async () => {
     const {
       article: { language },
     } = this.props;
@@ -214,9 +199,9 @@ class LearningResourceTaxonomy extends Component {
       handleError(e);
       this.setState({ status: 'error' });
     }
-  }
+  };
 
-  stageTaxonomyChanges(properties) {
+  stageTaxonomyChanges = properties => {
     this.setState(prevState => ({
       isDirty: true,
       taxonomyChanges: {
@@ -224,9 +209,9 @@ class LearningResourceTaxonomy extends Component {
         ...properties,
       },
     }));
-  }
+  };
 
-  async handleSubmit(evt) {
+  handleSubmit = async evt => {
     evt.preventDefault();
     const { resourceTaxonomy, taxonomyChanges, resourceId } = this.state;
     let reassignedResourceId = resourceId;
@@ -271,9 +256,9 @@ class LearningResourceTaxonomy extends Component {
       handleError(err);
       this.setState({ saveStatus: 'error' });
     }
-  }
+  };
 
-  async silentlyRefetchResourceTopics() {
+  silentlyRefetchResourceTopics = async () => {
     await new Promise(resolve => {
       setTimeout(resolve, 5000);
     });
@@ -284,9 +269,9 @@ class LearningResourceTaxonomy extends Component {
     this.setState({
       resourceTaxonomy,
     });
-  }
+  };
 
-  async fetchFullResouce(resourceId, language) {
+  fetchFullResouce = async (resourceId, language) => {
     const { resourceTypes, filters, topics } = await getFullResource(
       resourceId,
       language,
@@ -305,17 +290,17 @@ class LearningResourceTaxonomy extends Component {
       filter: filters,
       topics: topicsWithConnections,
     };
-  }
+  };
 
-  updateSubject(subjectId, newSubject) {
+  updateSubject = (subjectId, newSubject) => {
     this.setState(prevState => ({
       structure: prevState.structure.map(subject =>
         subject.id === subjectId ? { ...subject, ...newSubject } : subject,
       ),
     }));
-  }
+  };
 
-  retriveBreadCrumbs(topicPath) {
+  retriveBreadCrumbs = topicPath => {
     const {
       structure,
       taxonomyChoices: { allTopics },
@@ -349,9 +334,9 @@ class LearningResourceTaxonomy extends Component {
       handleError(err);
       return false;
     }
-  }
+  };
 
-  removeConnection(id) {
+  removeConnection = id => {
     const { topics, filter } = this.state.taxonomyChanges;
     const currentConnection = topics.find(topic => topic.id === id);
     const updatedTopics = topics.filter(topic => topic.id !== id);
@@ -388,9 +373,9 @@ class LearningResourceTaxonomy extends Component {
     this.stageTaxonomyChanges({
       topics: updatedTopics,
     });
-  }
+  };
 
-  updateFilter(resourceId, filter, relevanceId, remove) {
+  updateFilter = (resourceId, filter, relevanceId, remove) => {
     let updatedFilter = filter;
     const updatedFilters = this.state.taxonomyChanges.filter.filter(
       modelFilter => {
@@ -410,9 +395,9 @@ class LearningResourceTaxonomy extends Component {
     this.stageTaxonomyChanges({
       filter: updatedFilters,
     });
-  }
+  };
 
-  onCancel() {
+  onCancel = () => {
     const { isDirty } = this.state;
     const { closePanel } = this.props;
     if (!isDirty) {
@@ -421,7 +406,7 @@ class LearningResourceTaxonomy extends Component {
       // TODO open warning
       closePanel();
     }
-  }
+  };
 
   render() {
     const {

--- a/src/containers/LearningResourcePage/components/taxonomy/TopicConnections.jsx
+++ b/src/containers/LearningResourcePage/components/taxonomy/TopicConnections.jsx
@@ -62,12 +62,11 @@ class TopicConnections extends Component {
   }
 
   async addTopic(id, closeModal) {
-    const { activeTopics, taxonomyTopics, stageTaxonomyChanges } = this.props;
-    const addTopic = taxonomyTopics.find(
-      taxonomyTopic => taxonomyTopic.id === id,
-    );
+    const { activeTopics, allTopics, stageTaxonomyChanges } = this.props;
+    const addTopic = allTopics.find(taxonomyTopic => taxonomyTopic.id === id);
 
     const topicConnections = await fetchTopicConnections(addTopic.id);
+
     addTopic.topicConnections = topicConnections;
 
     stageTaxonomyChanges({
@@ -164,7 +163,7 @@ TopicConnections.propTypes = {
   isOpened: PropTypes.bool,
   structure: PropTypes.arrayOf(StructureShape),
   activeTopics: PropTypes.arrayOf(TopicShape),
-  taxonomyTopics: PropTypes.arrayOf(
+  allTopics: PropTypes.arrayOf(
     PropTypes.shape({
       contentUri: PropTypes.string,
       id: PropTypes.string.isRequired,

--- a/src/containers/TopicArticlePage/components/TopicArticleTaxonomy.jsx
+++ b/src/containers/TopicArticlePage/components/TopicArticleTaxonomy.jsx
@@ -30,6 +30,7 @@ import {
   pathToUrnArray,
 } from '../../../util/taxonomyHelpers';
 import handleError from '../../../util/handleError';
+import retriveBreadCrumbs from '../../../util/retriveBreadCrumbs';
 import SaveButton from '../../../components/SaveButton';
 import { FormikActionButton } from '../../FormikForm';
 import TopicArticleConnections from './TopicArticleConnections';
@@ -50,22 +51,13 @@ class TopicArticleTaxonomy extends Component {
         allTopics: [],
       },
     };
-    this.retriveBreadCrumbs = this.retriveBreadCrumbs.bind(this);
-    this.stageTaxonomyChanges = this.stageTaxonomyChanges.bind(this);
-    this.removeConnection = this.removeConnection.bind(this);
-    this.getSubjectTopics = this.getSubjectTopics.bind(this);
-    this.updateSubject = this.updateSubject.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.fetchTaxonomy = this.fetchTaxonomy.bind(this);
-    this.createAndPlaceTopic = this.createAndPlaceTopic.bind(this);
-    this.onCancel = this.onCancel.bind(this);
   }
 
   componentDidMount() {
     this.fetchTaxonomy();
   }
 
-  async getSubjectTopics(subjectId) {
+  getSubjectTopics = async subjectId => {
     if (
       this.state.structure.some(
         subject => subject.id === subjectId && subject.topics,
@@ -81,9 +73,9 @@ class TopicArticleTaxonomy extends Component {
     } catch (e) {
       handleError(e);
     }
-  }
+  };
 
-  async fetchTaxonomy() {
+  fetchTaxonomy = async () => {
     const {
       article: { language, id },
     } = this.props;
@@ -117,9 +109,9 @@ class TopicArticleTaxonomy extends Component {
       handleError(e);
       this.setState({ status: 'error' });
     }
-  }
+  };
 
-  stageTaxonomyChanges({ addTopicId, removeTopicId, path }) {
+  stageTaxonomyChanges = ({ addTopicId, removeTopicId, path }) => {
     const {
       article: { title },
     } = this.props;
@@ -154,9 +146,9 @@ class TopicArticleTaxonomy extends Component {
         ],
       }));
     }
-  }
+  };
 
-  async createAndPlaceTopic(topic, articleId) {
+  createAndPlaceTopic = async (topic, articleId) => {
     const newTopicPath = await addTopic({
       name: topic.name,
       contentUri: `urn:article:${articleId}`,
@@ -181,9 +173,9 @@ class TopicArticleTaxonomy extends Component {
       id: newTopicId,
       path: topic.path.replace('staged', newTopicId.replace('urn:', '')),
     };
-  }
+  };
 
-  async handleSubmit(evt) {
+  handleSubmit = async evt => {
     evt.preventDefault();
     const { stagedTopicChanges, topics } = this.state;
     const {
@@ -246,9 +238,9 @@ class TopicArticleTaxonomy extends Component {
       handleError(err);
       this.setState({ saveStatus: 'error' });
     }
-  }
+  };
 
-  updateSubject(subjectid, newSubject) {
+  updateSubject = (subjectid, newSubject) => {
     this.setState(prevState => ({
       structure: prevState.structure.map(subject => {
         if (subject.id === subjectid) {
@@ -257,50 +249,13 @@ class TopicArticleTaxonomy extends Component {
         return subject;
       }),
     }));
-  }
+  };
 
-  retriveBreadCrumbs(topicPath) {
-    const {
-      structure,
-      taxonomyChoices: { allTopics },
-    } = this.state;
-    const {
-      article: { title },
-    } = this.props;
-    try {
-      const [subjectPath, ...topicPaths] = pathToUrnArray(topicPath);
-
-      const subject = structure.find(
-        structureSubject => structureSubject.id === subjectPath,
-      );
-      const returnPaths = [];
-      returnPaths.push({
-        name: subject.name,
-        id: subject.id,
-      });
-      topicPaths.forEach(pathId => {
-        const topicPath = allTopics.find(subtopic => subtopic.id === pathId);
-        if (topicPath) {
-          returnPaths.push({
-            name: topicPath.name,
-            id: topicPath.id,
-          });
-        } else {
-          returnPaths.push({ name: title, id: pathId });
-        }
-      });
-      return returnPaths;
-    } catch (err) {
-      handleError(err);
-      return false;
-    }
-  }
-
-  removeConnection(id) {
+  removeConnection = id => {
     this.stageTaxonomyChanges({ removeTopicId: id });
-  }
+  };
 
-  onCancel() {
+  onCancel = () => {
     const { isDirty } = this.state;
     const { closePanel } = this.props;
     if (!isDirty) {
@@ -309,7 +264,7 @@ class TopicArticleTaxonomy extends Component {
       // TODO open warning
       closePanel();
     }
-  }
+  };
 
   render() {
     const {
@@ -320,7 +275,10 @@ class TopicArticleTaxonomy extends Component {
       saveStatus,
       isDirty,
     } = this.state;
-    const { t } = this.props;
+    const {
+      t,
+      article: { title },
+    } = this.props;
 
     if (status === 'loading') {
       return <Spinner />;
@@ -347,7 +305,9 @@ class TopicArticleTaxonomy extends Component {
           structure={structure}
           taxonomyTopics={allTopics}
           activeTopics={stagedTopicChanges}
-          retriveBreadCrumbs={this.retriveBreadCrumbs}
+          retriveBreadCrumbs={topicPath =>
+            retriveBreadCrumbs({ topicPath, allTopics, structure, title })
+          }
           removeConnection={this.removeConnection}
           getSubjectTopics={this.getSubjectTopics}
           stageTaxonomyChanges={this.stageTaxonomyChanges}

--- a/src/containers/TopicArticlePage/components/TopicArticleTaxonomy.jsx
+++ b/src/containers/TopicArticlePage/components/TopicArticleTaxonomy.jsx
@@ -40,8 +40,7 @@ class TopicArticleTaxonomy extends Component {
     super();
     this.state = {
       structure: [],
-      status: 'initial',
-      saveStatus: 'initial',
+      status: 'loading',
       isDirty: false,
       topics: [],
       stagedTopicChanges: [],
@@ -80,7 +79,6 @@ class TopicArticleTaxonomy extends Component {
       article: { language, id },
     } = this.props;
     try {
-      this.setState({ status: 'loading' });
       const [topics, allTopics, allFilters, subjects] = await Promise.all([
         queryTopics(id, language),
         fetchTopics(language),
@@ -93,7 +91,7 @@ class TopicArticleTaxonomy extends Component {
         .sort(sortByName);
 
       this.setState({
-        status: 'success',
+        status: 'initial',
         topics,
         stagedTopicChanges: topics,
         structure: sortedSubjects,
@@ -182,7 +180,7 @@ class TopicArticleTaxonomy extends Component {
       updateNotes,
       article: { id: articleId, language, revision },
     } = this.props;
-    this.setState({ saveStatus: 'loading', status: 'loading' });
+    this.setState({ status: 'loading' });
 
     const stagedNewTopics = stagedTopicChanges.filter(
       topic => topic.id === 'staged',
@@ -231,12 +229,11 @@ class TopicArticleTaxonomy extends Component {
         isDirty: false,
         topics: updatedTopics,
         stagedTopicChanges: updatedTopics,
-        saveStatus: 'success',
         status: 'success',
       });
     } catch (err) {
       handleError(err);
-      this.setState({ saveStatus: 'error' });
+      this.setState({ status: 'error' });
     }
   };
 
@@ -272,7 +269,6 @@ class TopicArticleTaxonomy extends Component {
       stagedTopicChanges,
       structure,
       status,
-      saveStatus,
       isDirty,
     } = this.state;
     const {
@@ -283,7 +279,7 @@ class TopicArticleTaxonomy extends Component {
     if (status === 'loading') {
       return <Spinner />;
     }
-    if (status === 'error' || saveStatus === 'error') {
+    if (status === 'error') {
       return (
         <ErrorMessage
           illustration={{
@@ -316,12 +312,12 @@ class TopicArticleTaxonomy extends Component {
           <FormikActionButton
             outline
             onClick={this.onCancel}
-            disabled={saveStatus === 'loading'}>
+            disabled={status === 'loading'}>
             {t('form.abort')}
           </FormikActionButton>
           <SaveButton
-            isSaving={saveStatus === 'loading'}
-            showSaved={saveStatus === 'success' && !isDirty}
+            isSaving={status === 'loading'}
+            showSaved={status === 'success' && !isDirty}
             disabled={!isDirty}
             onClick={this.handleSubmit}
             defaultText="saveTax"

--- a/src/util/retriveBreadCrumbs.js
+++ b/src/util/retriveBreadCrumbs.js
@@ -1,0 +1,34 @@
+import handleError from './handleError';
+import { pathToUrnArray } from './taxonomyHelpers';
+
+const retriveBreadCrumbs = ({ topicPath, structure, allTopics, title }) => {
+  try {
+    const [subjectPath, ...topicPaths] = pathToUrnArray(topicPath);
+
+    const subject = structure.find(
+      structureSubject => structureSubject.id === subjectPath,
+    );
+    const returnPaths = [];
+    returnPaths.push({
+      name: subject.name,
+      id: subject.id,
+    });
+    topicPaths.forEach(pathId => {
+      const topicPath = allTopics.find(subtopic => subtopic.id === pathId);
+      if (topicPath) {
+        returnPaths.push({
+          name: topicPath.name,
+          id: topicPath.id,
+        });
+      } else if (title) {
+        returnPaths.push({ name: title, id: pathId });
+      }
+    });
+    return returnPaths;
+  } catch (err) {
+    handleError(err);
+    return false;
+  }
+};
+
+export default retriveBreadCrumbs;

--- a/src/util/retriveBreadCrumbs.ts
+++ b/src/util/retriveBreadCrumbs.ts
@@ -1,24 +1,42 @@
 import handleError from './handleError';
 import { pathToUrnArray } from './taxonomyHelpers';
 
-const retriveBreadCrumbs = ({ topicPath, structure, allTopics, title }) => {
+type Input = {
+  topicPath: { name: string; id: string };
+  structure: PathArray;
+  allTopics: PathArray;
+  title: string;
+};
+
+type PathArray = Array<{
+  name: string;
+  id: string;
+}>;
+
+const retriveBreadCrumbs = ({
+  topicPath,
+  structure,
+  allTopics,
+  title,
+}: Input): PathArray => {
   try {
     const [subjectPath, ...topicPaths] = pathToUrnArray(topicPath);
 
     const subject = structure.find(
       structureSubject => structureSubject.id === subjectPath,
     );
+    if (!subject) return [];
     const returnPaths = [];
     returnPaths.push({
       name: subject.name,
       id: subject.id,
     });
-    topicPaths.forEach(pathId => {
-      const topicPath = allTopics.find(subtopic => subtopic.id === pathId);
-      if (topicPath) {
+    topicPaths.forEach((pathId: string) => {
+      const path = allTopics.find(subtopic => subtopic.id === pathId);
+      if (path) {
         returnPaths.push({
-          name: topicPath.name,
-          id: topicPath.id,
+          name: path.name,
+          id: path.id,
         });
       } else if (title) {
         returnPaths.push({ name: title, id: pathId });
@@ -27,7 +45,7 @@ const retriveBreadCrumbs = ({ topicPath, structure, allTopics, title }) => {
     return returnPaths;
   } catch (err) {
     handleError(err);
-    return false;
+    return [];
   }
 };
 


### PR DESCRIPTION
Fix taxonomy changes seemingly failing when saving, because timeout was not big enough

- Don't refetch taxonomy on topicArticles, just calculate new state based on returned path
- Silently refetch taxonomy in learning resources, and increase timeout to 5secs. State should then be updated until next time save is pressed
- Some other bug fixes and refactoring

Check that

- [ ] You can add new structure connection, and remove it without reloading, both for topics and learning resources
- [ ] Changes made are still correct when refreshing page