### PR TITLE
Add possibility to render code and embed in boxes

### DIFF
--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -97,6 +97,8 @@ export const createDetails = () => {
               { type: 'numbered-list' },
               { type: 'quote' },
               { type: 'table' },
+              { type: 'embed' },
+              { type: 'code-block' },
             ],
           },
         ],

--- a/src/components/SlateEditor/utils/schemaHelpers.js
+++ b/src/components/SlateEditor/utils/schemaHelpers.js
@@ -26,6 +26,8 @@ export const textBlockValidationRules = {
         { type: 'letter-list' },
         { type: 'numbered-list' },
         { type: 'quote' },
+        { type: 'table' },
+        { type: 'embed' },
       ],
     },
   ],

--- a/src/components/SlateEditor/utils/schemaHelpers.js
+++ b/src/components/SlateEditor/utils/schemaHelpers.js
@@ -28,6 +28,7 @@ export const textBlockValidationRules = {
         { type: 'quote' },
         { type: 'table' },
         { type: 'embed' },
+        { type: 'code-block' },
       ],
     },
   ],


### PR DESCRIPTION
Vi må støtte å rendre embeds og kode inni bokser.  Dette fordi dei med html-tilgang kopierer bilder og slikt inn i boksene. Det er mange bokser som har dette i seg allerde.