### PR TITLE
Fix link to learningpath

### DIFF
--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -41,6 +41,7 @@ import H5PPage from '../H5PPage/H5PPage';
 import Subjectpage from '../EditSubjectFrontpage/Subjectpage';
 
 export const FirstLoadContext = React.createContext(true);
+export const LocaleContext = React.createContext('');
 
 export class App extends React.Component {
   constructor() {
@@ -78,52 +79,54 @@ export class App extends React.Component {
     } = this.props;
     return (
       <ErrorBoundary>
-        <FirstLoadContext.Provider value={this.state.firstLoad}>
-          <PageContainer background>
-            <Helmet
-              meta={[{ name: 'description', content: t('meta.description') }]}
-            />
-            <Content>
-              <Navigation authenticated={authenticated} userName={userName} />
-              <Switch>
-                <Route
-                  path="/"
-                  exact
-                  component={() => <WelcomePage locale={locale} />}
-                />
-                <Route path="/login" component={Login} />
-                <Route path="/logout" component={Logout} />
-                <PrivateRoute path="/subjectpage" component={Subjectpage} />
-                <PrivateRoute path="/search" component={SearchPage} />
-                <PrivateRoute
-                  path="/subject-matter"
-                  component={SubjectMatterPage}
-                />
-                <PrivateRoute
-                  path="/edit-markup/:draftId/:language"
-                  component={EditMarkupPage}
-                />
-                <PrivateRoute path="/concept" component={ConceptPage} />
+        <LocaleContext.Provider value={locale}>
+          <FirstLoadContext.Provider value={this.state.firstLoad}>
+            <PageContainer background>
+              <Helmet
+                meta={[{ name: 'description', content: t('meta.description') }]}
+              />
+              <Content>
+                <Navigation authenticated={authenticated} userName={userName} />
+                <Switch>
+                  <Route
+                    path="/"
+                    exact
+                    component={() => <WelcomePage locale={locale} />}
+                  />
+                  <Route path="/login" component={Login} />
+                  <Route path="/logout" component={Logout} />
+                  <PrivateRoute path="/subjectpage" component={Subjectpage} />
+                  <PrivateRoute path="/search" component={SearchPage} />
+                  <PrivateRoute
+                    path="/subject-matter"
+                    component={SubjectMatterPage}
+                  />
+                  <PrivateRoute
+                    path="/edit-markup/:draftId/:language"
+                    component={EditMarkupPage}
+                  />
+                  <PrivateRoute path="/concept" component={ConceptPage} />
 
-                <Route
-                  path="/preview/:draftId/:language"
-                  component={PreviewDraftPage}
-                />
-                <PrivateRoute path="/media" component={MediaPage} />
-                <PrivateRoute path="/agreement" component={AgreementPage} />
-                <PrivateRoute path="/film" component={NdlaFilm} />
-                <PrivateRoute path="/h5p" component={H5PPage} />
-                <PrivateRoute
-                  path="/structure/:subject?/:topic?/:subtopics(.*)?"
-                  component={StructurePage}
-                />
-                <Route path="/forbidden" component={ForbiddenPage} />
-                <Route component={NotFoundPage} />
-              </Switch>
-            </Content>
-            <Messages dispatch={dispatch} messages={messages} />
-          </PageContainer>
-        </FirstLoadContext.Provider>
+                  <Route
+                    path="/preview/:draftId/:language"
+                    component={PreviewDraftPage}
+                  />
+                  <PrivateRoute path="/media" component={MediaPage} />
+                  <PrivateRoute path="/agreement" component={AgreementPage} />
+                  <PrivateRoute path="/film" component={NdlaFilm} />
+                  <PrivateRoute path="/h5p" component={H5PPage} />
+                  <PrivateRoute
+                    path="/structure/:subject?/:topic?/:subtopics(.*)?"
+                    component={StructurePage}
+                  />
+                  <Route path="/forbidden" component={ForbiddenPage} />
+                  <Route component={NotFoundPage} />
+                </Switch>
+              </Content>
+              <Messages dispatch={dispatch} messages={messages} />
+            </PageContainer>
+          </FirstLoadContext.Provider>
+        </LocaleContext.Provider>
       </ErrorBoundary>
     );
   }

--- a/src/containers/NdlaFilm/components/ElementList.jsx
+++ b/src/containers/NdlaFilm/components/ElementList.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { spacing, shadows } from '@ndla/core';
 import { ContentResultShape } from '../../../shapes';
+import { LocaleContext } from '../../App/App';
 
 import ElementListItem from './ElementListItem';
 
@@ -160,24 +161,31 @@ class ElementList extends Component {
     const { draggingIndex, deleteIndex } = this.state;
     return (
       <StyledWrapper>
-        <StyledList ref={this.wrapperRef} draggingIndex={draggingIndex}>
-          {elements
-            .filter(element => !!element)
-            .map((element, index) => (
-              <ElementListItem
-                key={element.id}
-                element={element}
-                deleteIndex={deleteIndex}
-                messages={messages}
-                index={index}
-                executeDeleteFile={this.executeDeleteFile}
-                showDragTooltip={elements.length > 1 && draggingIndex === -1}
-                onDragEnd={this.onDragEnd}
-                onDragStart={this.onDragStart}
-                deleteFile={this.deleteFile}
-              />
-            ))}
-        </StyledList>
+        <LocaleContext.Consumer>
+          {locale => (
+            <StyledList ref={this.wrapperRef} draggingIndex={draggingIndex}>
+              {elements
+                .filter(element => !!element)
+                .map((element, index) => (
+                  <ElementListItem
+                    key={element.id}
+                    element={element}
+                    deleteIndex={deleteIndex}
+                    messages={messages}
+                    index={index}
+                    locale={locale}
+                    executeDeleteFile={this.executeDeleteFile}
+                    showDragTooltip={
+                      elements.length > 1 && draggingIndex === -1
+                    }
+                    onDragEnd={this.onDragEnd}
+                    onDragStart={this.onDragStart}
+                    deleteFile={this.deleteFile}
+                  />
+                ))}
+            </StyledList>
+          )}
+        </LocaleContext.Consumer>
       </StyledWrapper>
     );
   }

--- a/src/containers/NdlaFilm/components/ElementListItem.tsx
+++ b/src/containers/NdlaFilm/components/ElementListItem.tsx
@@ -7,46 +7,94 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { spacing, colors, fonts, animations } from '@ndla/core';
 import Tooltip from '@ndla/tooltip';
 import { DragHorizontal, DeleteForever } from '@ndla/icons/editor';
-import { ContentResultShape } from '../../../shapes';
-import { toEditArticle } from '../../../util/routeHelpers';
+import { resourceToLinkProps } from '../../../util/resourceHelpers';
+import { ContentResultType } from '../../../interfaces';
 
 const ELEMENT_HEIGHT = 69;
 const ELEMENT_MARGIN = 4;
 
+interface StyledProps {
+  delete?: boolean;
+  draggable?: boolean;
+}
+
+interface MessageProps {
+  removeElement: string;
+  dragElement: string;
+}
+
+interface Props {
+  deleteFile: (deleteIndex: number) => void;
+  deleteIndex: number;
+  // Element can be of type Article or Learningpath
+  element: ContentResultType;
+  executeDeleteFile: () => void;
+  index: number;
+  locale: string;
+  messages: MessageProps;
+  onDragEnd: () => void;
+  onDragStart: (evt: React.MouseEvent, dragIndex: number) => void;
+  showDragTooltip: boolean;
+}
+
 const ElementListItem = ({
-  element,
+  deleteFile,
   deleteIndex,
-  messages: { removeElement, dragElement },
-  index,
-  showDragTooptil,
+  element,
   executeDeleteFile,
+  index,
+  locale,
+  messages: { removeElement, dragElement },
   onDragEnd,
   onDragStart,
-  deleteFile,
-}) => (
-  <StyledListItem
-    key={element.id}
-    delete={deleteIndex === index}
-    onAnimationEnd={deleteIndex === index ? executeDeleteFile : undefined}>
-    <div>
-      <StyledElementImage
-        src={element.metaImage ? element.metaImage.url : ''}
-        alt={element.metaImage ? element.metaImage.alt : ''}
-      />
-      <Link to={toEditArticle(element.id, element.learningReasourceType)}>
-        {element.title.title}
-      </Link>
-    </div>
-    <div>
-      {showDragTooptil ? (
-        <Tooltip tooltip={dragElement}>
+  showDragTooltip,
+}: Props) => {
+  const linkProps = resourceToLinkProps(
+    element,
+    element.articleType || 'learning-path',
+    locale,
+  );
+
+  return (
+    <StyledListItem
+      key={element.id}
+      delete={deleteIndex === index}
+      onAnimationEnd={deleteIndex === index ? executeDeleteFile : undefined}>
+      <div>
+        <StyledElementImage
+          src={element.metaImage?.url || ''}
+          alt={element.metaImage?.alt || ''}
+        />
+        {linkProps.to ? (
+          <Link to={linkProps.to}>{element.title.title}</Link>
+        ) : (
+          <a
+            href={linkProps.href}
+            target={linkProps.target}
+            rel={linkProps.rel}>
+            {element.title.title}
+          </a>
+        )}
+      </div>
+      <div>
+        {showDragTooltip ? (
+          <Tooltip tooltip={dragElement}>
+            <StyledButtonIcons
+              draggable
+              tabIndex={-1}
+              type="button"
+              onMouseDown={e => onDragStart(e, index)}
+              onMouseUp={onDragEnd}>
+              <DragHorizontal />
+            </StyledButtonIcons>
+          </Tooltip>
+        ) : (
           <StyledButtonIcons
             draggable
             tabIndex={-1}
@@ -55,31 +103,22 @@ const ElementListItem = ({
             onMouseUp={onDragEnd}>
             <DragHorizontal />
           </StyledButtonIcons>
+        )}
+        <Tooltip tooltip={removeElement}>
+          <StyledButtonIcons
+            tabIndex={-1}
+            type="button"
+            onClick={() => deleteFile(index)}
+            delete>
+            <DeleteForever />
+          </StyledButtonIcons>
         </Tooltip>
-      ) : (
-        <StyledButtonIcons
-          draggable
-          tabIndex={-1}
-          type="button"
-          onMouseDown={e => onDragStart(e, index)}
-          onMouseUp={onDragEnd}>
-          <DragHorizontal />
-        </StyledButtonIcons>
-      )}
-      <Tooltip tooltip={removeElement}>
-        <StyledButtonIcons
-          tabIndex={-1}
-          type="button"
-          onClick={() => deleteFile(index)}
-          delete>
-          <DeleteForever />
-        </StyledButtonIcons>
-      </Tooltip>
-    </div>
-  </StyledListItem>
-);
+      </div>
+    </StyledListItem>
+  );
+};
 
-const StyledListItem = styled.li`
+const StyledListItem = styled.li<StyledProps>`
   margin: ${ELEMENT_MARGIN}px 0 0;
   padding: 0;
   background: ${colors.brand.greyLighter};
@@ -119,7 +158,7 @@ const StyledElementImage = styled.img`
   margin-right: ${spacing.small};
 `;
 
-const StyledButtonIcons = styled.button`
+const StyledButtonIcons = styled.button<StyledProps>`
   border: 0;
   background: none;
   color: ${colors.brand.primary};
@@ -151,22 +190,5 @@ const StyledButtonIcons = styled.button`
       cursor: grabbing;
     `};
 `;
-
-ElementListItem.propTypes = {
-  element: ContentResultShape.isRequired,
-  deleteIndex: PropTypes.number,
-  removeElement: PropTypes.string,
-  dragElement: PropTypes.string,
-  index: PropTypes.number,
-  showDragTooptil: PropTypes.bool,
-  executeDeleteFile: PropTypes.func.isRequired,
-  onDragEnd: PropTypes.func.isRequired,
-  onDragStart: PropTypes.func.isRequired,
-  deleteFile: PropTypes.func.isRequired,
-  messages: PropTypes.shape({
-    removeElement: PropTypes.string.isRequired,
-    dragElement: PropTypes.string.isRequired,
-  }).isRequired,
-};
 
 export default ElementListItem;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,19 +63,27 @@ export interface ResourceTranslation {
   language: string;
 }
 
+export interface MetaImage {
+  alt: string;
+  url: string;
+  language: string;
+}
+
 export interface ContentResultType {
+  articleType: string;
   id: number;
   title: { title: string };
   url?: string;
   metaDescription?: { metaDescription: string };
-  metaImage?: { alt: string; url: string; language: string };
+  metaImage?: MetaImage;
+  metaUrl?: string;
   contexts: [
     {
       learningResourceType: string;
       resourceTypes: ResourceType[];
     },
   ];
-  learningResourceType: string;
+  learningResourceType?: string;
   supportedLanguages?: string[];
 }
 
@@ -95,11 +103,7 @@ export interface ArticleType {
   tags: string[];
   published: string;
   copyright: Copyright;
-  metaImage: {
-    url: string;
-    alt: string;
-    language: string;
-  };
+  metaImage: MetaImage;
   oldNdlaUrl: string;
   revision: number;
   updated: string;


### PR DESCRIPTION
Lenkene som skulle peke til Learningpaths pekte til LearningResources og articles. Nu er det fikset.

Dobbeltsjekk her: `/subjectpage/urn:subject:34/14/edit/nb`

Under `Artikler`, elementet "Overslagsregning og hoderegning" er en Learningpath, sjekk at lenken sender til siden: https://stier.test.ndla.no/learningpaths/398/step/2978

og at andre lenker linker til artikler ellers.