### PR TITLE
Add Sort options to image and audio search

### DIFF
--- a/src/containers/SearchPage/SearchContainer.jsx
+++ b/src/containers/SearchPage/SearchContainer.jsx
@@ -104,9 +104,7 @@ class SearchContainer extends Component {
           locale={locale}
           subjects={this.state.subjects}
         />
-        {(type === 'content' || type === 'concept') && (
-          <SearchSort location={location} onSortOrderChange={this.onSortOrderChange} />
-        )}
+        <SearchSort location={location} onSortOrderChange={this.onSortOrderChange} />
         <SearchListOptions
           type={type}
           searchObject={searchObject}


### PR DESCRIPTION
Fixes NDLANO/Issues#2458
Det finnes ikke statusfelt for lyd/bilde å vise fram på samme måte som for artikkel/forklaring så vidt jeg kan se. Har derfor ikke implementert dette.

Har lagt til sortingsvalg i bildesøk og lydsøk. 

How to test:
1. https://editorial-frontend-pr-899.ndla.sh/
2. Prøv forskjellige kombinasjoner av "sortering" og "rekkefølge" i bildesøk og lydsøk.