### PR TITLE
fix read from paths when pasting

### DIFF
--- a/src/containers/StructurePage/resourceComponents/AddResourceModal.jsx
+++ b/src/containers/StructurePage/resourceComponents/AddResourceModal.jsx
@@ -175,7 +175,6 @@ class AddResourceModal extends Component {
           this.props.type === RESOURCE_TYPE_LEARNING_PATH
             ? await this.findResourceIdLearningPath(selected)
             : getResourceIdFromPath(selected.paths[0]);
-        console.log(resourceId);
         await createTopicResource({
           resourceId,
           topicid: topicId,

--- a/src/containers/StructurePage/resourceComponents/AddResourceModal.jsx
+++ b/src/containers/StructurePage/resourceComponents/AddResourceModal.jsx
@@ -80,7 +80,11 @@ class AddResourceModal extends Component {
         const pastedType = resourceType.length > 0 && resourceType[0].id;
         const error =
           pastedType === type ? '' : `${t('taxonomy.wrongType')} ${pastedType}`;
-        this.setState({ selected: { id: val }, pastedUrl: val, error });
+        this.setState({
+          selected: { id: val, paths: [val] },
+          pastedUrl: val,
+          error,
+        });
       } catch (error) {
         handleError(error);
         this.setState({ error: error.message });
@@ -171,6 +175,7 @@ class AddResourceModal extends Component {
           this.props.type === RESOURCE_TYPE_LEARNING_PATH
             ? await this.findResourceIdLearningPath(selected)
             : getResourceIdFromPath(selected.paths[0]);
+        console.log(resourceId);
         await createTopicResource({
           resourceId,
           topicid: topicId,


### PR DESCRIPTION
Fixes error when pasting url into add resource modal. Still fails though, taxonomy-api returns 409 conflict when adding whatever resource, I think this is something they have changed on their end?