### PR TITLE
2474 load changes after save

### DIFF
--- a/src/containers/EditMarkupPage/EditMarkupPage.jsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.jsx
@@ -134,12 +134,13 @@ export class EditMarkupPage extends Component {
       const { draftId, language } = this.props.match.params;
       this.setState({ status: 'saving' });
       const content = standardizeContent(this.state.draft.content.content);
-      await updateDraft({
+      const draft = await updateDraft({
         id: parseInt(draftId, 10),
         content,
         revision: this.state.draft.revision,
         language,
       });
+      this.setState({ status: 'initial', draft });
     } catch (e) {
       handleError(e);
       this.setState({ status: 'save-error' });

--- a/src/containers/EditMarkupPage/EditMarkupPage.jsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.jsx
@@ -9,7 +9,6 @@
 import React, { Component, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { Trans } from '@ndla/i18n';
-import Button from '@ndla/button';
 import { Link } from 'react-router-dom';
 import { spacing, colors } from '@ndla/core';
 import styled from '@emotion/styled';
@@ -27,7 +26,8 @@ import { DRAFT_HTML_SCOPE } from '../../constants';
 import { getSessionStateFromLocalStorage } from '../../modules/session/session';
 import HeaderSupportedLanguages from '../../components/HeaderWithLanguage/HeaderSupportedLanguages';
 import { toEditMarkup } from '../../util/routeHelpers';
-import { FormikAlertModalWrapper } from '../FormikForm';
+import { FormikAlertModalWrapper, formClasses } from '../FormikForm';
+import SaveButton from '../../components/SaveButton';
 
 const MonacoEditor = React.lazy(() => import('../../components/MonacoEditor'));
 
@@ -86,7 +86,7 @@ ErrorMessage.propTypes = {
 
 export class EditMarkupPage extends Component {
   state = {
-    // initial | edit | fetch-error | save-error | access-error | saving
+    // initial | edit | fetch-error | save-error | access-error | saving | saved
     status: 'initial',
     draft: undefined,
   };
@@ -140,7 +140,7 @@ export class EditMarkupPage extends Component {
         revision: this.state.draft.revision,
         language,
       });
-      this.setState({ status: 'initial', draft });
+      this.setState({ status: 'saved', draft });
     } catch (e) {
       handleError(e);
       this.setState({ status: 'save-error' });
@@ -231,11 +231,13 @@ export class EditMarkupPage extends Component {
                     }>
                     {t('editMarkup.back')}
                   </Link>
-                  <Button
-                    disabled={status === 'initial' || status === 'saving'}
-                    onClick={this.saveChanges}>
-                    {t('form.save')}
-                  </Button>
+                  <SaveButton
+                    {...formClasses}
+                    isSaving={status === 'saving'}
+                    formIsDirty={status === 'edit'}
+                    showSaved={status === 'saved'}
+                    onClick={this.saveChanges}
+                  />
                 </Row>
               </Row>
             </Suspense>

--- a/src/containers/FormikForm/FormikMetadata.jsx
+++ b/src/containers/FormikForm/FormikMetadata.jsx
@@ -43,6 +43,7 @@ const FormikMetadata = ({ t, article, fetchSearchTags, handleSubmit, handleBlur 
           id={field.name}
           placeholder={t('form.metaDescription.label')}
           handleSubmit={handleSubmit}
+          {...field}
           onBlur={(event, editor, next) => {
             next();
             // this is a hack since formik onBlur-handler interferes with slates
@@ -50,7 +51,6 @@ const FormikMetadata = ({ t, article, fetchSearchTags, handleSubmit, handleBlur 
             // formik handleBlur needs to be called for validation to work (and touched to be set)
             setTimeout(() => handleBlur({ target: { name: 'metaDescription' } }), 0);
           }}
-          {...field}
         />
       )}
     </FormikField>


### PR DESCRIPTION
Fixes NDLANO/Issues#2474 and NDLANO/Issues#2475

Laster inn svar fra server ved lagring i html-editor, samt bruker SaveButton for å få grønn lagreknapp. 

Test:
HTML: Åpne artikkel i html-editor. Gjør en endring og sjekk at Lagreknappen blir grønn etter lagring og at innholdet oppfriskes.
