### PR TITLE
Enable br in markdown in introduction

### DIFF
--- a/src/components/PreviewDraft/PreviewDraft.tsx
+++ b/src/components/PreviewDraft/PreviewDraft.tsx
@@ -40,7 +40,7 @@ class PreviewDraft extends Component<Props, {}> {
       return null;
     }
 
-    const markdown = new Remarkable();
+    const markdown = new Remarkable({ breaks: true });
     markdown.inline.ruler.enable(['sub', 'sup']);
 
     const renderMarkdown = (text: string) => {

--- a/src/containers/FormikForm/FormikIngress.jsx
+++ b/src/containers/FormikForm/FormikIngress.jsx
@@ -10,13 +10,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import { Remarkable } from 'remarkable';
+import parse from 'html-react-parser';
 
 import StyledFormContainer from '../../components/SlateEditor/common/StyledFormContainer';
 import PlainTextEditor from '../../components/SlateEditor/PlainTextEditor';
 import FormikField from '../../components/FormikField';
 
-const md = new Remarkable();
-md.inline.ruler.enable(['sub', 'sup']);
+const markdown = new Remarkable({ breaks: true });
+markdown.inline.ruler.enable(['sub', 'sup']);
+
+const renderMarkdown = text => {
+  return markdown.render(text);
+};
 
 const FormikIngress = ({
   t,
@@ -34,11 +39,9 @@ const FormikIngress = ({
       maxLength={maxLength}>
       {({ field }) =>
         preview ? (
-          <span
-            dangerouslySetInnerHTML={{
-              __html: md.render(field.value.document.text),
-            }}
-          />
+          <p className="article_introduction">
+            {parse(renderMarkdown(field.value.document.text))}
+          </p>
         ) : (
           <PlainTextEditor
             id={field.name}


### PR DESCRIPTION
Fixes NDLANO/Issues#2141

Skrur på breaks i remarkable for at \n skal rendres som br i visninga.

Forhåndsvisninga i ingress-editor fungerer ikkje optimalt fordi field.value.document.text henter ut teksten fra feltet slått sammen til en lang tekststreng uten separatorer. Har sjekka kva som finnes av verdier i field.value men har ikkje funne bedre måte å gjøre det på.