### PR TITLE
Only allow moving topics within subject

### DIFF
--- a/cypress/integration/Taxonomy/topic_spec.js
+++ b/cypress/integration/Taxonomy/topic_spec.js
@@ -37,6 +37,11 @@ describe('Topic editing', () => {
     );
     cy.apiroute(
       'GET',
+      `/taxonomy/v1/topics?includeMetadata=true&recursive=true&language=nb`,
+      'allTopics',
+    );
+    cy.apiroute(
+      'GET',
       `/taxonomy/v1/subjects/${selectSubject}/filters`,
       'allSubjectFilters',
     );
@@ -78,11 +83,6 @@ describe('Topic editing', () => {
       response: '',
       alias: 'addFilter',
     });
-    cy.apiroute(
-      'GET',
-      '/taxonomy/v1/topics?includeMetadata=true&language=nb',
-      'allTopics',
-    );
     cy.apiroute(
       'GET',
       `/taxonomy/v1/topics/${selectTopic}/filters`,
@@ -127,7 +127,7 @@ describe('Topic editing', () => {
     cy.wait('@allSubjectTopics');
     cy.get('[data-testid=connectFilterItem]').click({ multiple: true });
     cy.get('[data-testid="submitConnectFilters"]').click();
-    cy.apiwait(['@addFilter', '@allSubjectTopics']);
+    cy.apiwait(['@addFilter']);
     cy.wait(500);
   });
 });

--- a/src/containers/StructurePage/folderComponents/menuOptions/AddExistingToSubjectTopic.jsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/AddExistingToSubjectTopic.jsx
@@ -34,14 +34,21 @@ class AddExistingToSubjectTopic extends React.PureComponent {
   }
 
   async componentDidMount() {
-    const { locale } = this.props;
+    const { locale, subjectId } = this.props;
+    // Should rather be fetching subjectTopics, but that endpoint does not return paths.
     const topics = await fetchTopics(locale || 'nb');
 
     this.setState({
-      topics: topics.map(topic => ({
-        ...topic,
-        description: this.getTopicBreadcrumb(topic, topics),
-      })),
+      topics: topics
+        .filter(topic =>
+          topic.paths.find(
+            path => path.split('/')[1] === subjectId.replace('urn:', ''),
+          ),
+        )
+        .map(topic => ({
+          ...topic,
+          description: this.getTopicBreadcrumb(topic, topics),
+        })),
     });
   }
 

--- a/src/containers/StructurePage/folderComponents/menuOptions/AddExistingToTopic.jsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/AddExistingToTopic.jsx
@@ -15,7 +15,6 @@ import {
   fetchTopics,
   addTopicToTopic,
   addFilterToTopic,
-  fetchSubjectTopics,
   fetchTopicConnections,
   deleteSubTopicConnection,
   deleteTopicConnection,
@@ -36,12 +35,17 @@ class AddExistingToTopic extends React.PureComponent {
   }
 
   async componentDidMount() {
-    const { locale, subjectId } = this.props;
-    const topics = await fetchTopics(locale || 'nb');
-    const subjectTopics = await fetchSubjectTopics(subjectId, locale);
+    const { locale, subjectId, path } = this.props;
+    // TODO: Should rather be fetching subjectTopics, but that endpoint does not return paths.
+    const topics = await fetchTopics(locale);
     this.setState({
       topics: topics
-        .filter(topic => !subjectTopics.some(t => t.id === topic.id))
+        .filter(topic =>
+          topic.paths.find(
+            path => path.split('/')[1] === subjectId.replace('urn:', ''),
+          ),
+        )
+        .filter(topic => !topic.paths?.find(p => path.includes(p)))
         .map(topic => ({
           ...topic,
           description: this.getTopicBreadcrumb(topic, topics),


### PR DESCRIPTION
Fixes NDLANO/Issues#2230

For å unngå problematikk rundt filter ved flytting av emner mellom fag, begrenser dette at emner kun kan flyttes innad i fag.

Alle emner kan flyttes til toppnivå i fag. Men emner kan ikkje flyttes til et underemne av seg sjølv, fordi dette vil føre til en sirkulæravhengighet som vi ikkje får rydda opp i.

Skulle helst ha brukt funksjon for å hente emner i et fag, men det endepunktet returnerer ikkje paths, og det er så vidt eg kan hugse fremdeles mulig at et emne kan ha fleire paths. Når det er endelig rydda opp i kan vi også endre endepunkt.