### PR TITLE
#2295 add data-type to concept

### DIFF
--- a/src/components/SlateEditor/plugins/concept/EditSlateConcept.jsx
+++ b/src/components/SlateEditor/plugins/concept/EditSlateConcept.jsx
@@ -20,6 +20,7 @@ const getConceptDataAttributes = ({ id, title: { title } }) => ({
     'content-id': id,
     'link-text': title,
     resource: 'concept',
+    type: 'inline',
   },
 });
 


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2295 
Legger til data-type inline til nye forklaringer som legges til i editoren.

Er det mer enn dette som skal til? Var så lite kode.
Dette er da at den defaulter til 'inline', så blir det egen pr på å velge type (inline eller expanded/ plakat). 