### PR TITLE
Only show link for articles

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.jsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.jsx
@@ -81,13 +81,17 @@ const HeaderStatusInformation = ({
     </Tooltip>
   );
 
-  const publishedIcon = published && (
+  const publishedIcon = (
+    <Tooltip tooltip={t('form.workflow.published')}>
+      <StyledCheckIcon title={t('form.status.published')} />
+    </Tooltip>
+  );
+
+  const publishedIconLink = (
     <StyledLink
       target="_blank"
       to={`${config.editorialFrontendDomain}${taxonomyPaths?.[0]}`}>
-      <Tooltip tooltip={t('form.workflow.published')}>
-        <StyledCheckIcon title={t('form.status.published')} />
-      </Tooltip>
+      {publishedIcon}
     </StyledLink>
   );
 
@@ -105,7 +109,9 @@ const HeaderStatusInformation = ({
       <StyledStatusWrapper>
         {splitter}
         <StyledStatus>{t('form.status.new_language')}</StyledStatus>
-        {publishedIcon}
+        {published && taxonomyPaths?.length > 0
+          ? publishedIconLink
+          : publishedIcon}
         {multipleTaxonomyIcon}
       </StyledStatusWrapper>
     );
@@ -119,7 +125,9 @@ const HeaderStatusInformation = ({
             ? t('form.status.new_language')
             : statusText || t('form.status.new')}
         </StyledStatus>
-        {publishedIcon}
+        {published && taxonomyPaths?.length > 0
+          ? publishedIconLink
+          : publishedIcon}
         {multipleTaxonomyIcon}
         {helperIcon}
       </StyledStatusWrapper>

--- a/src/components/HeaderWithLanguage/HeaderWithLanguage.jsx
+++ b/src/components/HeaderWithLanguage/HeaderWithLanguage.jsx
@@ -51,8 +51,11 @@ const HeaderWithLanguage = ({
   const published =
     status?.current === 'PUBLISHED' || status?.other?.includes('PUBLISHED');
   const multiType = articleType ? articleType : type;
+  const isArticle = multiType === 'standard' || multiType === 'topic-article';
 
-  const taxonomyPaths = getTaxonomyPathsFromTaxonomy(content?.taxonomy, id);
+  const taxonomyPaths = isArticle
+    ? getTaxonomyPathsFromTaxonomy(content?.taxonomy, id)
+    : [];
 
   return (
     <header>


### PR DESCRIPTION
Viser berre lenke til ndla.no for artikler og ikkje for forklaringer, som er det som skjer no.

Test:
Publiserte forklaringer skal vise grønt ikon men det skal ikkje være klikkbart.