### PR TITLE
#2033: Only trigger metaImageUpload when metaImage dialog is showing

### DIFF
--- a/src/containers/FormikForm/FormikMetaImageSearch.jsx
+++ b/src/containers/FormikForm/FormikMetaImageSearch.jsx
@@ -39,7 +39,7 @@ class FormikMetaImageSearch extends Component {
 
   componentDidUpdate({ metaImageId: prevMetaImageId }) {
     const { uploadedImage, clearUploadedImage, metaImageId } = this.props;
-    if (uploadedImage) {
+    if (uploadedImage && this.state.showImageSelect) {
       this.onImageChange(uploadedImage);
       clearUploadedImage();
     }


### PR DESCRIPTION
Opplastning av bilde sender et event som både FormikMetaImageSearch _og_ VisualElementSearch bruker.
Det gjør at meta panelet er rendret (åpent) så vil den fange eventet og endre metabilde basert på det opplastede bildet.