### PR TITLE
Vise placeholder med error når oembeds ikke hentes 

### DIFF
--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import Types from 'slate-prop-types';
@@ -132,6 +132,26 @@ export class DisplayExternal extends Component {
       domain,
     } = this.state;
 
+    const errorHolder = () => (
+      <>
+        <DeleteButton stripped onClick={onRemoveClick} />
+        <EditorErrorMessage
+          msg={
+            error
+              ? t('displayOembed.errorMessage')
+              : t('displayOembed.notSupported', {
+                  type,
+                  provider,
+                })
+          }
+        />
+      </>
+    );
+
+    if (error) {
+      return errorHolder();
+    }
+
     if (!type && !provider) {
       return null;
     }
@@ -147,22 +167,8 @@ export class DisplayExternal extends Component {
         : whitelistProvider.name === providerName,
     );
 
-    if (error || !allowedProvider) {
-      return (
-        <Fragment>
-          <DeleteButton stripped onClick={onRemoveClick} />
-          <EditorErrorMessage
-            msg={
-              error
-                ? t('displayOembed.errorMessage')
-                : t('displayOembed.notSupported', {
-                    type,
-                    provider,
-                  })
-            }
-          />
-        </Fragment>
-      );
+    if (!allowedProvider) {
+      return errorHolder();
     }
     return (
       <div className="c-figure">

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -152,10 +152,6 @@ export class DisplayExternal extends Component {
       return errorHolder();
     }
 
-    if (!type && !provider) {
-      return null;
-    }
-
     // H5P does not provide its name
     const providerName = domain && domain.includes('h5p') ? 'H5P' : provider;
 

--- a/src/components/DisplayEmbed/__tests__/DisplayExternal-test.jsx
+++ b/src/components/DisplayEmbed/__tests__/DisplayExternal-test.jsx
@@ -68,7 +68,9 @@ test('DisplayExternal renders external correctly', () => {
   };
 
   const component = TestRenderer.create(
-    <DisplayExternal embed={embed} t={() => ''} />,
+    <IntlWrapper>
+      <DisplayExternal embed={embed} />
+    </IntlWrapper>,
     options,
   );
   expect(component.toJSON()).toMatchSnapshot();
@@ -102,10 +104,9 @@ test('DisplayExternal display error on fetch fail', () => {
     });
 
   const component = TestRenderer.create(
-    <DisplayExternal
-      embed={{ url: 'https://ndla.no/oembed' }}
-      t={() => 'Error message'}
-    />,
+    <IntlWrapper>
+      <DisplayExternal embed={{ url: 'https://ndla.no/oembed' }} />
+    </IntlWrapper>,
     options,
   );
 

--- a/src/components/DisplayEmbed/__tests__/__snapshots__/DisplayExternal-test.jsx.snap
+++ b/src/components/DisplayEmbed/__tests__/__snapshots__/DisplayExternal-test.jsx.snap
@@ -1,8 +1,256 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DisplayExternal display error on fetch fail 1`] = `null`;
+exports[`DisplayExternal display error on fetch fail 1`] = `
+Array [
+  .emotion-0 {
+  display: inline-block;
+  color: #ffffff;
+  background-color: #20588f;
+  border: 2px solid #20588f;
+  border-radius: 4px;
+  padding: 4px 13px;
+  outline-width: 0;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  font-size: 0.8888888888888888rem;
+  line-height: 1.625;
+  font-family: 'Source Sans Pro',Helvetica,Arial,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',sans-serif;
+  font-weight: 700;
+  -webkit-transition: all .2s cubic-bezier(0.17,0.04,0.03,0.94);
+  transition: all .2s cubic-bezier(0.17,0.04,0.03,0.94);
+  box-shadow: none;
+  text-align: center;
+  -webkit-transition: background-color none;
+  transition: background-color none;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+  background-color: transparent;
+  box-shadow: none;
+  border: none;
+  font-weight: 400;
+  position: absolute;
+  top: 0.1rem;
+  right: 0.2rem;
+  color: #d1372e;
+}
 
-exports[`DisplayExternal renders external correctly 1`] = `null`;
+.emotion-0:hover,
+.emotion-0:focus {
+  color: white;
+  background-color: #184673;
+  border: 2px solid #184673;
+}
+
+.emotion-0[disabled] {
+  color: #777777;
+  background-color: #e6e6e6;
+  border-color: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-0:focus {
+  box-shadow: 0 0 2px #20588f;
+}
+
+.emotion-0:hover,
+.emotion-0:active,
+.emotion-0:disabled,
+.emotion-0:focus {
+  box-shadow: none;
+  color: #20588f;
+  background-color: transparent;
+  border: none;
+}
+
+.emotion-0:focus {
+  outline-width: medium;
+}
+
+.emotion-0:hover,
+.emotion-0:focus {
+  color: #7d211c;
+}
+
+<button
+    className="emotion-0 emotion-1"
+    data-cy="close-related-button"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      className="c-icon"
+      data-license="Apache License 2.0"
+      data-source="Material Design"
+      fill="currentColor"
+      height="1em"
+      preserveAspectRatio="xMidYMid meet"
+      style={
+        Object {
+          "color": undefined,
+          "verticalAlign": "middle",
+        }
+      }
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <title>
+        Cross
+      </title>
+      <g>
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+      </g>
+    </svg>
+  </button>,
+  .emotion-0 {
+  position: relative;
+  border: 1px solid #d1372e;
+  color: #d1372e;
+  padding: 1rem;
+}
+
+<div
+    className="emotion-0 emotion-1"
+  >
+    <span />
+  </div>,
+]
+`;
+
+exports[`DisplayExternal renders external correctly 1`] = `
+Array [
+  .emotion-0 {
+  display: inline-block;
+  color: #ffffff;
+  background-color: #20588f;
+  border: 2px solid #20588f;
+  border-radius: 4px;
+  padding: 4px 13px;
+  outline-width: 0;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  font-size: 0.8888888888888888rem;
+  line-height: 1.625;
+  font-family: 'Source Sans Pro',Helvetica,Arial,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',sans-serif;
+  font-weight: 700;
+  -webkit-transition: all .2s cubic-bezier(0.17,0.04,0.03,0.94);
+  transition: all .2s cubic-bezier(0.17,0.04,0.03,0.94);
+  box-shadow: none;
+  text-align: center;
+  -webkit-transition: background-color none;
+  transition: background-color none;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+  background-color: transparent;
+  box-shadow: none;
+  border: none;
+  font-weight: 400;
+  position: absolute;
+  top: 0.1rem;
+  right: 0.2rem;
+  color: #d1372e;
+}
+
+.emotion-0:hover,
+.emotion-0:focus {
+  color: white;
+  background-color: #184673;
+  border: 2px solid #184673;
+}
+
+.emotion-0[disabled] {
+  color: #777777;
+  background-color: #e6e6e6;
+  border-color: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-0:focus {
+  box-shadow: 0 0 2px #20588f;
+}
+
+.emotion-0:hover,
+.emotion-0:active,
+.emotion-0:disabled,
+.emotion-0:focus {
+  box-shadow: none;
+  color: #20588f;
+  background-color: transparent;
+  border: none;
+}
+
+.emotion-0:focus {
+  outline-width: medium;
+}
+
+.emotion-0:hover,
+.emotion-0:focus {
+  color: #7d211c;
+}
+
+<button
+    className="emotion-0 emotion-1"
+    data-cy="close-related-button"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      className="c-icon"
+      data-license="Apache License 2.0"
+      data-source="Material Design"
+      fill="currentColor"
+      height="1em"
+      preserveAspectRatio="xMidYMid meet"
+      style={
+        Object {
+          "color": undefined,
+          "verticalAlign": "middle",
+        }
+      }
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <title>
+        Cross
+      </title>
+      <g>
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+      </g>
+    </svg>
+  </button>,
+  .emotion-0 {
+  position: relative;
+  border: 1px solid #d1372e;
+  color: #d1372e;
+  padding: 1rem;
+}
+
+<div
+    className="emotion-0 emotion-1"
+  >
+    <span />
+  </div>,
+]
+`;
 
 exports[`DisplayExternal renders iframe correctly 1`] = `
 .emotion-14 {

--- a/src/components/DisplayEmbed/__tests__/__snapshots__/DisplayExternal-test.jsx.snap
+++ b/src/components/DisplayEmbed/__tests__/__snapshots__/DisplayExternal-test.jsx.snap
@@ -121,7 +121,9 @@ Array [
 <div
     className="emotion-0 emotion-1"
   >
-    <span />
+    <span>
+      oEmbed av type  og kilde  er ikke støttet.
+    </span>
   </div>,
 ]
 `;
@@ -247,7 +249,9 @@ Array [
 <div
     className="emotion-0 emotion-1"
   >
-    <span />
+    <span>
+      oEmbed av type  og kilde  er ikke støttet.
+    </span>
   </div>,
 ]
 `;


### PR DESCRIPTION
Fixes NDLANO/Issues#2346

Tidligere har oembeds som ikke fetches ikke blitt vist i ed (ref. øverst i ed.test.ndla.no/subject-matter/learning-resource/22729/edit/nb). Har lagt til `EditorErrorMessage` som placeholder for å vise feilmelding. Test i samme artikkel som over: https://editorial-frontend-pr-859.ndla.sh/subject-matter/learning-resource/22729/edit/nb

Erroren gir ikke veldig spesifikk info om hvorfor det er error, bør det spesifiseres?

