### PR TITLE
2379: Fixing bug where CreateConcept always sends initialConcept to ConceptForm

### DIFF
--- a/src/containers/ConceptPage/CreateConcept.jsx
+++ b/src/containers/ConceptPage/CreateConcept.jsx
@@ -29,6 +29,7 @@ const CreateConcept = props => {
   } = props;
   const {
     subjects,
+    concept,
     createConcept,
     fetchStatusStateMachine,
     fetchSearchTags,
@@ -48,7 +49,7 @@ const CreateConcept = props => {
     <Fragment>
       <HelmetWithTracker title={t(`conceptform.title`)} />
       <ConceptForm
-        concept={{ ...initialConcept, language: locale }}
+        concept={concept ? concept : { ...initialConcept, language: locale }}
         locale={locale}
         onUpdate={createConceptAndPushRoute}
         fetchStateStatuses={fetchStatusStateMachine}


### PR DESCRIPTION
Fixes NDLANO/Issues#2379 (forhåpentlig vis)

Fikser slik at `CreateConcept` sjekker om man har lokale verdier i `concept` slik at det ikke sendes inn `initialConcept` ved rerender om man har gjort endringer.