### PR TITLE
Fixing diffing of articles

### DIFF
--- a/scripts/checkArticles/index.js
+++ b/scripts/checkArticles/index.js
@@ -12,7 +12,7 @@ const fetch = require('isomorphic-fetch');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const { diffHTML } = require('../../src/util/diffHTML');
-const { getNdlaApiUrl } = require('../../src/config');
+const { getNdlaApiUrl, getAuth0Hostname } = require('../../src/config');
 const {
   learningResourceContentToEditorValue,
   learningResourceContentToHTML,
@@ -40,7 +40,7 @@ function sleep(ms) {
 }
 
 async function fetchSystemAccessToken() {
-  token = await fetch(`https://ndla.eu.auth0.com/oauth/token`, {
+  token = await fetch(`https://${getAuth0Hostname()}/oauth/token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/config.js
+++ b/src/config.js
@@ -77,7 +77,7 @@ const h5pApiUrl = () => {
   }
 };
 
-const getAuth0Hostname = () => {
+export const getAuth0Hostname = () => {
   switch (process.env.NDLA_ENVIRONMENT) {
     case 'prod':
       return 'ndla.eu.auth0.com';

--- a/src/util/diffHTML.js
+++ b/src/util/diffHTML.js
@@ -93,7 +93,7 @@ function allowStrongRemoval({ current, next, previous }) {
     return true;
   }
   // I.E. <strong>one</strong><strong>two</strong> -> <strong>onetwo</strong>
-  if (brWrappers.some(tag => current.includes(`${tag}></${tag}`))) {
+  if (brWrappers.some(tag => current.includes(`/${tag}><${tag}`))) {
     return true;
   }
   return false;

--- a/src/util/slateHelpers.js
+++ b/src/util/slateHelpers.js
@@ -118,6 +118,16 @@ export const textRule = {
       return null;
     }
     if (
+      el.nodeName.toLowerCase() === '#text' &&
+      el.parentNode?.tagName.toLowerCase() === 'section'
+    ) {
+      // handle text nodes directly inside section
+      return {
+        object: 'text',
+        text: el.data,
+      };
+    }
+    if (
       !el.nodeName ||
       el.nodeName.toLowerCase() !== '#text' ||
       (el.parentNode && el.parentNode.tagName.toLowerCase() !== 'section')


### PR DESCRIPTION
cleanUpHtml fjerner innslag av </tag><tag> for f.eks strong.
Men allowStrongRemoval sjekka på <tag/><tag> altså det motsatte.
Fiksen er altså at allowStrongRemoval snus til å sjekke på samme som fjernes i cleanUpHtml.

Er dette en forståelig fiks?