### PR TITLE
Unwrap if node if section within section.

### DIFF
--- a/src/components/SlateEditor/editorSchema.jsx
+++ b/src/components/SlateEditor/editorSchema.jsx
@@ -25,6 +25,7 @@ export const schema = {
     section: {
       first: { type: 'paragraph' },
       last: { type: 'paragraph' },
+      parent: { object: 'document' },
       nodes: [
         {
           match: [
@@ -81,6 +82,16 @@ export const schema = {
           case 'child_type_invalid':
             editor.withoutSaving(() => {
               editor.wrapBlockByKey(error.child.key, 'paragraph');
+            });
+            break;
+          case 'parent_type_invalid':
+            editor.withoutSaving(() => {
+              editor.unwrapBlockByKey(error.node.key, error.node.type);
+            });
+            break;
+          case 'parent_object_invalid':
+            editor.withoutSaving(() => {
+              editor.unwrapBlockByKey(error.node.key, error.node.type);
             });
             break;
           default:


### PR DESCRIPTION
Oppdaga en uheldig konsekvens av pastehandler som lar deg paste inn med formatering. Det var et hull i reglene som gjorde at section fra kopiert dokument kunne havne inni en p eller en section. Det forhindres her ved at det sjekkes at en section har en document som parent, og om den ikkje har det så unwrappes sectionen og problemet forsvinner.

Test: 
I ed-test kan du kopiere tekst fra en boks og lime inn i en tom p på rotnivå. Då får du en ny boks med kopiert tekst, men om du ser i html-editoren så ser du at det har havna en section rundt boksen. Lagreknappen blir heller ikkje grønn etter lagring.
I pr skal lagreknappen bli grønn og section skal bli borte fra html-koden.