### PR TITLE
Ignore parameters in pasted ndla-url

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.jsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.jsx
@@ -90,7 +90,7 @@ const HeaderStatusInformation = ({
   const publishedIconLink = (
     <StyledLink
       target="_blank"
-      to={`${config.editorialFrontendDomain}${taxonomyPaths?.[0]}`}>
+      to={`${config.ndlaFrontendDomain}${taxonomyPaths?.[0]}`}>
       {publishedIcon}
     </StyledLink>
   );

--- a/src/components/SlateEditor/plugins/link/EditLink.jsx
+++ b/src/components/SlateEditor/plugins/link/EditLink.jsx
@@ -54,25 +54,27 @@ export const isNDLAEdPathUrl = url =>
 export const isPlainId = url => /^\d+/.test(url);
 
 const getIdAndTypeFromUrl = async href => {
-  if (isNDLAArticleUrl(href)) {
-    const splittedHref = href.split('/');
+  // Removes search queries before split
+  const baseHref = href.split(/\?/)[0];
+  if (isNDLAArticleUrl(baseHref)) {
+    const splittedHref = baseHref.split('/');
     return {
       resourceId: splittedHref.pop(),
       resourceType: 'article',
     };
-  } else if (isNDLALearningPathUrl(href)) {
-    const splittedHref = href.split('learningpaths/');
+  } else if (isNDLALearningPathUrl(baseHref)) {
+    const splittedHref = baseHref.split('learningpaths/');
     return {
       resourceId: splittedHref[1],
       resourceType: 'learningpath',
     };
-  } else if (isPlainId(href)) {
+  } else if (isPlainId(baseHref)) {
     return {
-      resourceId: href,
+      resourceId: baseHref,
       resourceType: 'article',
     };
-  } else if (isNDLATaxonomyUrl(href)) {
-    const taxonomyPath = href.split('subjects').pop();
+  } else if (isNDLATaxonomyUrl(baseHref)) {
+    const taxonomyPath = baseHref.split('subjects').pop();
     const resolvedTaxonomy = await resolveUrls(taxonomyPath);
 
     const contentUriSplit =
@@ -82,8 +84,8 @@ const getIdAndTypeFromUrl = async href => {
     const resourceType = contentUriSplit.pop();
 
     return { resourceId, resourceType };
-  } else if (isNDLAEdPathUrl(href)) {
-    const splittedHref = href.split('/');
+  } else if (isNDLAEdPathUrl(baseHref)) {
+    const splittedHref = baseHref.split('/');
     return {
       resourceId: splittedHref[5],
       resourceType: 'article',

--- a/src/components/SlateEditor/plugins/link/Link.jsx
+++ b/src/components/SlateEditor/plugins/link/Link.jsx
@@ -14,8 +14,11 @@ import { injectT } from '@ndla/i18n';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { colors, spacing } from '@ndla/core';
-import { queryContent } from '../../../../modules/taxonomy/resources';
 import config from '../../../../config';
+import {
+  toEditArticle,
+  toLearningpathFull,
+} from '../../../../util/routeHelpers';
 import { Portal } from '../../../Portal';
 import isNodeInCurrentSelection from '../../utils/isNodeInCurrentSelection';
 import { EditorShape } from '../../../../shapes';
@@ -38,21 +41,10 @@ const StyledLinkMenu = styled('span')`
 `;
 
 const fetchResourcePath = async (data, language, contentType) => {
-  const fallbackType =
-    contentType === 'learningpath' ? 'learningpaths' : 'article';
-  const fallbackPath = `${language}/${fallbackType}/${data['content-id']}`;
-  try {
-    const resource = await queryContent(
-      data['content-id'],
-      language,
-      contentType,
-    );
-    return resource.path
-      ? `${language}/subjects${resource.path}`
-      : fallbackPath;
-  } catch (error) {
-    return fallbackPath;
-  }
+  const id = data['content-id'];
+  return contentType === 'learningpath'
+    ? toLearningpathFull(id, language)
+    : `${config.editorialFrontendDomain}${toEditArticle(id, contentType)}`;
 };
 
 function hasHrefOrContentId(node) {
@@ -94,11 +86,7 @@ const Link = props => {
 
     const href =
       data.resource === 'content-link'
-        ? `${config.editorialFrontendDomain}/${await fetchResourcePath(
-            data,
-            language,
-            contentType,
-          )}`
+        ? `${await fetchResourcePath(data, language, contentType)}`
         : data.href;
 
     const checkbox =

--- a/src/components/SlateEditor/plugins/link/LinkForm.jsx
+++ b/src/components/SlateEditor/plugins/link/LinkForm.jsx
@@ -14,6 +14,7 @@ import Button from '@ndla/button';
 import { injectT } from '@ndla/i18n';
 import { css } from '@emotion/core';
 import Field from '../../../Field';
+import config from '../../../../config';
 import { LinkShape } from '../../../../shapes';
 import validateFormik from '../../../formikValidationSchema';
 import FormikField from '../../../FormikField';
@@ -63,7 +64,13 @@ class LinkForm extends Component {
               type="text"
               label={t('form.content.link.text')}
             />
-            <FormikField name="href" label={t('form.content.link.href')} />
+            <FormikField
+              name="href"
+              description={`${t('form.content.link.description')} ${
+                config.ndlaFrontendDomain
+              }`}
+              label={t('form.content.link.href')}
+            />
             <FormikCheckbox
               name="checkbox"
               label={t('form.content.link.newTab')}

--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,7 @@ export const getNdlaApiUrl = env => {
   }
 };
 
-const editorialFrontendDomain = () => {
+const ndlaFrontendDomain = () => {
   switch (ndlaEnvironment) {
     case 'local':
       return 'http://localhost:30017';
@@ -33,6 +33,17 @@ const editorialFrontendDomain = () => {
       return 'https://ndla.no';
     default:
       return `https://${ndlaEnvironment}.ndla.no`;
+  }
+};
+
+const editorialFrontendDomain = () => {
+  switch (ndlaEnvironment) {
+    case 'local':
+      return 'http://localhost:30019';
+    case 'prod':
+      return 'https://ed.ndla.no';
+    default:
+      return `https://ed.${ndlaEnvironment}.ndla.no`;
   }
 };
 
@@ -110,6 +121,7 @@ const config = {
     'NDLA_API_URL',
     getNdlaApiUrl(ndlaEnvironment),
   ),
+  ndlaFrontendDomain: ndlaFrontendDomain(),
   editorialFrontendDomain: editorialFrontendDomain(),
   learningpathFrontendDomain: learningpathFrontendDomain(),
   ndlaPersonalClientId: getEnvironmentVariabel('NDLA_PERSONAL_CLIENT_ID', ''),

--- a/src/containers/StructurePage/resourceComponents/ResourceItemLink.jsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceItemLink.jsx
@@ -11,9 +11,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { colors } from '@ndla/core';
-import config from '../../../config';
 import { classes } from './ResourceGroup';
-import { toEditArticle } from '../../../util/routeHelpers';
+import { toEditArticle, toLearningpathFull } from '../../../util/routeHelpers';
 
 const StyledH1 = styled.h1`
   font-style: ${props => !props.isVisible && 'italic'};
@@ -33,7 +32,7 @@ const ResourceItemLink = ({
   if (linkTo) {
     if (contentType === 'learning-path') {
       const linkProps = {
-        href: `${config.learningpathFrontendDomain}/${locale}/learningpaths/${linkTo}/first-step`,
+        href: toLearningpathFull(linkTo, locale),
         target: '_blank',
         rel: 'noopener noreferrer',
       };

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -721,6 +721,8 @@ const phrases = {
         unSupported: 'Content in link is not supported',
         newUrlResource: 'New resource',
         changeUrlResource: 'Edit resource: {type}',
+        description:
+          'Links to ndla-resources is handled by the system and is displayed correct on',
       },
       footnote: {
         title: 'Title',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -731,6 +731,8 @@ const phrases = {
         unSupported: 'Innholdstypen i lenken er ikke støttet',
         newUrlResource: 'Ny ressurs',
         changeUrlResource: 'Rediger ressurs: {type}',
+        description:
+          'Lenker til ndla-ressurser spesialhåndteres av systemet og vises korrekt på',
       },
       footnote: {
         title: 'Tittel',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -740,6 +740,8 @@ const phrases = {
         unSupported: 'Innhaldstypen i lenka er ikkje støtta',
         newUrlResource: 'Ny ressurs',
         changeUrlResource: 'Rediger ressurs: {type}',
+        description:
+          'Lenker til ndla-ressursar spesialhandterast av systemet og visast korrekt på',
       },
       footnote: {
         title: 'Tittel',

--- a/src/util/resourceHelpers.js
+++ b/src/util/resourceHelpers.js
@@ -7,8 +7,7 @@
  */
 
 import { constants } from '@ndla/ui';
-import config from '../config';
-import { toEditArticle } from './routeHelpers';
+import { toEditArticle, toLearningpathFull } from './routeHelpers';
 
 import {
   RESOURCE_TYPE_LEARNING_PATH,
@@ -67,7 +66,7 @@ const isLearningPathResourceType = contentType =>
 export const resourceToLinkProps = (content, contentType, locale) => {
   if (isLearningPathResourceType(contentType)) {
     return {
-      href: `${config.learningpathFrontendDomain}/${locale}/learningpaths/${content.id}/first-step`,
+      href: toLearningpathFull(content.id, locale),
       target: '_blank',
       rel: 'noopener noreferrer',
     };
@@ -75,14 +74,10 @@ export const resourceToLinkProps = (content, contentType, locale) => {
   return {
     to: toEditArticle(
       content.id,
-      content.contexts &&
-        content.contexts.length > 0 &&
-        content.contexts[0].learningResourceType
-        ? content.contexts[0].learningResourceType
-        : 'standard',
-      content.supportedLanguages.includes(locale)
+      content?.contexts?.[0]?.learningResourceType || 'standard',
+      content?.supportedLanguages?.includes(locale)
         ? locale
-        : content.supportedLanguages[0],
+        : content?.supportedLanguages?.[0],
     ),
   };
 };

--- a/src/util/routeHelpers.js
+++ b/src/util/routeHelpers.js
@@ -1,4 +1,5 @@
 import queryString from 'query-string';
+import config from '../config';
 
 const articleTypes = {
   'topic-article': 'topic-article',
@@ -115,6 +116,10 @@ export function getResourceIdFromPath(path) {
   if (learningPath && learningPath[1]) return learningPath[1];
   const resource = path.match(/(resource:[:\da-fA-F-]+)\/?$/);
   return resource ? `urn:${resource[1]}` : '';
+}
+
+export function toLearningpathFull(id, locale) {
+  return `${config.learningpathFrontendDomain}/${locale}/learningpaths/${id}/first-step`;
 }
 
 export const removeLastItemFromUrl = url =>


### PR DESCRIPTION
I dag går det ikkje an å lime inn lenker til ndla.no artikler med ?filter= i urlen.

Test; 
Sett inn lenke i artikkel med adressa https://test.ndla.no/subjects/subject:33/topic:2:1:165344/resource:1:124037?filters=urn:filter:b100450f-c0bd-4b73-b924-44ab6baf4777