### PR TITLE
2376-legge-til-flere-artikler-i-forklaring

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.jsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.jsx
@@ -54,7 +54,6 @@ const HeaderActions = ({
     type === 'concept' ? (
       supportedLanguages.length > 1 && (
         <PreviewConceptLightbox
-          label={t(`articleType.concept`)}
           typeOfPreview="previewLanguageArticle"
           getConcept={getEntity}
         />

--- a/src/containers/ConceptPage/components/ConceptArticles.tsx
+++ b/src/containers/ConceptPage/components/ConceptArticles.tsx
@@ -82,7 +82,6 @@ const ConceptArticles: FC<Props & tType> = ({
       />
       <ElementList
         elements={articles}
-        data-cy="article-ids-list"
         messages={{
           dragElement: t('conceptpageForm.changeOrder'),
           removeElement: t('conceptpageForm.removeArticle'),

--- a/src/containers/ConceptPage/components/ConceptArticles.tsx
+++ b/src/containers/ConceptPage/components/ConceptArticles.tsx
@@ -77,15 +77,15 @@ const ConceptArticles: FC<Props & tType> = ({
   return (
     <>
       <FieldHeader
-        title={t('subjectpageForm.editorsChoices')}
-        subTitle={t('subjectpageForm.articles')}
+        title={t('conceptpageForm.articlesTitle')}
+        subTitle={t('conceptpageForm.articlesSubtitle')}
       />
       <ElementList
         elements={articles}
         data-cy="article-ids-list"
         messages={{
           dragElement: t('form.file.changeOrder'),
-          removeElement: t('subjectpageForm.removeArticle'),
+          removeElement: t('form.file.removeArticle'),
         }}
         onUpdateElements={onUpdateElements}
       />
@@ -93,7 +93,7 @@ const ConceptArticles: FC<Props & tType> = ({
         idField="id"
         name="relatedArticleSearch"
         labelField="title"
-        placeholder={t('subjectpageForm.addArticle')}
+        placeholder={t('form.content.relatedArticle.placeholder')}
         label="label"
         apiAction={searchForArticles}
         onClick={(event: Event) => event.stopPropagation()}

--- a/src/containers/ConceptPage/components/ConceptArticles.tsx
+++ b/src/containers/ConceptPage/components/ConceptArticles.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree. *
+ */
+
+import React, { FC, useState } from 'react';
+import { injectT, tType } from '@ndla/i18n';
+import { FieldHeader } from '@ndla/forms';
+import { FormikHelpers, FormikValues } from 'formik';
+import ElementList from '../../NdlaFilm/components/ElementList';
+import { AsyncDropdown } from '../../../components/Dropdown';
+import {
+  ArticleType,
+  ContentResultType,
+  FormikProperties,
+} from '../../../interfaces';
+import handleError from '../../../util/handleError';
+import { fetchDraft, searchDrafts } from '../../../modules/draft/draftApi';
+import { fetchLearningpath } from '../../../modules/learningpath/learningpathApi';
+
+interface Props {
+  locale: String;
+  articleIds: ArticleType[];
+  field: FormikProperties['field'];
+  form: {
+    setFieldTouched: FormikHelpers<FormikValues>['setFieldTouched'];
+  };
+}
+
+const ConceptArticles: FC<Props & tType> = ({
+  locale,
+  t,
+  articleIds,
+  field,
+  form,
+}) => {
+  const [articles, setArticles] = useState<ArticleType[]>(articleIds);
+
+  const onAddArticleToList = async (article: ContentResultType) => {
+    try {
+      let newArticle = await fetchDraft(article.id);
+      const temp = [...articles, newArticle];
+      if (newArticle !== undefined) {
+        setArticles(temp);
+        updateFormik(field, temp);
+      }
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  const onUpdateElements = (articleList: ArticleType[]) => {
+    setArticles(articleList);
+    updateFormik(field, articleList);
+  };
+
+  const updateFormik = (
+    formikField: Props['field'],
+    newData: ArticleType[],
+  ) => {
+    form.setFieldTouched('articleIds', true, false);
+    formikField.onChange({
+      target: {
+        name: formikField.name,
+        value: newData || null,
+      },
+    });
+  };
+
+  const searchForArticles = async (inp: String) => {
+    return await searchDrafts({
+      query: inp,
+      language: locale,
+    });
+  };
+
+  return (
+    <>
+      <FieldHeader
+        title={t('subjectpageForm.editorsChoices')}
+        subTitle={t('subjectpageForm.articles')}
+      />
+      <ElementList
+        elements={articles}
+        data-cy="editors-choices-article-list"
+        messages={{
+          dragElement: t('form.file.changeOrder'),
+          removeElement: t('subjectpageForm.removeArticle'),
+        }}
+        onUpdateElements={onUpdateElements}
+      />
+      <AsyncDropdown
+        idField="id"
+        name="relatedArticleSearch"
+        labelField="title"
+        placeholder={t('subjectpageForm.addArticle')}
+        label="label"
+        apiAction={searchForArticles}
+        onClick={(event: Event) => event.stopPropagation()}
+        onChange={(article: ContentResultType) => onAddArticleToList(article)}
+        clearInputField
+      />
+    </>
+  );
+};
+
+export default injectT(ConceptArticles);

--- a/src/containers/ConceptPage/components/ConceptArticles.tsx
+++ b/src/containers/ConceptPage/components/ConceptArticles.tsx
@@ -84,12 +84,13 @@ const ConceptArticles: FC<Props & tType> = ({
         elements={articles}
         data-cy="article-ids-list"
         messages={{
-          dragElement: t('form.file.changeOrder'),
-          removeElement: t('form.file.removeArticle'),
+          dragElement: t('conceptpageForm.changeOrder'),
+          removeElement: t('conceptpageForm.removeArticle'),
         }}
         onUpdateElements={onUpdateElements}
       />
       <AsyncDropdown
+        selectedElements={articles}
         idField="id"
         name="relatedArticleSearch"
         labelField="title"

--- a/src/containers/ConceptPage/components/ConceptArticles.tsx
+++ b/src/containers/ConceptPage/components/ConceptArticles.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../../interfaces';
 import handleError from '../../../util/handleError';
 import { fetchDraft, searchDrafts } from '../../../modules/draft/draftApi';
-import { fetchLearningpath } from '../../../modules/learningpath/learningpathApi';
 
 interface Props {
   locale: String;
@@ -37,7 +36,6 @@ const ConceptArticles: FC<Props & tType> = ({
   form,
 }) => {
   const [articles, setArticles] = useState<ArticleType[]>(articleIds);
-
   const onAddArticleToList = async (article: ContentResultType) => {
     try {
       let newArticle = await fetchDraft(article.id);
@@ -84,7 +82,7 @@ const ConceptArticles: FC<Props & tType> = ({
       />
       <ElementList
         elements={articles}
-        data-cy="editors-choices-article-list"
+        data-cy="article-ids-list"
         messages={{
           dragElement: t('form.file.changeOrder'),
           removeElement: t('subjectpageForm.removeArticle'),

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -72,7 +72,7 @@ const getInitialValues = (concept = {}, subjects = []) => {
     metaImageId,
     metaImageAlt: concept.metaImage?.alt || '',
     tags: concept.tags || [],
-    articleIds: concept.articleIds || [],
+    articleIds: concept.articleIds,
     status: concept.status || {},
     visualElement: visualElement || {},
   };

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -72,7 +72,7 @@ const getInitialValues = (concept = {}, subjects = []) => {
     metaImageId,
     metaImageAlt: concept.metaImage?.alt || '',
     tags: concept.tags || [],
-    articleIds: concept.articleIds,
+    articleIds: concept.articleIds || [],
     status: concept.status || {},
     visualElement: visualElement || {},
   };

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -288,7 +288,7 @@ class ConceptForm extends Component {
       },
       {
         id: 'concept-articles',
-        title: t('form.articles'),
+        title: t('form.articleSection'),
         className: 'u-6/6',
         hasError: ['articleIds'].some(field => !!errors[field]),
         component: props => (

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -44,6 +44,8 @@ import { nullOrUndefined } from '../../../util/articleUtil';
 import EditorFooter from '../../../components/SlateEditor/EditorFooter';
 import * as articleStatuses from '../../../util/constants/ArticleStatus';
 import { createEmbedTag, parseEmbedTag } from '../../../util/embedTagHelpers';
+import FormikField from '../../../components/FormikField';
+import ConceptArticles from './ConceptArticles';
 
 const getInitialValues = (concept = {}, subjects = []) => {
   const visualElement = parseEmbedTag(concept.visualElement?.visualElement);
@@ -69,7 +71,7 @@ const getInitialValues = (concept = {}, subjects = []) => {
     metaImageId,
     metaImageAlt: concept.metaImage?.alt || '',
     tags: concept.tags || [],
-    articleId: concept.articleId,
+    articleIds: concept.articleIds || [],
     status: concept.status || {},
     visualElement: visualElement || {},
   };
@@ -173,7 +175,7 @@ class ConceptForm extends Component {
       subjectIds: values.subjects.map(subject => subject.id),
       tags: values.tags,
       created: this.getCreatedDate(values),
-      articleId: values.articleId,
+      articleIds: values.articleIds,
       metaImage,
       visualElement,
     };
@@ -281,6 +283,23 @@ class ConceptForm extends Component {
             subjects={subjects}
             locale={locale}
           />
+        ),
+      },
+      {
+        id: 'concept-articles',
+        title: t('form.articles'),
+        className: 'u-6/6',
+        hasError: ['articleIds'].some(field => !!errors[field]),
+        component: ({ values }) => (
+          <FormikField name={'articleIds'}>
+            {({ field, form }) => (
+              <ConceptArticles
+                articleIds={values.articleIds}
+                field={field}
+                form={form}
+              />
+            )}
+          </FormikField>
         ),
       },
     ];

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -50,6 +50,7 @@ import ConceptArticles from './ConceptArticles';
 const getInitialValues = (concept = {}, subjects = []) => {
   const visualElement = parseEmbedTag(concept.visualElement?.visualElement);
   const metaImageId = parseImageUrl(concept.metaImage);
+
   return {
     id: concept.id,
     title: concept.title || '',
@@ -290,11 +291,11 @@ class ConceptForm extends Component {
         title: t('form.articles'),
         className: 'u-6/6',
         hasError: ['articleIds'].some(field => !!errors[field]),
-        component: ({ values }) => (
+        component: props => (
           <FormikField name={'articleIds'}>
             {({ field, form }) => (
               <ConceptArticles
-                articleIds={values.articleIds}
+                articleIds={props.values.articleIds}
                 field={field}
                 form={form}
               />

--- a/src/containers/ConceptPage/components/ConceptMetaData.jsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.jsx
@@ -13,7 +13,6 @@ import FormikField from '../../../components/FormikField';
 import { FormikMetaImageSearch } from '../../FormikForm';
 import { SubjectShape, ConceptShape } from '../../../shapes';
 import { MultiSelectDropdown } from '../../../components/Dropdown';
-import ConceptMetaDataArticle from './ConceptMetaDataArticle';
 import AsyncSearchTags from '../../../components/Dropdown/asyncDropdown/AsyncSearchTags';
 
 const ConceptMetaData = ({ t, subjects, locale, concept, fetchTags }) => (
@@ -50,15 +49,6 @@ const ConceptMetaData = ({ t, subjects, locale, concept, fetchTags }) => (
           field={field}
           form={form}
           fetchTags={fetchTags}
-        />
-      )}
-    </FormikField>
-    <FormikField name="articleId">
-      {({ field }) => (
-        <ConceptMetaDataArticle
-          locale={locale}
-          field={field}
-          articleId={concept.articleId}
         />
       )}
     </FormikField>

--- a/src/containers/FormikForm/formikConceptHooks.jsx
+++ b/src/containers/FormikForm/formikConceptHooks.jsx
@@ -13,7 +13,11 @@ import {
   fetchSearchTags,
   fetchStatusStateMachine,
 } from '../../modules/concept/conceptApi';
-import { transformConceptFromApiVersion } from '../../util/conceptUtil';
+import { fetchDraft } from '../../modules/draft/draftApi';
+import {
+  transformConceptFromApiVersion,
+  transformConceptToApiVersion,
+} from '../../util/conceptUtil';
 import handleError from '../../util/handleError';
 
 export function useFetchConceptData(conceptId, locale) {
@@ -34,12 +38,21 @@ export function useFetchConceptData(conceptId, locale) {
       if (conceptId) {
         setLoading(true);
         const concept = await conceptApi.fetchConcept(conceptId, locale);
-        setConcept(transformConceptFromApiVersion(concept, locale));
+        const articleIds = await fetchElementList(concept.articleIds);
+        setConcept(transformConceptFromApiVersion(concept, locale, articleIds));
         setLoading(false);
       }
     } catch (e) {
       handleError(e);
     }
+  };
+
+  const fetchElementList = async articleIds => {
+    return await Promise.all(
+      articleIds.map(async elementId => {
+        return fetchDraft(elementId);
+      }),
+    );
   };
 
   const fetchSubjects = async () => {
@@ -48,21 +61,30 @@ export function useFetchConceptData(conceptId, locale) {
   };
 
   const updateConcept = async updatedConcept => {
-    const savedConcept = await conceptApi.updateConcept(updatedConcept);
+    const articleIds = updatedConcept.articleIds.map(articleId => articleId.id);
+    const savedConcept = await conceptApi.updateConcept(
+      transformConceptToApiVersion(updatedConcept, articleIds),
+    );
     setConcept(transformConceptFromApiVersion(savedConcept, locale));
     return savedConcept;
   };
 
   const createConcept = async createdConcept => {
-    const savedConcept = await conceptApi.addConcept(createdConcept);
+    const articleIds = createdConcept.articleIds.map(articleId => articleId.id);
+    const savedConcept = await conceptApi.addConcept(
+      transformConceptToApiVersion(createdConcept, articleIds),
+    );
     setConcept(transformConceptFromApiVersion(savedConcept, locale));
     return savedConcept;
   };
 
   const updateConceptAndStatus = async (updatedConcept, newStatus, dirty) => {
+    const articleIds = updatedConcept.articleIds.map(articleId => articleId.id);
     let newConcept = updatedConcept;
     if (dirty) {
-      const savedConcept = await conceptApi.updateConcept(updatedConcept);
+      const savedConcept = await conceptApi.updateConcept(
+        transformConceptToApiVersion(updatedConcept, articleIds),
+      );
       newConcept = transformConceptFromApiVersion(savedConcept, locale);
     }
     const conceptChangedStatus = await conceptApi.updateConceptStatus(

--- a/src/containers/FormikForm/formikConceptHooks.jsx
+++ b/src/containers/FormikForm/formikConceptHooks.jsx
@@ -32,14 +32,8 @@ export function useFetchConceptData(conceptId, locale) {
       if (conceptId) {
         setLoading(true);
         const concept = await conceptApi.fetchConcept(conceptId, locale);
-        const articleIds = concept.articleIds;
 
-        let convertedArticles = undefined;
-        if (articleIds) {
-          convertedArticles = await fetchElementList(concept.articleIds);
-        } else {
-          convertedArticles = [];
-        }
+        const convertedArticles = await fetchElementList(concept.articleIds);
         setConcept(
           transformConceptFromApiVersion(concept, locale, convertedArticles),
         );

--- a/src/containers/FormikForm/subjectpageFormHooks.ts
+++ b/src/containers/FormikForm/subjectpageFormHooks.ts
@@ -29,7 +29,6 @@ export function useSubjectpageFormHooks(
   const handleSubmit = async (formik: FormikProps<SubjectpageEditType>) => {
     formik.setSubmitting(true);
     const newSubjectpage = getSubjectpageFromSlate(formik.values);
-
     try {
       await updateSubjectpage(newSubjectpage);
 

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -317,6 +317,10 @@ const phrases = {
   noEmbedMessage: {
     deleteOnSave: 'Element of type {type} will be deleted on save.',
   },
+  conceptpageForm: {
+    articlesTitle: 'Related Articles',
+    articlesSubtitle: 'Articles',
+  },
   subjectpageForm: {
     title: 'Subject',
     about: 'About subject',

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -320,6 +320,8 @@ const phrases = {
   conceptpageForm: {
     articlesTitle: 'Related Articles',
     articlesSubtitle: 'Articles',
+    changeOrder: 'Change order',
+    removeArticle: 'Remove article',
   },
   subjectpageForm: {
     title: 'Subject',

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -448,6 +448,7 @@ const phrases = {
     },
   },
   form: {
+    articleSection: 'Articles',
     metadataSection: 'Metadata',
     contentSection: 'Content',
     workflowSection: 'Version log and notes',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -465,6 +465,7 @@ const phrases = {
     },
   },
   form: {
+    articleSection: 'Artikler',
     metadataSection: 'Metadata',
     contentSection: 'Innhold',
     workflowSection: 'Versjonslogg og merknader',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -318,6 +318,10 @@ const phrases = {
   noEmbedMessage: {
     deleteOnSave: 'Element av type {type} vil bli fjernet ved lagring.',
   },
+  conceptpageForm: {
+    articlesTitle: 'Relaterte artikler',
+    articlesSubtitle: 'Artikler',
+  },
   subjectpageForm: {
     title: 'Fag',
     about: 'Om faget',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -321,6 +321,8 @@ const phrases = {
   conceptpageForm: {
     articlesTitle: 'Relaterte artikler',
     articlesSubtitle: 'Artikler',
+    changeOrder: 'Endre rekkefølge',
+    removeArticle: 'Fjern artikkel',
   },
   subjectpageForm: {
     title: 'Fag',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -470,6 +470,7 @@ const phrases = {
     placeholder: 'Kort sammendrag',
   },
   form: {
+    articleSection: 'Artikler',
     metadataSection: 'Metadata',
     contentSection: 'Innhald',
     workflowSection: 'Versjonslogg og merknader',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -319,6 +319,10 @@ const phrases = {
   noEmbedMessage: {
     deleteOnSave: 'Element av type {type} vil bli fjerna ved lagring.',
   },
+  conceptpageForm: {
+    articlesTitle: 'Relaterte artiklar',
+    articlesSubtitle: 'Artiklar',
+  },
   subjectpageForm: {
     title: 'Fag',
     about: 'Om faget',
@@ -470,7 +474,7 @@ const phrases = {
     placeholder: 'Kort sammendrag',
   },
   form: {
-    articleSection: 'Artikler',
+    articleSection: 'Artiklar',
     metadataSection: 'Metadata',
     contentSection: 'Innhald',
     workflowSection: 'Versjonslogg og merknader',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -322,6 +322,8 @@ const phrases = {
   conceptpageForm: {
     articlesTitle: 'Relaterte artiklar',
     articlesSubtitle: 'Artiklar',
+    changeOrder: 'Endre rekkefølgje',
+    removeArticle: 'Fjern artikkel',
   },
   subjectpageForm: {
     title: 'Fag',

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -38,6 +38,7 @@ const connectSrc = (() => {
       'http://localhost:3001',
       'ws://localhost:3001',
       'http://localhost:3100',
+      'http://localhost',
     ];
   }
 

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -131,7 +131,7 @@ export const ConceptShape = PropTypes.shape({
   id: PropTypes.number,
   title: PropTypes.string,
   content: PropTypes.string,
-  articleId: PropTypes.number,
+  articleIds: PropTypes.arrayOf(PropTypes.number),
 });
 
 export const ImageShape = PropTypes.shape({

--- a/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
+++ b/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`transformConceptFromApiVersion 1`] = `
 Object {
+  "articleIds": undefined,
   "content": "Beskrivelse av testforklaring.",
   "copyright": Object {
     "creators": Array [

--- a/src/util/conceptUtil.js
+++ b/src/util/conceptUtil.js
@@ -1,9 +1,19 @@
 import { convertFieldWithFallback } from './convertFieldWithFallback';
 
-export const transformConceptFromApiVersion = (concept, locale) => ({
+export const transformConceptFromApiVersion = (
+  concept,
+  locale,
+  articleIds,
+) => ({
   ...concept,
+  articleIds: articleIds,
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
   tags: convertFieldWithFallback(concept, 'tags', []),
   ...(locale ? { language: locale } : {}),
+});
+
+export const transformConceptToApiVersion = (concept, articleIds) => ({
+  ...concept,
+  articleIds: articleIds,
 });


### PR DESCRIPTION
Fixes NDLANO/Issues#2376

1. https://editorial-frontend-pr-851.ndla.sh/
2. Følgende skal fungere
- Opprette ny forklaring
- Legge til artikkel til forklaring
- Fjerne artikkel fra forklaring
- Fjerne alle artikler fra forklaring
- Bytte rekkefølge på artikler i eksisterende forklaring


~Se også PR for concept-api:
https://github.com/NDLANO/concept-api/pull/71~