### PR TITLE
Stripping formatting on paste and pasting plain text

### DIFF
--- a/src/components/SlateEditor/plugins/pastehandler/index.js
+++ b/src/components/SlateEditor/plugins/pastehandler/index.js
@@ -14,7 +14,7 @@ function pasteHandler() {
     onPaste(event, editor, next) {
       const transfer = getEventTransfer(event);
       if (transfer.type === 'fragment') {
-        return editor.insertText(transfer.text)
+        return editor.insertText(transfer.text);
       }
       return next();
     },

--- a/src/components/SlateEditor/plugins/pastehandler/index.js
+++ b/src/components/SlateEditor/plugins/pastehandler/index.js
@@ -7,7 +7,6 @@
  */
 
 import { getEventTransfer } from 'slate-react';
-import { getTopNode } from '../DND/utils';
 
 function pasteHandler() {
   return {
@@ -15,17 +14,7 @@ function pasteHandler() {
     onPaste(event, editor, next) {
       const transfer = getEventTransfer(event);
       if (transfer.type === 'fragment') {
-        const target = editor.findNode(event.target);
-        const topLevelTarget = getTopNode(target, editor);
-        if (topLevelTarget.type === 'paragraph') {
-          if (topLevelTarget.text === '') {
-            // Only support pasting fragment into empty p for now
-            return editor.insertFragmentByKey(topLevelTarget.key, 0, transfer.fragment);
-          } else {
-            // Extract text and append to p
-            return editor.insertText(transfer.text);
-          }
-        }
+        return editor.insertText(transfer.text)
       }
       return next();
     },


### PR DESCRIPTION
Fixes NDLANO/Issues#2401
Skriver om pasteHandler til å strippe vekk formatering og bare lime inn ren-tekst for consistency.

Hvordan teste:
Prøv å paste tekst fra forskjellige kilder (tabelller, bokser, etc) inn i ed elementer (tekstfelt, ekspanderende boks, tabell, etc) og sjekk at det bare pastes ren tekst og ikke formateringer. 