### PR TITLE
2385 bugfix article meta image alt text disappear

### DIFF
--- a/src/components/PreviewConcept/PreviewConceptLightbox.tsx
+++ b/src/components/PreviewConcept/PreviewConceptLightbox.tsx
@@ -20,7 +20,10 @@ import { Portal } from '../Portal';
 import PreviewLightboxContent from '../PreviewDraft/PreviewLightboxContent';
 import { ConceptPreviewType } from '../../interfaces';
 import StyledFilledButton from '../StyledFilledButton';
-import { transformApiToPreviewVersion } from '../../util/conceptUtil';
+import {
+  transformApiToPreviewVersion,
+  transformFormikToPreviewVersion,
+} from '../../util/conceptUtil';
 import { parseEmbedTag } from '../../util/embedTagHelpers';
 import { getYoutubeEmbedUrl } from '../../util/videoUtil';
 import PreviewConcept from './PreviewConcept';
@@ -68,11 +71,8 @@ const PreviewConceptLightbox: FC<Props & tType> = ({
 
   const openPreview = async () => {
     const concept = getConcept();
-    const visualElement = await getVisualElement(concept.visualElement);
-    setFirstConcept({
-      ...concept,
-      visualElement: visualElement,
-    });
+    const transformed = transformFormikToPreviewVersion(concept);
+    setFirstConcept(transformed);
     const secondConceptLanguage =
       concept.supportedLanguages &&
       concept.supportedLanguages.find((l: string) => l !== concept.language);

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -43,7 +43,6 @@ const ConceptContent = props => {
       values: { creators, created },
     },
   } = props;
-  console.log(props.formik.values);
   return (
     <>
       <FormikField

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -43,6 +43,7 @@ const ConceptContent = props => {
       values: { creators, created },
     },
   } = props;
+  console.log(props.formik.values);
   return (
     <>
       <FormikField

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -43,7 +43,7 @@ const ConceptContent = props => {
       values: { creators, created },
     },
   } = props;
-  console.log(props.formik.values);
+
   return (
     <>
       <FormikField

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -43,7 +43,6 @@ const ConceptContent = props => {
       values: { creators, created },
     },
   } = props;
-  console.log(props.formik.values);
 
   return (
     <>

--- a/src/containers/ConceptPage/components/ConceptContent.jsx
+++ b/src/containers/ConceptPage/components/ConceptContent.jsx
@@ -43,6 +43,7 @@ const ConceptContent = props => {
       values: { creators, created },
     },
   } = props;
+  console.log(props.formik.values);
 
   return (
     <>

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -43,13 +43,12 @@ import { toEditConcept } from '../../../util/routeHelpers.js';
 import { nullOrUndefined } from '../../../util/articleUtil';
 import EditorFooter from '../../../components/SlateEditor/EditorFooter';
 import * as articleStatuses from '../../../util/constants/ArticleStatus';
-import { createEmbedTag, parseEmbedTag } from '../../../util/embedTagHelpers';
 import FormikField from '../../../components/FormikField';
 import ConceptArticles from './ConceptArticles';
 
 const getInitialValues = (concept = {}, subjects = []) => {
-  const visualElement = parseEmbedTag(concept.visualElement?.visualElement);
   const metaImageId = parseImageUrl(concept.metaImage);
+  console.log(concept);
 
   return {
     id: concept.id,
@@ -74,7 +73,7 @@ const getInitialValues = (concept = {}, subjects = []) => {
     tags: concept.tags || [],
     articleIds: concept.articleIds || [],
     status: concept.status || {},
-    visualElement: visualElement || {},
+    visualElement: concept.visualElement || {},
   };
 };
 
@@ -158,9 +157,6 @@ class ConceptForm extends Component {
           alt: values.metaImageAlt,
         }
       : nullOrUndefined(values?.metaImageId);
-    const visualElement = createEmbedTag(
-      isEmpty(values.visualElement) ? {} : values.visualElement,
-    );
 
     return {
       id: values.id,
@@ -183,7 +179,7 @@ class ConceptForm extends Component {
       created: this.getCreatedDate(values),
       articleIds: values.articleIds,
       metaImage,
-      visualElement,
+      visualElement: values.visualElement,
     };
   };
 

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -31,7 +31,6 @@ import HeaderWithLanguage from '../../../components/HeaderWithLanguage';
 import {
   isFormikFormDirty,
   parseCopyrightContributors,
-  parseImageUrl,
 } from '../../../util/formHelper';
 import { FormikActionButton } from '../../FormikForm';
 import { FormikAlertModalWrapper, formClasses } from '../../FormikForm';
@@ -47,8 +46,6 @@ import FormikField from '../../../components/FormikField';
 import ConceptArticles from './ConceptArticles';
 
 const getInitialValues = (concept = {}, subjects = []) => {
-  const metaImageId = parseImageUrl(concept.metaImage);
-
   return {
     id: concept.id,
     title: concept.title || '',
@@ -67,8 +64,8 @@ const getInitialValues = (concept = {}, subjects = []) => {
     processors: parseCopyrightContributors(concept, 'processors'),
     source: concept && concept.source ? concept.source : '',
     license: concept.copyright?.license?.license,
-    metaImageId,
-    metaImageAlt: concept.metaImage?.alt || '',
+    metaImageId: concept.metaImageId,
+    metaImageAlt: concept.metaImageAlt || '',
     tags: concept.tags || [],
     articleIds: concept.articleIds || [],
     status: concept.status || {},

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -28,10 +28,7 @@ import {
 import ConceptContent from './ConceptContent';
 import ConceptMetaData from './ConceptMetaData';
 import HeaderWithLanguage from '../../../components/HeaderWithLanguage';
-import {
-  isFormikFormDirty,
-  parseCopyrightContributors,
-} from '../../../util/formHelper';
+import { isFormikFormDirty } from '../../../util/formHelper';
 import { FormikActionButton } from '../../FormikForm';
 import { FormikAlertModalWrapper, formClasses } from '../../FormikForm';
 import ConceptCopyright from './ConceptCopyright';
@@ -58,11 +55,11 @@ const getInitialValues = (concept = {}, subjects = []) => {
     created: concept.created,
     conceptContent: plainTextToEditorValue(concept.content || '', true),
     supportedLanguages: concept.supportedLanguages || [],
-    creators: parseCopyrightContributors(concept, 'creators'),
-    rightsholders: parseCopyrightContributors(concept, 'rightsholders'),
-    processors: parseCopyrightContributors(concept, 'processors'),
+    creators: concept.creators || [],
+    rightsholders: concept.rightsholders || [],
+    processors: concept.processors || [],
     source: concept && concept.source ? concept.source : '',
-    license: concept.copyright?.license?.license,
+    license: concept.copyright?.license?.license || '',
     metaImageId: concept.metaImageId,
     metaImageAlt: concept.metaImageAlt || '',
     tags: concept.tags || [],
@@ -152,13 +149,11 @@ class ConceptForm extends Component {
       content: editorValueToPlainText(values.conceptContent),
       language: values.language,
       supportedLanguages: values.supportedLanguages,
-      copyright: {
-        license: licenses.find(license => license.license === values.license),
-        creators: values.creators,
-        processors: values.processors,
-        rightsholders: values.rightsholders,
-        agreementId: values.agreementId,
-      },
+      license: licenses.find(license => license.license === values.license),
+      creators: values.creators,
+      processors: values.processors,
+      rightsholders: values.rightsholders,
+      agreementId: values.agreementId,
       metaImageAlt: values.metaImageAlt,
       metaImageId: values.metaImageId,
       source: values.source,

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -39,7 +39,6 @@ import validateFormik from '../../../components/formikValidationSchema';
 import { ConceptShape, LicensesArrayOf, SubjectShape } from '../../../shapes';
 import SaveButton from '../../../components/SaveButton';
 import { toEditConcept } from '../../../util/routeHelpers.js';
-import { nullOrUndefined } from '../../../util/articleUtil';
 import EditorFooter from '../../../components/SlateEditor/EditorFooter';
 import * as articleStatuses from '../../../util/constants/ArticleStatus';
 import FormikField from '../../../components/FormikField';

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -50,6 +50,7 @@ import ConceptArticles from './ConceptArticles';
 const getInitialValues = (concept = {}, subjects = []) => {
   const visualElement = parseEmbedTag(concept.visualElement?.visualElement);
   const metaImageId = parseImageUrl(concept.metaImage);
+
   return {
     id: concept.id,
     title: concept.title || '',

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -147,13 +147,6 @@ class ConceptForm extends Component {
 
   getConcept = values => {
     const { licenses } = this.props;
-    const metaImage = values?.metaImageId
-      ? {
-          id: values.metaImageId,
-          alt: values.metaImageAlt,
-        }
-      : nullOrUndefined(values?.metaImageId);
-
     return {
       id: values.id,
       title: values.title,
@@ -174,7 +167,6 @@ class ConceptForm extends Component {
       tags: values.tags,
       created: this.getCreatedDate(values),
       articleIds: values.articleIds,
-      metaImage,
       visualElement: values.visualElement,
     };
   };

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -48,7 +48,6 @@ import ConceptArticles from './ConceptArticles';
 
 const getInitialValues = (concept = {}, subjects = []) => {
   const metaImageId = parseImageUrl(concept.metaImage);
-  console.log(concept);
 
   return {
     id: concept.id,

--- a/src/containers/ConceptPage/components/ConceptForm.jsx
+++ b/src/containers/ConceptPage/components/ConceptForm.jsx
@@ -50,7 +50,6 @@ import ConceptArticles from './ConceptArticles';
 const getInitialValues = (concept = {}, subjects = []) => {
   const visualElement = parseEmbedTag(concept.visualElement?.visualElement);
   const metaImageId = parseImageUrl(concept.metaImage);
-
   return {
     id: concept.id,
     title: concept.title || '',
@@ -175,6 +174,8 @@ class ConceptForm extends Component {
         rightsholders: values.rightsholders,
         agreementId: values.agreementId,
       },
+      metaImageAlt: values.metaImageAlt,
+      metaImageId: values.metaImageId,
       source: values.source,
       subjectIds: values.subjects.map(subject => subject.id),
       tags: values.tags,
@@ -216,6 +217,7 @@ class ConceptForm extends Component {
       this.setState({ savedToServer: false });
       return;
     }
+
     try {
       if (statusChange) {
         // if editor is not dirty, OR we are unpublishing, we don't save before changing status

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,6 +75,7 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
+    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,11 +75,9 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
-    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );
-    console.log(savedConcept);
 
     setConcept(
       transformApiToFormikVersion(

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,9 +75,12 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
+    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );
+    console.log(transformFormikToUpdatedApiVersion(updatedConcept, locale));
+    console.log(savedConcept);
 
     setConcept(
       transformApiToFormikVersion(

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,12 +75,9 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
-    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );
-    console.log(transformFormikToUpdatedApiVersion(updatedConcept, locale));
-    console.log(savedConcept);
 
     setConcept(
       transformApiToFormikVersion(

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,9 +75,12 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
+    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );
+    console.log(savedConcept);
+
     setConcept(
       transformApiToFormikVersion(
         savedConcept,

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -75,7 +75,6 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const updateConcept = async (
     updatedConcept: ConceptFormikType,
   ): Promise<ConceptApiType> => {
-    console.log(updatedConcept);
     const savedConcept = await conceptApi.updateConcept(
       transformFormikToUpdatedApiVersion(updatedConcept, locale),
     );

--- a/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
@@ -38,7 +38,7 @@ import usePreventWindowUnload from '../../FormikForm/preventWindowUnloadHook';
 import Spinner from '../../../components/Spinner';
 
 export const getInitialValues = (article = {}) => {
-  const metaImageId = parseImageUrl(article.metaImage) || article.metaImage?.id;
+  const metaImageId = parseImageUrl(article.metaImage);
   return {
     agreementId: article.copyright ? article.copyright.agreementId : undefined,
     articleType: 'standard',

--- a/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
@@ -38,7 +38,7 @@ import usePreventWindowUnload from '../../FormikForm/preventWindowUnloadHook';
 import Spinner from '../../../components/Spinner';
 
 export const getInitialValues = (article = {}) => {
-  const metaImageId = parseImageUrl(article.metaImage);
+  const metaImageId = parseImageUrl(article.metaImage) || article.metaImage?.id;
   return {
     agreementId: article.copyright ? article.copyright.agreementId : undefined,
     articleType: 'standard',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,7 +17,7 @@ export interface TranslateType {
   ): string;
 }
 
-interface Author {
+export interface Author {
   name: string;
   type: string;
 }

--- a/src/modules/concept/conceptApiInterfaces.ts
+++ b/src/modules/concept/conceptApiInterfaces.ts
@@ -150,10 +150,7 @@ export interface ConceptFormikType {
   source?: string;
   metaImageId?: string;
   metaImageAlt?: string;
-  tags?: {
-    tags: string[];
-    language: string;
-  };
+  tags?: string[];
   subjectIds?: string[];
   created: string;
   updated: string;

--- a/src/modules/concept/conceptApiInterfaces.ts
+++ b/src/modules/concept/conceptApiInterfaces.ts
@@ -6,7 +6,12 @@
  *
  */
 
-import { ArticleType, Copyright, Status } from '../../interfaces';
+import {
+  ArticleType,
+  Copyright,
+  Status,
+  VisualElement,
+} from '../../interfaces';
 
 export enum ConceptStatusType {
   DRAFT,
@@ -156,10 +161,7 @@ export interface ConceptFormikType {
   supportedLanguages: string[];
   articleIds: ArticleType[];
   status: Status;
-  visualElement?: {
-    visualElement: string;
-    language: string;
-  };
+  visualElement?: VisualElement;
 }
 
 export interface ConceptStatusStateMashineType {

--- a/src/modules/concept/conceptApiInterfaces.ts
+++ b/src/modules/concept/conceptApiInterfaces.ts
@@ -11,6 +11,7 @@ import {
   Copyright,
   Status,
   VisualElement,
+  Author,
 } from '../../interfaces';
 
 export enum ConceptStatusType {
@@ -138,15 +139,18 @@ export interface UpdatedConceptType {
 export interface ConceptFormikType {
   id: number;
   revision: number;
-  title?: {
-    title: string;
-    language: string;
+  title?: string;
+  content?: string;
+  license: {
+    license: string;
+    description?: string;
+    url?: string;
   };
-  content?: {
-    content: string;
-    language: string;
-  };
-  copyright?: Copyright;
+  language: string;
+  creators: Author[];
+  processors: Author[];
+  rightsholders: Author[];
+  agreementId?: number;
   source?: string;
   metaImageId?: string;
   metaImageAlt?: string;

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -131,7 +131,7 @@ export const ConceptShape = PropTypes.shape({
   id: PropTypes.number,
   title: PropTypes.string,
   content: PropTypes.string,
-  articleIds: PropTypes.arrayOf(PropTypes.number),
+  articleIds: PropTypes.arrayOf(PropTypes.object),
 });
 
 export const ImageShape = PropTypes.shape({

--- a/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
+++ b/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`transformApiToFormikVersion 1`] = `
 Object {
-  "articleIds": undefined,
+  "articleIds": Array [],
   "content": "Beskrivelse av testforklaring.",
   "copyright": Object {
     "creators": Array [
@@ -21,9 +21,23 @@ Object {
     "rightsholders": Array [],
   },
   "created": "2013-02-26T11:06:14Z",
+  "creators": Array [
+    Object {
+      "name": "Ragna Marie Tørdal",
+      "type": "Writer",
+    },
+  ],
   "id": 400,
+  "language": "nb",
+  "license": Object {
+    "description": "Creative Commons Attribution-ShareAlike 4.0 International",
+    "license": "CC-BY-SA-4.0",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/",
+  },
   "metaImageAlt": "",
   "metaImageId": "",
+  "processors": Array [],
+  "rightsholders": Array [],
   "supportedLanguages": Array [
     "nb",
     "nn",

--- a/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
+++ b/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transformConceptFromApiVersion 1`] = `
+exports[`transformApiToFormikVersion 1`] = `
 Object {
   "articleIds": undefined,
   "content": "Beskrivelse av testforklaring.",
@@ -30,5 +30,13 @@ Object {
   "tags": Array [],
   "title": "Testforklaring",
   "updated": "2019-05-15T08:45:46Z",
+  "visualElement": Object {
+    "align": "",
+    "alt": "Test data alt",
+    "caption": "",
+    "resource": "image",
+    "resource_id": "1234",
+    "size": "fullbredde",
+  },
 }
 `;

--- a/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
+++ b/src/util/__tests__/__snapshots__/conceptUtil-test.js.snap
@@ -22,6 +22,8 @@ Object {
   },
   "created": "2013-02-26T11:06:14Z",
   "id": 400,
+  "metaImageAlt": "",
+  "metaImageId": "",
   "supportedLanguages": Array [
     "nb",
     "nn",

--- a/src/util/__tests__/conceptMocks.js
+++ b/src/util/__tests__/conceptMocks.js
@@ -20,31 +20,9 @@ export const apiConcept = {
   updated: '2019-05-15T08:45:46Z',
   supportedLanguages: ['nb', 'nn', 'en'],
   articleIds: [],
-};
-
-export const transformedConcept = {
-  content: 'Beskrivelse av testforklaring.',
-  copyright: {
-    creators: [
-      {
-        name: 'Ragna Marie Tørdal',
-        type: 'Writer',
-      },
-    ],
-    license: {
-      description: 'Creative Commons Attribution-ShareAlike 4.0 International',
-      license: 'CC-BY-SA-4.0',
-      url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-    },
-    origin: '',
-    processors: [],
-    rightsholders: [],
+  visualElement: {
+    visualElement:
+      '<embed data-resource="image" data-resource_id="1234" data-size="fullbredde" data-align="" data-alt="Test data alt" data-caption="">',
+    language: 'nb',
   },
-  created: '2013-02-26T11:06:14Z',
-  id: 400,
-  published: '2019-01-16T12:30:04Z',
-  supportedLanguages: ['nb', 'nn', 'en'],
-  title: 'Testforklaring',
-  updated: '2019-05-15T08:45:46Z',
-  articleIds: [],
 };

--- a/src/util/__tests__/conceptUtil-test.js
+++ b/src/util/__tests__/conceptUtil-test.js
@@ -2,6 +2,6 @@ import { transformApiToFormikVersion } from '../conceptUtil';
 import { apiConcept } from './conceptMocks';
 
 test('transformApiToFormikVersion', () => {
-  const transformed = transformApiToFormikVersion(apiConcept);
+  const transformed = transformApiToFormikVersion(apiConcept, 'nb', []);
   expect(transformed).toMatchSnapshot();
 });

--- a/src/util/__tests__/conceptUtil-test.js
+++ b/src/util/__tests__/conceptUtil-test.js
@@ -1,7 +1,7 @@
 import { transformApiToFormikVersion } from '../conceptUtil';
 import { apiConcept } from './conceptMocks';
 
-test('transformConceptFromApiVersion', () => {
+test('transformApiToFormikVersion', () => {
   const transformed = transformApiToFormikVersion(apiConcept);
   expect(transformed).toMatchSnapshot();
 });

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -56,7 +56,7 @@ export const transformFormikToUpdatedApiVersion = (
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   status: concept.status?.current,
-  visualElement: createEmbedTag(concept.visualElement) || '',
+  visualElement: createEmbedTag(concept.visualElement),
 });
 
 export const transformFormikToNewApiVersion = (
@@ -78,7 +78,7 @@ export const transformFormikToNewApiVersion = (
   tags: concept.tags,
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
-  visualElement: createEmbedTag(concept.visualElement) || '',
+  visualElement: createEmbedTag(concept.visualElement),
 });
 
 export const transformApiToPreviewVersion = (

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import isEmpty from 'lodash/fp/isEmpty';
 import { ArticleType, VisualElement, ConceptPreviewType } from '../interfaces';
 import {
   ConceptApiType,

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -56,7 +56,7 @@ export const transformFormikToUpdatedApiVersion = (
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   status: concept.status?.current,
-  visualElement: createEmbedTag(concept.visualElement),
+  visualElement: createEmbedTag(concept.visualElement || {}),
 });
 
 export const transformFormikToNewApiVersion = (
@@ -78,7 +78,7 @@ export const transformFormikToNewApiVersion = (
   tags: concept.tags,
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
-  visualElement: createEmbedTag(concept.visualElement),
+  visualElement: createEmbedTag(concept.visualElement || {}),
 });
 
 export const transformApiToPreviewVersion = (

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -16,7 +16,7 @@ import {
 } from '../modules/concept/conceptApiInterfaces';
 import { convertFieldWithFallback } from './convertFieldWithFallback';
 import { createEmbedTag, parseEmbedTag } from './embedTagHelpers';
-import { parseImageUrl } from './formHelper';
+import { parseImageUrl, parseCopyrightContributors } from './formHelper';
 import { nullOrUndefined } from './articleUtil';
 
 export const transformApiToFormikVersion = (
@@ -26,6 +26,11 @@ export const transformApiToFormikVersion = (
 ): ConceptFormikType => ({
   ...concept,
   articleIds,
+  language: language,
+  creators: parseCopyrightContributors(concept, 'creators'),
+  rightsholders: parseCopyrightContributors(concept, 'rightsholders'),
+  processors: parseCopyrightContributors(concept, 'processors'),
+  license: concept.copyright?.license || { license: '' },
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
   tags: convertFieldWithFallback(concept, 'tags', []),
@@ -50,7 +55,13 @@ export const transformFormikToUpdatedApiVersion = (
           alt: concept.metaImageAlt,
         }
       : nullOrUndefined(concept?.metaImageId),
-  copyright: concept.copyright,
+  copyright: {
+    license: concept.license,
+    creators: concept.creators,
+    processors: concept.processors,
+    rightsholders: concept.rightsholders,
+    agreementId: concept.agreementId,
+  },
   source: concept.source,
   tags: concept.tags,
   subjectIds: concept.subjectIds,
@@ -73,7 +84,13 @@ export const transformFormikToNewApiVersion = (
           alt: concept.metaImageAlt,
         }
       : nullOrUndefined(concept?.metaImageId),
-  copyright: concept.copyright,
+  copyright: {
+    license: concept.license,
+    creators: concept.creators,
+    processors: concept.processors,
+    rightsholders: concept.rightsholders,
+    agreementId: concept.agreementId,
+  },
   source: concept.source,
   tags: concept.tags,
   subjectIds: concept.subjectIds,
@@ -97,5 +114,30 @@ export const transformApiToPreviewVersion = (
     visualElement,
     language,
     metaImage,
+  };
+};
+
+export const transformFormikToPreviewVersion = (
+  concept: ConceptFormikType,
+): ConceptPreviewType => {
+  return {
+    id: concept.id,
+    title: concept.title,
+    tags: concept.tags || [],
+    content: concept.content,
+    copyright: {
+      license: concept.license,
+      creators: concept.creators,
+      processors: concept.processors,
+      rightsholders: concept.rightsholders,
+      agreementId: concept.agreementId,
+    },
+    language: concept.language,
+    supportedLanguages: concept.supportedLanguages,
+    articleIds: concept.articleIds.map(article => article.id),
+    created: concept.created,
+    source: concept.source,
+    subjectIds: concept.subjectIds || [],
+    visualElement: concept.visualElement,
   };
 };

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -18,6 +18,7 @@ import {
 import { convertFieldWithFallback } from './convertFieldWithFallback';
 import { createEmbedTag, parseEmbedTag } from './embedTagHelpers';
 import { parseImageUrl } from './formHelper';
+import { nullOrUndefined } from './articleUtil';
 
 export const transformApiToFormikVersion = (
   concept: ConceptApiType,
@@ -43,13 +44,13 @@ export const transformFormikToUpdatedApiVersion = (
   language: language,
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
-  ...(concept.metaImageId &&
-    concept.metaImageAlt && {
-      metaImage: {
-        id: concept.metaImageId,
-        alt: concept.metaImageAlt,
-      },
-    }),
+  metaImage:
+    concept.metaImageId && concept.metaImageAlt
+      ? {
+          id: concept.metaImageId,
+          alt: concept.metaImageAlt,
+        }
+      : nullOrUndefined(concept?.metaImageId),
   copyright: concept.copyright,
   source: concept.source,
   tags: concept.tags,

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -57,9 +57,7 @@ export const transformFormikToUpdatedApiVersion = (
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   status: concept.status?.current,
-  visualElement: createEmbedTag(
-    isEmpty(concept.visualElement) ? {} : concept.visualElement,
-  ),
+  visualElement: createEmbedTag(concept.visualElement) || '',
 });
 
 export const transformFormikToNewApiVersion = (
@@ -81,9 +79,7 @@ export const transformFormikToNewApiVersion = (
   tags: concept.tags,
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
-  visualElement: createEmbedTag(
-    isEmpty(concept.visualElement) ? {} : concept.visualElement,
-  ),
+  visualElement: createEmbedTag(concept.visualElement) || '',
 });
 
 export const transformApiToPreviewVersion = (

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import isEmpty from 'lodash/fp/isEmpty';
 import { ArticleType, VisualElement, ConceptPreviewType } from '../interfaces';
 import {
   ConceptApiType,
@@ -15,6 +16,7 @@ import {
   PreviewMetaImage as ConceptPreviewMetaImage,
 } from '../modules/concept/conceptApiInterfaces';
 import { convertFieldWithFallback } from './convertFieldWithFallback';
+import { createEmbedTag, parseEmbedTag } from './embedTagHelpers';
 
 export const transformApiToFormikVersion = (
   concept: ConceptApiType,
@@ -26,6 +28,7 @@ export const transformApiToFormikVersion = (
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
   tags: convertFieldWithFallback(concept, 'tags', []),
+  visualElement: parseEmbedTag(concept.visualElement?.visualElement),
   ...(language ? { language: language } : {}),
 });
 
@@ -34,6 +37,12 @@ export const transformFormikToApiVersion = (
 ): ConceptApiType => ({
   ...concept,
   articleIds: concept.articleIds.map(article => article.id),
+  visualElement: concept.visualElement && {
+    visualElement: createEmbedTag(
+      isEmpty(concept.visualElement) ? {} : concept.visualElement,
+    ),
+    language: concept.visualElement?.metaData?.language,
+  },
 });
 
 export const transformFormikToUpdatedApiVersion = (
@@ -57,7 +66,9 @@ export const transformFormikToUpdatedApiVersion = (
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   status: concept.status?.current,
-  visualElement: concept.visualElement?.visualElement,
+  visualElement: createEmbedTag(
+    isEmpty(concept.visualElement) ? {} : concept.visualElement,
+  ),
 });
 
 export const transformFormikToNewApiVersion = (
@@ -79,7 +90,9 @@ export const transformFormikToNewApiVersion = (
   tags: convertFieldWithFallback(concept, 'tags', []),
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
-  visualElement: concept.visualElement?.visualElement,
+  visualElement: createEmbedTag(
+    isEmpty(concept.visualElement) ? {} : concept.visualElement,
+  ),
 });
 
 export const transformApiToPreviewVersion = (

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -17,6 +17,7 @@ import {
 } from '../modules/concept/conceptApiInterfaces';
 import { convertFieldWithFallback } from './convertFieldWithFallback';
 import { createEmbedTag, parseEmbedTag } from './embedTagHelpers';
+import { parseImageUrl } from './formHelper';
 
 export const transformApiToFormikVersion = (
   concept: ConceptApiType,
@@ -28,21 +29,10 @@ export const transformApiToFormikVersion = (
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
   tags: convertFieldWithFallback(concept, 'tags', []),
+  metaImageId: parseImageUrl(concept.metaImage),
+  metaImageAlt: concept.metaImage?.alt || '',
   visualElement: parseEmbedTag(concept.visualElement?.visualElement),
   ...(language ? { language: language } : {}),
-});
-
-export const transformFormikToApiVersion = (
-  concept: ConceptFormikType,
-): ConceptApiType => ({
-  ...concept,
-  articleIds: concept.articleIds.map(article => article.id),
-  visualElement: concept.visualElement && {
-    visualElement: createEmbedTag(
-      isEmpty(concept.visualElement) ? {} : concept.visualElement,
-    ),
-    language: concept.visualElement?.metaData?.language,
-  },
 });
 
 export const transformFormikToUpdatedApiVersion = (
@@ -62,7 +52,7 @@ export const transformFormikToUpdatedApiVersion = (
     }),
   copyright: concept.copyright,
   source: concept.source,
-  tags: convertFieldWithFallback(concept, 'tags', []),
+  tags: concept.tags,
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   status: concept.status?.current,

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -77,7 +77,7 @@ export const transformFormikToNewApiVersion = (
     }),
   copyright: concept.copyright,
   source: concept.source,
-  tags: convertFieldWithFallback(concept, 'tags', []),
+  tags: concept.tags,
   subjectIds: concept.subjectIds,
   articleIds: concept.articleIds.map(article => article.id),
   visualElement: createEmbedTag(

--- a/src/util/conceptUtil.ts
+++ b/src/util/conceptUtil.ts
@@ -69,13 +69,13 @@ export const transformFormikToNewApiVersion = (
   language: language,
   title: convertFieldWithFallback(concept, 'title', ''),
   content: convertFieldWithFallback(concept, 'content', ''),
-  ...(concept.metaImageId &&
-    concept.metaImageAlt && {
-      metaImage: {
-        id: concept.metaImageId,
-        alt: concept.metaImageAlt,
-      },
-    }),
+  metaImage:
+    concept.metaImageId && concept.metaImageAlt
+      ? {
+          id: concept.metaImageId,
+          alt: concept.metaImageAlt,
+        }
+      : nullOrUndefined(concept?.metaImageId),
   copyright: concept.copyright,
   source: concept.source,
   tags: concept.tags,

--- a/src/util/formHelper.js
+++ b/src/util/formHelper.js
@@ -223,7 +223,7 @@ export const ndlaFilmRules = {
 
 export const parseImageUrl = metaImage => {
   if (!metaImage || !metaImage.url || metaImage.url.length === 0) {
-    if (metaImage.id) {
+    if (metaImage?.id) {
       return metaImage.id;
     }
     return '';

--- a/src/util/formHelper.js
+++ b/src/util/formHelper.js
@@ -223,6 +223,9 @@ export const ndlaFilmRules = {
 
 export const parseImageUrl = metaImage => {
   if (!metaImage || !metaImage.url || metaImage.url.length === 0) {
+    if (metaImage.id) {
+      return metaImage.id;
+    }
     return '';
   }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2385
Fixes NDLANO/Issues#2412

Et problem i artikkel/forklaring-form gjorde at metabilde alt-tekst forsvant dersom man endret status to ganger på rad. Det eksisterte fortsatt i databasen og dukket opp igjen ved refresh. Dette er nå løst ved at parseImageUrl returnerer imageId som en fallback dersom url'en allerede har blitt parset.

Denne PRen fikser også feil nevnt i NDLANO/Issues#2412. Det skal nå være mulig å opprette forklaring igjen.

How to test:
1. Sjekk at metabilde kan legges til, redigeres og fjernes.
2. Sjekk at metabilde alt-tekst ikke forsvinner dersom du endre status to ganger på rad.
3. Sjekk at andre felter fortsatt fungerer både å opprette ved ny forklaring og endring/fjerning av felt på eksisterende forklaring.
4. Forklaring skal kunne opprettes.

Sider som kan brukes til testing:
https://editorial-frontend-pr-871.ndla.sh/concept/746/edit/nb
https://editorial-frontend-pr-871.ndla.sh/subject-matter/topic-article/22745/edit/nb
https://editorial-frontend-pr-871.ndla.sh/subject-matter/learning-resource/22741/edit/nb



~Ser at det er problemer med metaImage i /concept også. Der blir ikke bildet lagret i det heletatt. Prøver å løse det nå.~ fixed