### PR TITLE
Serialize line to paragraph. Enable br in code.

### DIFF
--- a/src/util/diffHTML.js
+++ b/src/util/diffHTML.js
@@ -15,7 +15,7 @@ const allowedConversions = [
   ['&#x27;', "'"],
   ['&quot;', '"'],
 ];
-const brWrappers = ['strong', 'em', 'u'];
+const brWrappers = ['strong', 'em', 'u', 'code'];
 
 /**
  * Get current, next and previous diff values. Return undefined if one of them is undefiend

--- a/src/util/slateHelpers.js
+++ b/src/util/slateHelpers.js
@@ -216,7 +216,11 @@ export const paragraphRule = {
   },
   serialize(slateObject, children) {
     if (slateObject.object !== 'block') return;
-    if (slateObject.type !== 'paragraph' && slateObject.type !== 'list-text')
+    if (
+      slateObject.type !== 'paragraph' &&
+      slateObject.type !== 'list-text' &&
+      slateObject.type !== 'line'
+    )
       return;
     if (slateObject.type === 'list-text') {
       return <ListText>{children}</ListText>;


### PR DESCRIPTION
Basert på kommentar i ndla-slack. Det fungerer ikkje å kopiere tekst fra ingress og lime inn i artikkel. Det er fordi ingress er en slate-editor uten skjema og derfor håndteres linjer som block av type line. Denne håndterer vi ikkje i vårt skjema, men vi kan serialisere det til p-tags.

I tillegg er det lov å ha br-tags inni code-tags så enabler dette. Har sett eksempel på artikler i prod der knappen ikkje blir blå fordi dette ikkje godtas i editoren.

Test: Rediger en artikkel og kopier inn tekst fra ingress inn i artikkelen. Dette skal gå bra og ikkje feile. Sammenlign gjerne med test.