### PR TITLE
Allow lists for concepts but not articles.

### DIFF
--- a/src/components/PreviewConcept/PreviewConcept.tsx
+++ b/src/components/PreviewConcept/PreviewConcept.tsx
@@ -65,7 +65,6 @@ const PreviewConcept: FC<Props & tType> = ({ concept, t }) => {
   const [subjects, setSubjects] = useState<SubjectType[]>([]);
   const markdown = new Remarkable({ breaks: true });
   markdown.inline.ruler.enable(['sub', 'sup']);
-  markdown.block.ruler.disable(['list']);
 
   useEffect(() => {
     getSubjects();
@@ -73,7 +72,7 @@ const PreviewConcept: FC<Props & tType> = ({ concept, t }) => {
 
   const getSubjects = async () => {
     const subjects = await Promise.all(
-      concept.subjectIds.map(id => fetchSubject(id)),
+      concept.subjectIds?.map(id => fetchSubject(id)),
     );
     setSubjects(subjects);
   };

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -86,6 +86,7 @@ const ConceptContent = props => {
         maxLength={800}
         placeholder={t('form.name.conceptContent')}
         preview={preview}
+        concept
       />
     </>
   );

--- a/src/containers/FormikForm/FormikIngress.jsx
+++ b/src/containers/FormikForm/FormikIngress.jsx
@@ -19,9 +19,11 @@ import FormikField from '../../components/FormikField';
 
 const markdown = new Remarkable({ breaks: true });
 markdown.inline.ruler.enable(['sub', 'sup']);
-markdown.block.ruler.disable(['list']);
 
-const renderMarkdown = text => {
+const renderMarkdown = (text, concept) => {
+  if (!concept) {
+    markdown.block.ruler.disable(['list']);
+  }
   return markdown.render(text);
 };
 
@@ -31,6 +33,7 @@ const FormikIngress = ({
   maxLength,
   placeholder,
   preview = false,
+  concept = false,
 }) => (
   <StyledFormContainer>
     <FormikField
@@ -42,7 +45,7 @@ const FormikIngress = ({
       {({ field }) =>
         preview ? (
           <p className="article_introduction">
-            {parse(renderMarkdown(Plain.serialize(field.value)))}
+            {parse(renderMarkdown(Plain.serialize(field.value), concept))}
           </p>
         ) : (
           <PlainTextEditor
@@ -70,6 +73,7 @@ FormikIngress.propTypes = {
   type: PropTypes.string,
   placeholder: PropTypes.string,
   preview: PropTypes.bool,
+  concept: PropTypes.bool,
 };
 
 export default injectT(FormikIngress);


### PR DESCRIPTION
Ref https://trello.com/c/M9nkpu9A/816-bug-i-ed-med-visning-av-markdown-ved-bruk-av-%C3%B8ye-ikonet

Lar forklaringer vise lister men ikkje artikkelingress.