### PR TITLE
Bugfix: Alt text for image search results

### DIFF
--- a/src/containers/SearchPage/components/results/SearchImage.jsx
+++ b/src/containers/SearchPage/components/results/SearchImage.jsx
@@ -17,7 +17,7 @@ import { searchClasses } from '../../SearchContainer';
 const SearchImage = ({ image, locale, t }) => (
   <div {...searchClasses('result')}>
     <div {...searchClasses('image')}>
-      <img src={image.previewUrl + '?width=200'} alt={image.altText} />
+      <img src={image.previewUrl + '?width=200'} alt={image.altText?.alttext} />
     </div>
     <div {...searchClasses('content')}>
       <Link to={toEditImage(image.id, image.title.language)}>

--- a/src/containers/SearchPage/components/results/SearchImage.jsx
+++ b/src/containers/SearchPage/components/results/SearchImage.jsx
@@ -17,7 +17,7 @@ import { searchClasses } from '../../SearchContainer';
 const SearchImage = ({ image, locale, t }) => (
   <div {...searchClasses('result')}>
     <div {...searchClasses('image')}>
-      <img src={image.previewUrl + '?width=200'} alt={image.altText?.alttext} />
+      <img src={image.previewUrl + '?width=200'} alt={image.altText.alttext} />
     </div>
     <div {...searchClasses('content')}>
       <Link to={toEditImage(image.id, image.title.language)}>


### PR DESCRIPTION
Alt-tekst på bilder i bildesøk blir vist som `"[Object, object]"`. Bruker image-api nå og ikke search-api og alt-tekst er visst strukturert noe annerledes.

Test:
1. Gjør et bildesøk /search/image?page=1&page-size=10&sort=-relevance
2. Se at bildene har fått satt en streng som alt-tekst og ikke object.