### PR TITLE
Only paste text if inside component

### DIFF
--- a/src/components/SlateEditor/plugins/pastehandler/index.js
+++ b/src/components/SlateEditor/plugins/pastehandler/index.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { getEventTransfer } from 'slate-react';
+
+function pasteHandler() {
+  return {
+    schema: {},
+    onPaste(event, editor, next) {
+      const transfer = getEventTransfer(event);
+      if (transfer.type === 'fragment') {
+        // Dersom path < 4 la slate håndtere innliming.
+        if (editor.value.selection.focus.path.size < 4) return next();
+        // Dersom du limer inn på et lavere, er du inne i en komponent og treng berre teksten.
+        return editor.insertText(transfer.text);
+      }
+      return next();
+    },
+  };
+}
+
+export default pasteHandler;

--- a/src/containers/LearningResourcePage/components/LearningResourceContent.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceContent.jsx
@@ -48,6 +48,7 @@ import blockquotePlugin from '../../../components/SlateEditor/plugins/blockquote
 import paragraphPlugin from '../../../components/SlateEditor/plugins/paragraph';
 import mathmlPlugin from '../../../components/SlateEditor/plugins/mathml';
 import dndPlugin from '../../../components/SlateEditor/plugins/DND';
+import pasteHandler from '../../../components/SlateEditor/plugins/pastehandler';
 import { TYPE as footnoteType } from '../../../components/SlateEditor/plugins/footnote';
 import {
   editListPlugin,
@@ -122,6 +123,7 @@ class LearningResourceContent extends Component {
         },
       }),
       dndPlugin,
+      pasteHandler(),
       toolbarPlugin(),
     ];
   }


### PR DESCRIPTION
Om du kopierer tekst fra tekst i ramme og limer inn i samme ramma får du ei ny ramme inni den gamle. For å unngå dette sjekker denne pastehandleren om kor lang path det er fram til plassen der markøren står. Dersom det er mindre enn 4 er du på toppnivået (document > section > markør) og kan la slate håndtere innliminga. Men dersom pathen er lengre er du inni en komponent og då limes berre inn teksten du har kopiert.

PR kan testes ved å kopiere tekst fra kor som helst i dokumentet og lime inn i enten tekst i ramme eller ekspanderboks. Men du skal også kunne kopiere en heil artikkel og lime innholdet inn i en ny artikkel og få med alt av formatering.