### PR TITLE
Always show list and subject

### DIFF
--- a/src/components/PreviewConcept/PreviewConcept.tsx
+++ b/src/components/PreviewConcept/PreviewConcept.tsx
@@ -125,25 +125,21 @@ const PreviewConcept: FC<Props & tType> = ({ concept, t }) => {
             />
           </NotionDialogText>
         </NotionDialogContent>
-        {concept.tags?.length && (
-          <TagWrapper>
-            <div className="tags">
-              <span>{t('form.categories.label')}:</span>
-              {concept.tags.map(tag => (
-                <span className="tag" key={`key-${tag}`}>
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </TagWrapper>
-        )}
-        {concept.subjectIds?.length && (
-          <NotionDialogTags
-            tags={subjects
-              .filter(subject => concept.subjectIds?.includes(subject.id))
-              .map(s => s.name)}
-          />
-        )}
+        <TagWrapper>
+          <div className="tags">
+            <span>{t('form.categories.label')}:</span>
+            {concept.tags.map(tag => (
+              <span className="tag" key={`key-${tag}`}>
+                {tag}
+              </span>
+            ))}
+          </div>
+        </TagWrapper>
+        <NotionDialogTags
+          tags={subjects
+            .filter(subject => concept.subjectIds?.includes(subject.id))
+            .map(s => s.name)}
+        />
         <NotionDialogLicenses
           license={concept.copyright?.license?.license}
           source={concept.source}


### PR DESCRIPTION
Ref:  https://trello.com/c/0ZAFA5qW/720-sammenligning-av-spr%C3%A5kversjoner#comment-5fe07cd9b4e3b77edc478340

Vi skal alltid vise liste og fag sjølv om dei er tomme.
Eks: https://editorial-frontend-pr-850.ndla.sh/concept/717/edit/nb skal vise `Liste og filter:` uten noko etter :