### PR TITLE
Add link to brightcove. Some languagelaundry.

### DIFF
--- a/src/components/SlateEditor/plugins/embed/FigureButtons.tsx
+++ b/src/components/SlateEditor/plugins/embed/FigureButtons.tsx
@@ -14,6 +14,7 @@ import { spacing } from '@ndla/core';
 import { Link as LinkIcon } from '@ndla/icons/common';
 import { DeleteForever } from '@ndla/icons/editor';
 import { injectT, tType } from '@ndla/i18n';
+import SafeLink from '@ndla/safelink';
 import { Link } from 'react-router-dom';
 import IconButton from '../../../IconButton';
 import { Embed } from '../../../../interfaces';
@@ -127,6 +128,18 @@ const FigureButtons: React.FC<Props & tType> = ({
           })}
           align="right">
           <IconButton type="button" tabIndex={-1} onClick={onEdit}>
+            <LinkIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+      {figureType === 'video' && embed.resource === 'brightcove' && (
+        <Tooltip tooltip={t('form.video.brightcove')} align="right">
+          <IconButton
+            as={SafeLink}
+            to={`https://studio.brightcove.com/products/videocloud/media/videos/${embed.videoid}`}
+            target="_blank"
+            title={t('form.video.brightcove')}
+            tabIndex={-1}>
             <LinkIcon />
           </IconButton>
         </Tooltip>

--- a/src/phrases/phrases-en.js
+++ b/src/phrases/phrases-en.js
@@ -867,6 +867,7 @@ const phrases = {
         stop: 'Stop',
         hms: 'h:m:s',
       },
+      brightcove: 'Open in Brightcove',
     },
     audio: {
       file: 'Audio file',

--- a/src/phrases/phrases-nb.js
+++ b/src/phrases/phrases-nb.js
@@ -876,6 +876,7 @@ const phrases = {
         stop: 'Stopp',
         hms: 'h:m:s',
       },
+      brightcove: 'Åpne i Brightcove',
     },
     audio: {
       file: 'Lydfil',
@@ -966,7 +967,7 @@ const phrases = {
     dateBeforeInvalid: '{label} kan ikke være etter {afterLabel}.',
     dateAfterInvalid: '{label} kan ikke være før {beforeLabel}.',
     minItems:
-      '{label} feltet må minst inneholde {minItems, plural, one{en} other{# ulike}} {labelLowerCase}.',
+      '{label} feltet må minst inneholde {minItems, plural, one{en/ett} other{# ulike}} {labelLowerCase}.',
     noEmptyNote: 'En merknad kan ikke være tom',
     grepCodes:
       'Koden er på feil format. Det korrekte formatet er K(E/M) eller TT fulgt av ett eller flere siffer. Eks. KE137, KM2255, TT2',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -962,7 +962,7 @@ const phrases = {
     dateBeforeInvalid: '{label} kan ikkje være etter {afterLabel}.',
     dateAfterInvalid: '{label} kan ikkje være før {beforeLabel}.',
     minItems:
-      '{label} feltet må minst inneholde {minItems, plural, one{ein/eit} other{# ulike}} {labelLowerCase}.',
+      '{label} feltet må minst inneholde {minItems, plural, one{ein/eitt} other{# ulike}} {labelLowerCase}.',
     noEmptyNote: 'Ein merknad kan ikkje være tom',
     grepCodes:
       'Koden er på feil format. Det korrekte formatet er K(E/M) eller TT fulgt av eit eller fleire siffer. Eks. KE137, KM2255, TT2.',

--- a/src/phrases/phrases-nn.js
+++ b/src/phrases/phrases-nn.js
@@ -593,7 +593,7 @@ const phrases = {
       translate: 'Oversett til nynorsk',
     },
     remainingCharacters:
-      'Maks {maxLength, number} tegn og du har {remaining, number} igjen.',
+      'Maks {maxLength, number} teikn og du har {remaining, number} igjen.',
     title: {
       label: 'Tittel',
     },
@@ -885,6 +885,7 @@ const phrases = {
         stop: 'Stopp',
         hms: 'h:m:s',
       },
+      brightcove: 'Åpne i Brightcove',
     },
     audio: {
       file: 'Lydfil',
@@ -952,16 +953,16 @@ const phrases = {
   },
   validation: {
     isRequired: '{label} er påkrevd.',
-    bothFields: 'En {labelLowerCase} må inneholde alle felter.',
+    bothFields: 'Ein {labelLowerCase} må inneholde alle felt.',
     isNumeric: '{label} må inneholde tall.',
-    maxLength: '{label} kan ikkje ha meir enn {maxLength, number} tegn.',
-    minLength: '{label} må ha minst {minLength, number} tegn.',
+    maxLength: '{label} kan ikkje ha meir enn {maxLength, number} teikn.',
+    minLength: '{label} må ha minst {minLength, number} teikn.',
     url: '{label} må inneholde ei gyldig lenke.',
     urlOrNumber: '{label} må inneholde ei gyldig lenke eller artikkel-id.',
     dateBeforeInvalid: '{label} kan ikkje være etter {afterLabel}.',
     dateAfterInvalid: '{label} kan ikkje være før {beforeLabel}.',
     minItems:
-      '{label} feltet må minst inneholde {minItems, plural, one{en} other{# ulike}} {labelLowerCase}.',
+      '{label} feltet må minst inneholde {minItems, plural, one{ein/eit} other{# ulike}} {labelLowerCase}.',
     noEmptyNote: 'Ein merknad kan ikkje være tom',
     grepCodes:
       'Koden er på feil format. Det korrekte formatet er K(E/M) eller TT fulgt av eit eller fleire siffer. Eks. KE137, KM2255, TT2.',


### PR DESCRIPTION
Fixes NDLANO/Issues#2415 

Legger på lenke til brightcove for redigering av video.

Tst:
Lag eller rediger artikkel. Legg til video og velg en video fra brightcove. Lagre artikkelen.
Videoen skal ha et lenke-ikon under slett-ikonet og når du klikker på det skal du komme til brightcove.