### PR TITLE
Using he for encoding and decoding tags

### DIFF
--- a/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { Block, Document, Inline, Node } from 'slate';
+import he from 'he';
 
 import Button from '@ndla/button';
 import { Cross } from '@ndla/icons/action';
@@ -38,7 +39,7 @@ const getInfoFromNode = (node: Node) => {
 
   return {
     model: {
-      code,
+      code: he.decode(code),
       title: codeBlock.title || getTitleFromFormat(format),
       format,
     },
@@ -56,8 +57,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ attributes, editor, node }) => {
   };
 
   const handleSave = (codeBlock: CodeBlockType) => {
+    const { code } = codeBlock;
     const properties = {
-      data: { ...getSchemaEmbed(node), 'code-block': codeBlock },
+      data: {
+        ...getSchemaEmbed(node),
+        'code-block': { ...codeBlock, code: he.encode(code) },
+      },
     };
     setEditMode(false);
     setFirstEdit(false);


### PR DESCRIPTION
Lagring av html i kodeblokk funker ikkje fordi validator i draft-api plukker det opp som ugyldig kode. Vi må encode og decode det som lagres for at dette skal fungere. Lagra html blir litt rar med masse `&lt;` og slikt men det må nesten bli slik.

Test: 
Lag en kodeblokk og legg inn html eller faktisk berre en <. Det skal fungere å lagre artikkelen,