### PR TITLE
Keep status if article fetched from article-api.

### DIFF
--- a/src/containers/FormikForm/VersionAndNotesPanel.jsx
+++ b/src/containers/FormikForm/VersionAndNotesPanel.jsx
@@ -111,7 +111,10 @@ const VersionAndNotesPanel = ({
         article = await articleApi.getArticle(article.id, article.language);
       }
       const newValues = getInitialValues(
-        transformArticleFromApiVersion(article, language),
+        transformArticleFromApiVersion(
+          { ...article, status: version.status },
+          language,
+        ),
       );
 
       setValues(newValues);


### PR DESCRIPTION
Saving after reset from article-api fails due to missing statuses.