### PR TITLE
Hides empty search params

### DIFF
--- a/src/containers/WelcomePage/components/SavedSearch.tsx
+++ b/src/containers/WelcomePage/components/SavedSearch.tsx
@@ -61,15 +61,22 @@ const SavedSearch: FC<Props> = ({ deleteSearch, locale, search, index, t }) => {
   };
 
   const linkText = (search: string) => {
-    const query = searchObject.query || t('welcomePage.emptySearchQuery');
-    const status = searchObject['/search/content?draft-status'] || '';
-    const contextType = searchObject['context-types'] || '';
+    const query = searchObject.query || undefined;
+    const status = searchObject['/search/content?draft-status'] || undefined;
+    const contextType = searchObject['context-types'] || undefined;
 
-    return `${query} ${status &&
-      `- ${t(`form.status.${status.toLowerCase()}`)}`} ${subject &&
-      `- ${subjectName}`} ${resourceType &&
-      `- ${resourceTypeName}`} ${contextType && `- ${t(`contextTypes.topic`)}`}
-      `;
+    const results = [];
+    results.push(query);
+    results.push(status && t(`form.status.${status.toLowerCase()}`));
+    results.push(subject && subjectName);
+    results.push(resourceType && resourceTypeName);
+    results.push(contextType && t(`contextTypes.topic`));
+
+    return results
+      .filter(function(e) {
+        return e;
+      })
+      .join(' + ');
   };
 
   return (

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -149,7 +149,6 @@ const phrases = {
     deleteSearch: 'Delete search',
     emptyLastUsed: 'Empty last edited list',
     emptySavedSearch: 'No saved searches',
-    emptySearchQuery: 'Empty search query',
     guidelines: 'Guidelines',
     mustBeSearch: 'Link must be a search url',
     lastUsed: 'Last edited',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -147,7 +147,6 @@ const phrases = {
     deleteSearch: 'Slett søk',
     emptyLastUsed: 'Ingen sist redigerte',
     emptySavedSearch: 'Ingen lagrede søk',
-    emptySearchQuery: 'Ingen søketekst',
     guidelines: 'Retningslinjer',
     mustBeSearch: 'Lenken må være til et søk',
     lastUsed: 'Sist redigert',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -147,7 +147,6 @@ const phrases = {
     deleteSearch: 'Slett søk',
     emptyLastUsed: 'Ingen sist redigerte',
     emptySavedSearch: 'Ingen lagra søk',
-    emptySearchQuery: 'Ingen søketekst',
     guidelines: 'Retningslinjer',
     mustBeSearch: 'Lenka må være til eit søk',
     lastUsed: 'Sist redigert',


### PR DESCRIPTION
Fixes NDLANO/Issues#2213

Does not show "ingen søketekst" for saved searches. Found simple code to remove undefineds from array.