### PR TITLE
Forsøker å fikse matterendering uten at det går alt for masse på bekostning av ytelse.

### DIFF
--- a/src/components/PreviewDraft/PreviewDraft.tsx
+++ b/src/components/PreviewDraft/PreviewDraft.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 class PreviewDraft extends Component<Props & tType, {}> {
   componentDidMount() {
-    if (window.MathJax) window.MathJax.typeset();
+    if (window.MathJax) window.MathJax.typesetPromise();
   }
 
   render() {

--- a/src/components/SlateEditor/plugins/mathml/EditMathModal.js
+++ b/src/components/SlateEditor/plugins/mathml/EditMathModal.js
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { injectT } from '@ndla/i18n';
@@ -47,65 +47,73 @@ const EditMathModal = ({
   renderMathML,
   previewMath,
   t,
-}) => (
-  <Modal
-    narrow
-    controllable
-    isOpen
-    size="large"
-    backgroundColor="white"
-    onClose={handleExit}
-    minHeight="90vh">
-    {onCloseModal => (
-      <>
-        <ModalHeader>
-          <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
-        </ModalHeader>
-        <ModalBody>
-          <h1>{t('mathEditor.editMath')}</h1>
-          <hr />
-          <StyledMathEditorWrapper id="mathEditorContainer" />
-          <StyledButtonWrapper>
-            <Button outline css={buttonStyle} onClick={previewMath}>
-              {t('form.preview.button')}
-            </Button>
-            <Button outline css={buttonStyle} onClick={handleSave}>
-              {t('form.save')}
-            </Button>
-            <Button outline css={buttonStyle} onClick={onCloseModal}>
-              {t('form.abort')}
-            </Button>
-            <Button outline css={buttonStyle} onClick={handleRemove}>
-              {t('form.remove')}
-            </Button>
-          </StyledButtonWrapper>
-          <h3>{t('mathEditor.preview')}</h3>
-          <hr />
-          <StyledMathPreviewWrapper
-            dangerouslySetInnerHTML={{
-              __html: renderMathML,
-            }}
-          />
-          <AlertModal
-            show={openDiscardModal}
-            text={t('mathEditor.continue')}
-            actions={[
-              {
-                text: t('form.abort'),
-                onClick: handleCancelDiscard,
-              },
-              {
-                text: t('alertModal.continue'),
-                onClick: handleContinue,
-              },
-            ]}
-            onCancel={handleCancelDiscard}
-          />
-        </ModalBody>
-      </>
-    )}
-  </Modal>
-);
+}) => {
+  useEffect(() => {
+    if (window.MathJax) window.MathJax.typesetPromise();
+  }, [renderMathML]);
+  return (
+    <Modal
+      narrow
+      controllable
+      isOpen
+      size="large"
+      backgroundColor="white"
+      onClose={handleExit}
+      minHeight="90vh">
+      {onCloseModal => (
+        <>
+          <ModalHeader>
+            <ModalCloseButton
+              title={t('dialog.close')}
+              onClick={onCloseModal}
+            />
+          </ModalHeader>
+          <ModalBody>
+            <h1>{t('mathEditor.editMath')}</h1>
+            <hr />
+            <StyledMathEditorWrapper id="mathEditorContainer" />
+            <StyledButtonWrapper>
+              <Button outline css={buttonStyle} onClick={previewMath}>
+                {t('form.preview.button')}
+              </Button>
+              <Button outline css={buttonStyle} onClick={handleSave}>
+                {t('form.save')}
+              </Button>
+              <Button outline css={buttonStyle} onClick={onCloseModal}>
+                {t('form.abort')}
+              </Button>
+              <Button outline css={buttonStyle} onClick={handleRemove}>
+                {t('form.remove')}
+              </Button>
+            </StyledButtonWrapper>
+            <h3>{t('mathEditor.preview')}</h3>
+            <hr />
+            <StyledMathPreviewWrapper
+              dangerouslySetInnerHTML={{
+                __html: renderMathML,
+              }}
+            />
+            <AlertModal
+              show={openDiscardModal}
+              text={t('mathEditor.continue')}
+              actions={[
+                {
+                  text: t('form.abort'),
+                  onClick: handleCancelDiscard,
+                },
+                {
+                  text: t('alertModal.continue'),
+                  onClick: handleContinue,
+                },
+              ]}
+              onCancel={handleCancelDiscard}
+            />
+          </ModalBody>
+        </>
+      )}
+    </Modal>
+  );
+};
 
 EditMathModal.propTypes = {
   handleExit: PropTypes.func.isRequired,

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.js
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.js
@@ -59,11 +59,11 @@ class MathEditor extends Component {
 
   toggleMenu() {
     this.setState(prevState => ({ showMenu: !prevState.showMenu }));
+    if (window.MathJax) window.MathJax.typesetPromise();
   }
 
   toggleEdit() {
     this.setState(prevState => ({ editMode: !prevState.editMode }));
-    if (window.MathJax) window.MathJax.typeset();
   }
 
   onExit = () => {
@@ -102,12 +102,7 @@ class MathEditor extends Component {
           tabIndex={0}
           onKeyPress={this.toggleMenu}
           onClick={this.toggleMenu}>
-          <MathML
-            mathRef={this.mathMLRef}
-            node={node}
-            model={model}
-            {...this.props}
-          />
+          <MathML node={node} model={model} {...this.props} />
           <Portal isOpened={showMenu}>
             <BlockMenu
               top={top}


### PR DESCRIPTION
Gjør matte like raskt å laste første gong. Krever at det klikkes på en matteformel for at den skal rendres etter endring.

Test:
Matte rendres fullt ved åpning av artikkel.
Ved redigering av matte må du klikke på Forhåndsvis-knapp for å rendre forhåndsvisninga.
Etter å ha lagra matteendringer må du klikke på formelen for å rendre den på nytt.
Etter å ha lagra artikkelen må du klikke på en tilfeldig matteformel for å rendre all matte i sida på nytt.
