### PR TITLE
Fixing superslow math loading

### DIFF
--- a/src/components/SlateEditor/RichBlockTextEditor.jsx
+++ b/src/components/SlateEditor/RichBlockTextEditor.jsx
@@ -27,6 +27,10 @@ class RichBlockTextEditor extends PureComponent {
     if (window.MathJax) window.MathJax.typeset();
   }
 
+  componentDidUpdate() {
+    if (window.MathJax) window.MathJax.typeset();
+  }
+
   onChange(evt, index) {
     const { onChange, name, value } = this.props;
     const newValue = [].concat(value);

--- a/src/components/SlateEditor/plugins/mathml/EditMath.js
+++ b/src/components/SlateEditor/plugins/mathml/EditMath.js
@@ -32,7 +32,6 @@ class EditMath extends Component {
   }
 
   componentDidMount() {
-    if (window.MathJax) window.MathJax.typeset();
     // force set state to trigger rerender.
     this.setState({});
     const { renderMathML } = this.state;
@@ -52,10 +51,6 @@ class EditMath extends Component {
     script.onload = callback;
 
     document.head.appendChild(script);
-  }
-
-  componentDidUpdate() {
-    if (window.MathJax) window.MathJax.typeset();
   }
 
   handleExit() {

--- a/src/components/SlateEditor/plugins/mathml/MathML.js
+++ b/src/components/SlateEditor/plugins/mathml/MathML.js
@@ -16,14 +16,9 @@ class MathML extends Component {
     this.state = { reRender: false };
   }
 
-  async componentDidMount(prevProps) {
-    if (window.MathJax) window.MathJax.typeset();
-  }
-
   async componentDidUpdate(prevProps) {
     const { model } = this.props;
     const { innerHTML } = model;
-    if (window.MathJax) window.MathJax.typeset();
     if (prevProps.model.innerHTML !== innerHTML) {
       // Note: a small delay before a 're-render" is required in order to
       // get the MathJax script to render correctly after editing the MathML


### PR DESCRIPTION
Vi la til for mange mathjax-loadings og det gjør sida supertreig.

Denne artikkelen lar seg ikkje åpne https://ed.test.ndla.no/subject-matter/learning-resource/22679/edit men samme i pr-installasjon skal funke.
