### PR TITLE
Fix focus traps for metadata.

### DIFF
--- a/src/containers/EditSubjectFrontpage/components/SubjectpageAbout.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageAbout.tsx
@@ -8,15 +8,17 @@
 import React, { FC } from 'react';
 import { injectT, tType } from '@ndla/i18n';
 import { FieldProps } from 'formik';
+import { Editor } from 'slate';
 import FormikField from '../../../components/FormikField';
 import FormikVisualElement from '../../FormikForm/components/FormikVisualElement';
 import PlainTextEditor from '../../../components/SlateEditor/PlainTextEditor';
 
 interface Props {
   handleSubmit: () => void;
+  onBlur: (event: Event, editor: Editor, next: Function) => void;
 }
 
-const SubjectpageAbout: FC<Props & tType> = ({ t, handleSubmit }) => {
+const SubjectpageAbout: FC<Props & tType> = ({ t, handleSubmit, onBlur }) => {
   return (
     <>
       <FormikField name="title" noBorder title placeholder={t('form.name.title')} />
@@ -32,6 +34,7 @@ const SubjectpageAbout: FC<Props & tType> = ({ t, handleSubmit }) => {
             {...field}
             placeholder={t('subjectpageForm.description')}
             handleSubmit={handleSubmit}
+            onBlur={onBlur}
           />
         )}
       </FormikField>

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
@@ -8,6 +8,7 @@ import React, { FC, Fragment } from 'react';
 import Accordion, { AccordionWrapper, AccordionBar, AccordionPanel } from '@ndla/accordion';
 import { injectT, tType } from '@ndla/i18n';
 import { FormikErrors } from 'formik';
+import { Editor } from 'slate';
 import SubjectpageAbout from './SubjectpageAbout';
 import SubjectpageMetadata from './SubjectpageMetadata';
 import SubjectpageArticles from './SubjectpageArticles';
@@ -20,6 +21,7 @@ interface Props {
   elementId: string;
   errors: FormikErrors<Values>;
   handleSubmit: () => void;
+  onBlur: (event: Event, editor: Editor, next: Function) => void;
 }
 
 interface ComponentProps {
@@ -33,9 +35,13 @@ const panels = [
     title: 'subjectpageForm.about',
     className: 'u-4/6@desktop u-push-1/6@desktop',
     errorFields: ['title', 'description', 'visualElement'],
-    component: ({ handleSubmit }: { handleSubmit: () => void }) => (
-      <SubjectpageAbout handleSubmit={handleSubmit} />
-    ),
+    component: ({
+      handleSubmit,
+      onBlur,
+    }: {
+      handleSubmit: () => void;
+      onBlur: (event: any, editor: any, next: any) => void;
+    }) => <SubjectpageAbout handleSubmit={handleSubmit} onBlur={onBlur} />,
   },
   {
     id: 'metadata',
@@ -72,6 +78,7 @@ const SubjectpageAccordionPanels: FC<Props & tType> = ({
   elementId,
   errors,
   handleSubmit,
+  onBlur,
 }) => {
   return (
     <Accordion openIndexes={['about']}>
@@ -99,6 +106,7 @@ const SubjectpageAccordionPanels: FC<Props & tType> = ({
                         editorsChoices,
                         elementId,
                         handleSubmit,
+                        onBlur,
                       })}
                     </div>
                   </AccordionPanel>

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
@@ -40,7 +40,7 @@ const panels = [
       onBlur,
     }: {
       handleSubmit: () => void;
-      onBlur: (event: any, editor: any, next: any) => void;
+      onBlur: (event: Event, editor: Editor, next: Function) => void;
     }) => <SubjectpageAbout handleSubmit={handleSubmit} onBlur={onBlur} />,
   },
   {
@@ -48,9 +48,13 @@ const panels = [
     title: 'subjectpageForm.metadata',
     className: 'u-6/6',
     errorFields: ['metaDescription', 'mobileBannerId'],
-    component: ({ handleSubmit }: { handleSubmit: () => void }) => (
-      <SubjectpageMetadata handleSubmit={handleSubmit} />
-    ),
+    component: ({
+      handleSubmit,
+      onBlur,
+    }: {
+      handleSubmit: () => void;
+      onBlur: (event: Event, editor: Editor, next: Function) => void;
+    }) => <SubjectpageMetadata handleSubmit={handleSubmit} onBlur={onBlur} />,
   },
   {
     id: 'articles',

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -119,7 +119,7 @@ const SubjectpageForm: FC<Props & tType> = ({
       onSubmit={() => {}}
       validate={values => validateFormik(values, subjectpageRules, t)}>
       {(formik: FormikProps<SubjectpageEditType>) => {
-        const { values, dirty, isSubmitting, errors, isValid } = formik;
+        const { values, dirty, isSubmitting, errors, isValid, handleBlur } = formik;
 
         const formIsDirty: boolean = isFormikFormDirty({
           values,
@@ -143,6 +143,13 @@ const SubjectpageForm: FC<Props & tType> = ({
               elementId={values.elementId!}
               errors={errors}
               handleSubmit={() => handleSubmit(formik)}
+              onBlur={(event, editor, next) => {
+                next();
+                // this is a hack since formik onBlur-handler interferes with slates
+                // related to: https://github.com/ianstormtaylor/slate/issues/2434
+                // formik handleBlur needs to be called for validation to work (and touched to be set)
+                setTimeout(() => handleBlur({ target: { name: 'introduction' } }), 0);
+              }}
             />
             <Field right>
               <SaveButton

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageMetadata.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageMetadata.tsx
@@ -8,6 +8,7 @@
 import React, { FC } from 'react';
 import { injectT, tType } from '@ndla/i18n';
 import { FieldProps } from 'formik';
+import { Editor } from 'slate';
 import FormikField from '../../../components/FormikField';
 import PlainTextEditor from '../../../components/SlateEditor/PlainTextEditor';
 import { FormikProperties, VisualElement } from '../../../interfaces';
@@ -20,9 +21,10 @@ interface FormikProps {
 
 interface Props {
   handleSubmit: () => void;
+  onBlur: (event: Event, editor: Editor, next: Function) => void;
 }
 
-const SubjectpageMetadata: FC<Props & tType> = ({ handleSubmit, t }) => {
+const SubjectpageMetadata: FC<Props & tType> = ({ handleSubmit, onBlur, t }) => {
   return (
     <>
       <FormikField
@@ -37,6 +39,7 @@ const SubjectpageMetadata: FC<Props & tType> = ({ handleSubmit, t }) => {
             placeholder={t('form.metaDescription.label')}
             handleSubmit={handleSubmit}
             {...field}
+            onBlur={onBlur}
           />
         )}
       </FormikField>

--- a/src/containers/FormikForm/FormikMetadata.jsx
+++ b/src/containers/FormikForm/FormikMetadata.jsx
@@ -15,7 +15,7 @@ import PlainTextEditor from '../../components/SlateEditor/PlainTextEditor';
 import { FormikMetaImageSearch } from '.';
 import AsyncSearchTags from '../../components/Dropdown/asyncDropdown/AsyncSearchTags';
 
-const FormikMetadata = ({ t, article, fetchSearchTags, handleSubmit }) => (
+const FormikMetadata = ({ t, article, fetchSearchTags, handleSubmit, handleBlur }) => (
   <Fragment>
     <FormikField
       name="tags"
@@ -43,6 +43,13 @@ const FormikMetadata = ({ t, article, fetchSearchTags, handleSubmit }) => (
           id={field.name}
           placeholder={t('form.metaDescription.label')}
           handleSubmit={handleSubmit}
+          onBlur={(event, editor, next) => {
+            next();
+            // this is a hack since formik onBlur-handler interferes with slates
+            // related to: https://github.com/ianstormtaylor/slate/issues/2434
+            // formik handleBlur needs to be called for validation to work (and touched to be set)
+            setTimeout(() => handleBlur({ target: { name: 'metaDescription' } }), 0);
+          }}
           {...field}
         />
       )}
@@ -67,6 +74,7 @@ FormikMetadata.propTypes = {
   }).isRequired,
   fetchSearchTags: PropTypes.func,
   handleSubmit: PropTypes.func,
+  handleBlur: PropTypes.func,
 };
 
 export default injectT(FormikMetadata);

--- a/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourceForm.jsx
@@ -174,6 +174,7 @@ const LearningResourceForm = props => {
             handleSubmit={() => {
               handleSubmit(formik, isNewlyCreated);
             }}
+            {...formikProps}
             {...rest}
           />
         )}

--- a/src/containers/NdlaFilm/components/NdlaFilmAccordionPanels.tsx
+++ b/src/containers/NdlaFilm/components/NdlaFilmAccordionPanels.tsx
@@ -8,6 +8,7 @@ import React, { FC, Fragment } from 'react';
 import Accordion, { AccordionWrapper, AccordionBar, AccordionPanel } from '@ndla/accordion';
 import { injectT, tType } from '@ndla/i18n';
 import { FieldProps, FormikErrors, FormikHelpers, FormikValues } from 'formik';
+import { Editor } from 'slate';
 import SubjectpageAbout from '../../EditSubjectFrontpage/components/SubjectpageAbout';
 import {
   AccordionProps,
@@ -30,6 +31,7 @@ interface ComponentProps extends Props {
   errors: FormikErrors<Values>;
   formIsDirty: boolean;
   handleSubmit: () => void;
+  onBlur: (event: Event, editor: Editor, next: Function) => void;
 }
 
 interface PanelProps extends Props {
@@ -52,9 +54,10 @@ const panels = [
     title: 'subjectpageForm.about',
     className: 'u-4/6@desktop u-push-1/6@desktop',
     errorFields: ['title', 'description', 'visualElement'],
-    component: ({ handleSubmit }: { handleSubmit: () => void }) => (
-      <SubjectpageAbout handleSubmit={handleSubmit} />
-    ),
+    component: (props: {
+      handleSubmit: () => void;
+      onBlur: (event: any, editor: any, next: any) => void;
+    }) => <SubjectpageAbout handleSubmit={props.handleSubmit} onBlur={props.onBlur} />,
   },
   {
     id: 'slideshow',
@@ -104,6 +107,7 @@ const SubjectpageAccordionPanels: FC<ComponentProps & tType> = ({
   loading,
   selectedLanguage,
   handleSubmit,
+  onBlur,
 }) => {
   const onUpdateMovieList = (
     field: FieldProps<FormikValues>['field'],
@@ -147,6 +151,7 @@ const SubjectpageAccordionPanels: FC<ComponentProps & tType> = ({
                         onUpdateMovieList,
                         selectedLanguage,
                         handleSubmit,
+                        onBlur,
                       })}
                     </div>
                   </AccordionPanel>

--- a/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
+++ b/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
@@ -58,7 +58,7 @@ const NdlaFilmForm: FC<Props & tType> = ({
       validate={values => validateFormik(values, ndlaFilmRules, t)}
       enableReinitialize={enableReinitialize}>
       {formik => {
-        const { values, dirty, isSubmitting, errors, isValid } = formik;
+        const { values, dirty, isSubmitting, errors, isValid, handleBlur } = formik;
         const formIsDirty: boolean = isFormikFormDirty({
           values,
           initialValues,
@@ -84,6 +84,13 @@ const NdlaFilmForm: FC<Props & tType> = ({
               loading={loading}
               selectedLanguage={selectedLanguage}
               handleSubmit={() => handleSubmit(formik)}
+              onBlur={(event, editor, next) => {
+                next();
+                // this is a hack since formik onBlur-handler interferes with slates
+                // related to: https://github.com/ianstormtaylor/slate/issues/2434
+                // formik handleBlur needs to be called for validation to work (and touched to be set)
+                setTimeout(() => handleBlur({ target: { name: 'introduction' } }), 0);
+              }}
             />
             <Field right>
               <SaveButton

--- a/src/containers/TopicArticlePage/components/TopicArticleForm.jsx
+++ b/src/containers/TopicArticlePage/components/TopicArticleForm.jsx
@@ -190,6 +190,7 @@ const TopicArticleForm = props => {
             getArticle={getArticle}
             fetchSearchTags={fetchSearchTags}
             handleSubmit={() => handleSubmit(formik)}
+            {...formikProps}
             {...rest}
           />
         )}


### PR DESCRIPTION
Etter å ha skreve tekst i metadescription går det ikkje an å klikke utenfor. Fikser dette ved å sende formikprops nedover i treet og legger på onBlur. 

Merk:  Dette er fremdeles feil for ndla-film og fagforsider! Men der vil det være kjappere for en med bedre typescript-fu enn meg å fikse.