### PR TITLE
Fix ndla url link

### DIFF
--- a/src/components/SlateEditor/plugins/link/EditLink.jsx
+++ b/src/components/SlateEditor/plugins/link/EditLink.jsx
@@ -10,6 +10,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import Types from 'slate-prop-types';
+import Url from 'url-parse';
+import { isValidLocale } from '../../../../i18n';
 import { Portal } from '../../../Portal';
 import Lightbox from '../../../Lightbox';
 import { TYPE } from '.';
@@ -44,9 +46,7 @@ const createLinkData = (href, targetRel) => ({
 export const isNDLAArticleUrl = url =>
   /^http(s)?:\/\/((.*)\.)?ndla.no\/((.*)\/)?article\/\d*/.test(url);
 export const isNDLATaxonomyUrl = url =>
-  /^http(s)?:\/\/((.*)\.)?ndla.no\/((.*)\/)?(subjects\/)?(.*)\/topic(.*)/.test(
-    url,
-  );
+  /^http(s)?:\/\/((.*)\.)?ndla.no\/((.*)\/)?(.*)\/topic(.*)/.test(url);
 export const isNDLALearningPathUrl = url =>
   /^http(s)?:\/\/((.*)\.)?ndla.no\/((.*)\/)?learningpaths\/(.*)/.test(url);
 export const isNDLAEdPathUrl = url =>
@@ -74,8 +74,10 @@ const getIdAndTypeFromUrl = async href => {
       resourceType: 'article',
     };
   } else if (isNDLATaxonomyUrl(baseHref)) {
-    const taxonomyPath = baseHref.split('subjects').pop();
-    const resolvedTaxonomy = await resolveUrls(taxonomyPath);
+    const { pathname } = new Url(baseHref.replace('/subjects', ''));
+    const paths = pathname.split('/');
+    const path = isValidLocale(paths[1]) ? paths.slice(2).join('/') : pathname;
+    const resolvedTaxonomy = await resolveUrls(path);
 
     const contentUriSplit =
       resolvedTaxonomy && resolvedTaxonomy.contentUri.split(':');

--- a/src/components/SlateEditor/plugins/link/__tests__/EditLink-test.js
+++ b/src/components/SlateEditor/plugins/link/__tests__/EditLink-test.js
@@ -21,12 +21,12 @@ test('urls are parsed correctly', async () => {
   ];
 
   const subjectUrls = [
-    'https://api.test.ndla.no/en/subject:3/topic:1:2342/resource:1:64323',
+    'https://api.test.ndla.no/en/subjects/subject:3/topic:1:2342/resource:1:64323',
     'https://api.test.ndla.no/subject:3/topic:1:2342/resource:1:64323',
     'https://ndla-frontend.api.test.ndla.no/sma/subject:3/topic:1:2342/resource:1:64323',
     'https://ndla-frontend.api.test.ndla.no/subject:3/topic:1:2342/resource:1:64323',
     'https://ndla-frontend.test.api.ndla.no/nn/subject:3/topic:1:2342/resource:1:64323',
-    'https://ndla-frontend.test.api.ndla.no/subject:3/topic:1:2342/resource:1:64323',
+    'https://ndla-frontend.test.api.ndla.no/subjects/subject:3/topic:1:2342/resource:1:64323',
     'https://ndla.no/sma/subject:3/topic:1:2342/resource:1:64323',
     'https://ndla.no/subject:3/topic:1:2342/resource:1:64323',
     'https://test.ndla.no/nb/subject:3/topic:1:2342/resource:1:64323',


### PR DESCRIPTION
Etter at vi fjerna /subjects fra ndla-urler fungerer ikkje lenger automatisk oversettelse fra ndla-urler til lenkeembeds.

Test:
Gå til test.ndla.no og finn en vilkårlig artikkel med taksonomiurl. Kopier urlen.
Rediger en artikkel og sett inn ei lenke og bruk urlen som du kopierte. Lagre artikkelen.
Klikk på lenka og sjå at lenka som vises er på formatet ed.test.ndla.no/*.
Sjekk html-editoren for artikkelen og sjekk at det er satt inn en embed av type article og med data-content-id.