### PR TITLE
Increase query-limit in search-editor

### DIFF
--- a/src/containers/NdlaFilm/NdlaFilmEditor.jsx
+++ b/src/containers/NdlaFilm/NdlaFilmEditor.jsx
@@ -110,7 +110,7 @@ class NdlaFilmEditor extends React.Component {
       subjects: 'urn:subject:20',
       'context-types': 'topic-article',
       sort: '-relevance',
-      'page-size': 100,
+      'page-size': 10000,
     };
     const response = await searchResources(query);
     return response.results;


### PR DESCRIPTION
Løsningen burde nok vært skrevet om slik at den ikke er avhengig av en liste av alle tilgjengelige filmer.  Det blir for tidkrevende i denne omgang. Det er uansett p.t. bare ca 250 filmer. 