### PR TITLE
Do not archive if article is used in multiple topics

### DIFF
--- a/src/containers/StructurePage/folderComponents/menuOptions/DeleteTopic.jsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/DeleteTopic.jsx
@@ -14,11 +14,12 @@ import RoundIcon from '../../../../components/RoundIcon';
 import handleError from '../../../../util/handleError';
 import AlertModal from '../../../../components/AlertModal';
 import {
-  fetchTopic,
-  deleteTopic,
-  fetchTopicConnections,
-  deleteTopicConnection,
   deleteSubTopicConnection,
+  deleteTopic,
+  deleteTopicConnection,
+  fetchTopic,
+  fetchTopicConnections,
+  queryTopics,
 } from '../../../../modules/taxonomy';
 import Spinner from '../../../../components/Spinner';
 import Overlay from '../../../../components/Overlay';
@@ -81,7 +82,10 @@ class DeleteTopic extends PureComponent {
   async setTopicArticleArchived(topicId, locale) {
     let article = await fetchTopic(topicId, locale);
     let articleId = article.contentUri.split(':')[2];
-    await updateStatusDraft(articleId, ARCHIVED);
+    const topics = await queryTopics(articleId, locale);
+    if (topics.length === 1) {
+      await updateStatusDraft(articleId, ARCHIVED);
+    }
   }
 
   render() {


### PR DESCRIPTION
NDLANO/Issues#2361

Vi har arkivert emneartikkel ved sletting av emne, men det går ikkje dersom artikkelen er brukt i fleire emner.

Test:
Emneartikkel som kun er brukt i et emne skal arkiveres ved sletting av emnet i taksonomi. Emneartikkel som er brukt i fleire emner skal ikkje arkiveres ved sletting av emnet.