### PR TITLE
2374 image editor size consistency

### DIFF
--- a/src/components/SlateEditor/plugins/embed/EditImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditImage.tsx
@@ -99,6 +99,9 @@ const EditImage: React.FC<Props & tType> = ({
   const onUpdatedImageSettings = (
     transformedData: NonNullable<StateProps['imageUpdates']>,
   ) => {
+    if (transformedData.align === 'center') {
+      transformedData.size = 'fullwidth';
+    }
     setState({
       ...state,
       imageUpdates: {

--- a/src/components/SlateEditor/plugins/embed/EditImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditImage.tsx
@@ -99,9 +99,6 @@ const EditImage: React.FC<Props & tType> = ({
   const onUpdatedImageSettings = (
     transformedData: NonNullable<StateProps['imageUpdates']>,
   ) => {
-    if (transformedData.align === 'center') {
-      transformedData.size = 'fullwidth';
-    }
     setState({
       ...state,
       imageUpdates: {

--- a/src/components/SlateEditor/plugins/embed/SlateImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.tsx
@@ -55,7 +55,7 @@ const SlateImage: React.FC<Props & tType> = ({
   const showCopyOutline = isSelectedForCopy && (!editMode || !active);
 
   const constructFigureClassName = () => {
-    const isFullWidth = embed.size === 'fullwidth';
+    const isFullWidth = embed.size === 'fullwidth' && embed.align === 'center';
     const size = ['small', 'xsmall'].includes(embed.size)
       ? `-${embed.size}`
       : '';

--- a/src/components/SlateEditor/plugins/embed/SlateImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.tsx
@@ -55,7 +55,7 @@ const SlateImage: React.FC<Props & tType> = ({
   const showCopyOutline = isSelectedForCopy && (!editMode || !active);
 
   const constructFigureClassName = () => {
-    const isFullWidth = embed.size === 'fullwidth' && embed.align === 'center';
+    const isFullWidth = embed.align === 'center';
     const size = ['small', 'xsmall'].includes(embed.size)
       ? `-${embed.size}`
       : '';

--- a/src/containers/ImageEditor/ImageAlignButton.jsx
+++ b/src/containers/ImageEditor/ImageAlignButton.jsx
@@ -21,9 +21,6 @@ const icon = {
 const ImageAlignButton = ({ currentAlign, alignType, onFieldChange, t }) => {
   const onChange = evt => {
     onFieldChange(evt, 'align', alignType);
-    if (alignType === 'center') {
-      onFieldChange(evt, 'size', 'fullwidth');
-    }
   };
 
   return (

--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -41,7 +41,7 @@ const StyledImageEditorEditMode = styled('div')`
 
 const alignments = ['left', 'center', 'right'];
 
-const sizes = ['xsmall', 'small', 'medium', 'fullwidth'];
+const sizes = ['xsmall', 'small', 'medium'];
 
 const defaultData = {
   focalPoint: {


### PR DESCRIPTION
Fixes NDLANO/Issues#2374

Endringene av bildestørrelse i editor skal nå gjenspeile det som vises i forhåndsvisning. 

Det dukker opp noen feilmeldinger i article-converter og det ser ut som størrelsesnavnene som brukes her er forskjellige og behandles på en annen måte.  Slik det er nå fører dette til at både "medium" og "stort" produserer et bilde med størrelse "medium".