### PR TITLE
Replace license text with icons

### DIFF
--- a/src/containers/SearchPage/components/results/SearchConcept/ContentView.jsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/ContentView.jsx
@@ -9,6 +9,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@ndla/button';
+import { LicenseByline, getLicenseByAbbreviation } from '@ndla/licenses';
+import { colors } from '@ndla/core';
 import { css } from '@emotion/core';
 import {
   StyledInfo,
@@ -73,9 +75,11 @@ const ContentView = ({
       </div>
       <StyledDescription>{content}</StyledDescription>
       {license && (
-        <StyledDescription>
-          {t('form.name.license')}: {license.description}
-        </StyledDescription>
+        <LicenseByline
+          licenseRights={getLicenseByAbbreviation(license.license, locale).rights}
+          locale={locale}
+          color={colors.brand.grey}
+        />
       )}
       <StyledBreadcrumbs>
         {breadcrumbs?.map(breadcrumb => <Crumb key={breadcrumb.id}>{breadcrumb.name}</Crumb>) || (

--- a/src/containers/SearchPage/components/results/SearchConcept/SearchStyles.jsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/SearchStyles.jsx
@@ -98,7 +98,6 @@ export const Crumb = styled.p`
 
 export const StyledBreadcrumbs = styled.div`
   display: flex;
-  margin-top: -20px;
 `;
 
 export const InputField = styled.div`


### PR DESCRIPTION
Fixes NDLANO/Issues#2440

Test:
* https://editorial-frontend-pr-892.ndla.sh/search/concept?page=1&page-size=10&sort=-lastUpdated
* Lisenstekst skal være byttet ut med ikoner. Se at dette ser riktig ut
