### PR TITLE
Fixing resetting form at save

### DIFF
--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.jsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.jsx
@@ -206,7 +206,7 @@ AsyncDropDown.propTypes = {
   disableSelected: PropTypes.bool,
   onCreate: PropTypes.func,
   onKeyDown: PropTypes.func,
-  children: PropTypes.node,
+  children: PropTypes.func,
   removeItem: PropTypes.func,
   clearInputField: PropTypes.bool,
   customCreateButtonText: PropTypes.string,

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -120,7 +120,6 @@ export function useArticleFormHooks({
       await deleteRemovedFiles(article.content, newArticle.content);
 
       setSavedToServer(true);
-      formik.resetForm(formik);
 
       Object.keys(formik.values).map(fieldName =>
         formik.setFieldTouched(fieldName, true, true),
@@ -138,13 +137,13 @@ export function useArticleFormHooks({
       } else {
         applicationError(err);
       }
-      formik.setSubmitting(false);
       if (statusChange) {
         // if validation failed we need to set status back so it won't be saved as new status on next save
         formik.setFieldValue('status', { current: initialStatus });
       }
       setSavedToServer(false);
     }
+    formik.setSubmitting(false);
     await formik.validateForm();
   };
 

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -78,8 +78,6 @@ export function useArticleFormHooks({
       ? { ...slateArticle, createNewVersion: true }
       : slateArticle;
 
-    let savedArticle = {};
-
     try {
       if (statusChange) {
         // if editor is not dirty, OR we are unpublishing, we don't save before changing status
@@ -90,7 +88,7 @@ export function useArticleFormHooks({
             initialValues,
             dirty: true,
           });
-        savedArticle = await updateArticleAndStatus({
+        await updateArticleAndStatus({
           updatedArticle: {
             ...newArticle,
             revision,
@@ -99,7 +97,7 @@ export function useArticleFormHooks({
           dirty: !skipSaving,
         });
       } else {
-        savedArticle = await updateArticle({
+        await updateArticle({
           ...newArticle,
           revision,
         });
@@ -122,9 +120,6 @@ export function useArticleFormHooks({
       await deleteRemovedFiles(article.content, newArticle.content);
 
       setSavedToServer(true);
-      formik.resetForm({
-        values: getInitialValues(savedArticle),
-      });
 
       Object.keys(formik.values).map(fieldName =>
         formik.setFieldTouched(fieldName, true, true),

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -78,6 +78,8 @@ export function useArticleFormHooks({
       ? { ...slateArticle, createNewVersion: true }
       : slateArticle;
 
+    let savedArticle = {};
+
     try {
       if (statusChange) {
         // if editor is not dirty, OR we are unpublishing, we don't save before changing status
@@ -88,7 +90,7 @@ export function useArticleFormHooks({
             initialValues,
             dirty: true,
           });
-        await updateArticleAndStatus({
+        savedArticle = await updateArticleAndStatus({
           updatedArticle: {
             ...newArticle,
             revision,
@@ -97,7 +99,7 @@ export function useArticleFormHooks({
           dirty: !skipSaving,
         });
       } else {
-        await updateArticle({
+        savedArticle = await updateArticle({
           ...newArticle,
           revision,
         });
@@ -120,6 +122,9 @@ export function useArticleFormHooks({
       await deleteRemovedFiles(article.content, newArticle.content);
 
       setSavedToServer(true);
+      formik.resetForm({
+        values: getInitialValues(savedArticle),
+      });
 
       Object.keys(formik.values).map(fieldName =>
         formik.setFieldTouched(fieldName, true, true),

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -78,6 +78,7 @@ export function useArticleFormHooks({
       ? { ...slateArticle, createNewVersion: true }
       : slateArticle;
 
+    let savedArticle = {};
     try {
       if (statusChange) {
         // if editor is not dirty, OR we are unpublishing, we don't save before changing status
@@ -88,7 +89,7 @@ export function useArticleFormHooks({
             initialValues,
             dirty: true,
           });
-        await updateArticleAndStatus({
+        savedArticle = await updateArticleAndStatus({
           updatedArticle: {
             ...newArticle,
             revision,
@@ -97,7 +98,7 @@ export function useArticleFormHooks({
           dirty: !skipSaving,
         });
       } else {
-        await updateArticle({
+        savedArticle = await updateArticle({
           ...newArticle,
           revision,
         });
@@ -120,6 +121,7 @@ export function useArticleFormHooks({
       await deleteRemovedFiles(article.content, newArticle.content);
 
       setSavedToServer(true);
+      formik.resetForm({ values: getInitialValues(savedArticle) });
 
       Object.keys(formik.values).map(fieldName =>
         formik.setFieldTouched(fieldName, true, true),

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -120,7 +120,7 @@ export function useArticleFormHooks({
       await deleteRemovedFiles(article.content, newArticle.content);
 
       setSavedToServer(true);
-      formik.resetForm();
+      formik.resetForm(formik);
 
       Object.keys(formik.values).map(fieldName =>
         formik.setFieldTouched(fieldName, true, true),

--- a/src/containers/FormikForm/formikDraftHooks.js
+++ b/src/containers/FormikForm/formikDraftHooks.js
@@ -39,10 +39,12 @@ export function useFetchArticleData(articleId, locale) {
   const updateArticle = async updatedArticle => {
     const savedArticle = await draftApi.updateDraft(updatedArticle);
     const taxonomy = await fetchTaxonomy(articleId, locale);
-    setArticle(
-      transformArticleFromApiVersion({ taxonomy, ...savedArticle }, locale),
+    const updated = transformArticleFromApiVersion(
+      { taxonomy, ...savedArticle },
+      locale,
     );
-    return savedArticle;
+    setArticle(updated);
+    return updated;
   };
 
   const updateArticleAndStatus = async ({


### PR DESCRIPTION
Dette er litt prøving og feiling, men ser ut til å være et stykke på vei.

Feilen blei innført med oppgradering til formik 2, og det ser ut som om endra resetForm er grunnen til at det feiler. I [migreringsoppskrifta](https://jaredpalmer.com/formik/docs/migrating-v2) står det 

> Because we introduced initialErrors, initialTouched, initialStatus props, resetForm's signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).

Parameter til resetForm er av type [FormikState](https://github.com/formik/formik/blob/master/packages/formik/src/types.tsx#L39) så eg testa å sette inn formik som parameter i og med at den såg ut til å dekke interfacet. Uten parameter til funksjonen blei formik satt tilbake til staten den hadde ved starten på redigeringa.

Problemet no er at lagreknappen blir blå etter lagring, så antageligvis er ikkje det nok å sende inn formik her.
