### PR TITLE
allow scroll on WelcomePage

### DIFF
--- a/src/containers/PreviewDraftPage/PreviewDraftPage.jsx
+++ b/src/containers/PreviewDraftPage/PreviewDraftPage.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { Hero, OneColumn } from '@ndla/ui';
+import { css } from '@emotion/core';
 import * as draftApi from '../../modules/draft/draftApi';
 import * as articleApi from '../../modules/article/articleApi';
 import PreviewDraft from '../../components/PreviewDraft/PreviewDraft';
@@ -62,19 +63,24 @@ const PreviewDraftPage = ({
 
   return (
     <Fragment>
-      <Hero contentType={contentType}>
-        <LanguageSelector supportedLanguages={draft.supportedLanguages} />
-      </Hero>
-      <HelmetWithTracker
-        title={`${draft.title} ${t('htmlTitles.titleTemplate')}`}
-      />
-      <OneColumn>
-        <PreviewDraft
-          article={draft}
-          resource={resource}
-          contentType={contentType}
+      <div
+        css={css`
+          overflow: auto;
+        `}>
+        <Hero contentType={contentType}>
+          <LanguageSelector supportedLanguages={draft.supportedLanguages} />
+        </Hero>
+        <HelmetWithTracker
+          title={`${draft.title} ${t('htmlTitles.titleTemplate')}`}
         />
-      </OneColumn>
+        <OneColumn>
+          <PreviewDraft
+            article={draft}
+            resource={resource}
+            contentType={contentType}
+          />
+        </OneColumn>
+      </div>
     </Fragment>
   );
 };

--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -29,6 +29,7 @@ const ContentWrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   height: calc(100vh - ${NAVIGATION_HEADER_MARGIN});
+  overflow: auto;
 `;
 
 export const classes = new BEMHelper({


### PR DESCRIPTION
jeg har irritert meg over at jeg ikke får scrollet på WelcomePage/ hjem-siden på ed, spesielt om jeg har åpen konsollen. 
Så her er et forlag til å legge til  `overflow: auto;` som gjør at vi kan scrolle på denne siden nå som den har litt content. 

pluss:
> Kan du fikse det samme på PreviewDraft? Feks på https://ed.test.ndla.no/preview/22663/nb så ser du ikkje alt om du ekspanderer forklaringa under hallo.
