### PR TITLE
Unwrap math with text content in stead of 'm'

### DIFF
--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -96,6 +96,7 @@ export const createDetails = () => {
               { type: 'letter-list' },
               { type: 'numbered-list' },
               { type: 'quote' },
+              { type: 'table' },
             ],
           },
         ],

--- a/src/util/slateHelpers.js
+++ b/src/util/slateHelpers.js
@@ -282,7 +282,7 @@ export const mathRules = {
       nodes: [
         {
           object: 'text',
-          text: 'm',
+          text: el.textContent,
           marks: [],
         },
       ],


### PR DESCRIPTION
Eg har irritert meg over at dersom du fjerner en mateformel så settes det inn m i steden for formelen. Denne endringa setter inn tekstverdien til html-elementet, så dersom formelen var 2+2=4 så er det faktisk det som settes inn i teksten. 