### PR TITLE
#2020 Hide last used from dashboard

### DIFF
--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -89,7 +89,7 @@ export const WelcomePage: FC<Props> = ({ locale, t }) => {
                 <LastUsed className="c-icon--medium" />
                 <span>{t('welcomePage.lastUsed')}</span>
               </div>
-              {lastUsed.length ? (
+              {false && lastUsed.length ? (
                 lastUsed.map((result: ContentResultType) => (
                   <LastUsedContent
                     key={result.id}


### PR DESCRIPTION
[Issue #2020](https://github.com/NDLANO/Issues/issues/2020)
NDLA ønsker at mine siste artikler må fungere litt anderledes enn det gjør i dag. Vi må derfor skjule funksjonaliteten inntil dei har fått beskreve korleis dei vil ha det. Vi treng ikkje slette noko, berre legge til et flagg som skjuler søket fra forsida.