### PR TITLE
2300 custom for css tilpasset visning av h5p

### DIFF
--- a/public/h5p-custom-css.css
+++ b/public/h5p-custom-css.css
@@ -1,3 +1,0 @@
-.h5p-dialogcards li{
-  text-align: left;
-}

--- a/public/h5p-custom-css.css
+++ b/public/h5p-custom-css.css
@@ -1,13 +1,3 @@
-.h5p-dialogcards {
-  box-shadow: none;
-  background-color: blue;
-  color: pink;
-}
-
-.h5p-questions {
-  color: red;
-}
-
 .h5p-dialogcards li{
   text-align: left;
 }

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -72,10 +72,14 @@ export class DisplayExternal extends Component {
       try {
         let url = embed.url || `${domain}${embed.path}`;
         url = url.includes(config.h5pApiUrl)
-          ? `${url}?locale=${getH5pLocale(language)}`
-          : url;
+          ? `${url}?locale=${getH5pLocale(
+              language,
+            )}&cssUrl=https%3A%2F%2Fed.test.ndla.no%2Fh5p-custom-css.css`
+          : `${url}?cssUrl=https%3A%2F%2Fed.test.ndla.no%2Fh5p-custom-css.css`;
+
         const data = await fetchExternalOembed(url);
         const src = getIframeSrcFromHtmlString(data.html);
+
         if (src) {
           this.setState({
             title: data.title,

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -66,16 +66,17 @@ export class DisplayExternal extends Component {
   async getPropsFromEmbed() {
     const { embed, language } = this.props;
     const domain = embed.url ? urlDomain(embed.url) : config.h5pApiUrl;
+    const cssUrl = encodeURIComponent(
+      'https://ed.test.ndla.no/h5p-custom-css.css',
+    );
     this.setState({ domain });
 
     if (embed.resource === 'external' || embed.resource === 'h5p') {
       try {
         let url = embed.url || `${domain}${embed.path}`;
         url = url.includes(config.h5pApiUrl)
-          ? `${url}?locale=${getH5pLocale(
-              language,
-            )}&cssUrl=https%3A%2F%2Fed.test.ndla.no%2Fh5p-custom-css.css`
-          : `${url}?cssUrl=https%3A%2F%2Fed.test.ndla.no%2Fh5p-custom-css.css`;
+          ? `${url}?locale=${getH5pLocale(language)}&cssUrl=${cssUrl}`
+          : `${url}?cssUrl=${cssUrl}`;
 
         const data = await fetchExternalOembed(url);
         const src = getIframeSrcFromHtmlString(data.html);

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -67,7 +67,7 @@ export class DisplayExternal extends Component {
     const { embed, language } = this.props;
     const domain = embed.url ? urlDomain(embed.url) : config.h5pApiUrl;
     const cssUrl = encodeURIComponent(
-      'https://ed.test.ndla.no/h5p-custom-css.css',
+      'https://test.ndla.no/static/h5p-custom-css.css', // TODO HOWTO make first part of link dynamic?
     );
     this.setState({ domain });
 

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -67,7 +67,7 @@ export class DisplayExternal extends Component {
     const { embed, language } = this.props;
     const domain = embed.url ? urlDomain(embed.url) : config.h5pApiUrl;
     const cssUrl = encodeURIComponent(
-      'https://test.ndla.no/static/h5p-custom-css.css', // TODO HOWTO make first part of link dynamic?
+      `${config.ndlaFrontendDomain}/static/h5p-custom-css.css`,
     );
     this.setState({ domain });
 

--- a/src/util/apiHelpers.js
+++ b/src/util/apiHelpers.js
@@ -114,7 +114,9 @@ export const setOembedUrl = query =>
     query,
   )}`;
 
-export const fetchExternalOembed = (url, options) =>
-  fetchOembed(setOembedUrl({ url }), options);
+export const fetchExternalOembed = (url, options) => {
+  const setOembed = setOembedUrl({ url });
+  return fetchOembed(setOembed, options);
+};
 
 export { resolveJsonOrRejectWithError, createErrorPayload };


### PR DESCRIPTION
Issue NDLANO/Issues#2300

Trello https://trello.com/c/u9KIMobD/760-knowit-ed-sjekk-dialogkort-i-fagpresentasjon-den-er-altfor-h%C3%B8y

PR i article-converter: https://github.com/NDLANO/article-converter/pull/215

Legger til custom css fil fra ndla og sender denne inn til custom. Har brukt denne artikkelen for testing: https://ed.test.ndla.no/subject-matter/learning-resource/22726/edit/nb

Det som skal være endret: 
* mindre luft rundt tekst i dialogboks (de hvite boksene inni h5p)
* venstrestilt tekst i lister i dialogboks