### PR TITLE
Make visual element return empty string

### DIFF
--- a/src/util/__tests__/embedTagHelpers-test.js
+++ b/src/util/__tests__/embedTagHelpers-test.js
@@ -100,8 +100,8 @@ test('createEmbedTag creates brightcove embed tag from object', () => {
   expect(tag).toMatchSnapshot();
 });
 
-test('createEmbedTag returns undefined if the object contains no keys', () => {
-  expect(createEmbedTag({})).toBe(undefined);
+test('createEmbedTag returns empty string if the object contains no keys', () => {
+  expect(createEmbedTag({})).toBe('');
 });
 
 test('isUserProvidedEmbedDataValid for image', () => {

--- a/src/util/embedTagHelpers.js
+++ b/src/util/embedTagHelpers.js
@@ -87,7 +87,7 @@ export const parseEmbedTag = embedTag => {
 
 export const createEmbedTag = visualElement => {
   if (Object.keys(visualElement).length === 0) {
-    return undefined;
+    return '';
   }
   const embed = document.createElement('embed');
   Object.keys(visualElement)


### PR DESCRIPTION
Ikke merge denne før det er fikset i backend ref Issue 1867, da vil det ikke funke å opprette drafts uten visuelt element.