### PR TITLE
Make sure all math is wrapped in math-tag before edit.

### DIFF
--- a/src/components/SlateEditor/plugins/mathml/MathEditor.js
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.js
@@ -41,9 +41,12 @@ const buttonStyle = css`
 
 const getInfoFromNode = node => {
   const data = node.data ? node.data.toJS() : {};
+  const innerHTML = data.innerHTML || `<mn>${he.encode(node.text)}</mn>`;
   return {
     model: {
-      innerHTML: data.innerHTML || `<mn>${he.encode(node.text)}</mn>`,
+      innerHTML: innerHTML.startsWith('<math')
+        ? innerHTML
+        : `<math>${innerHTML}</math>`,
       xlmns: data.xlmns || 'xmlns="http://www.w3.org/1998/Math/MathML',
     },
     isFirstEdit: data.innerHTML === undefined,


### PR DESCRIPTION
Redigering av matte feiler om lagra matte ikkje har `<math>` som ytterste ledd. Dette har tidligerere blitt fjerna av vår kode, så endringa må med for at både gamle og nye formler skal virke.