### PR TITLE
2481 leggtil knapp i slate liste

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/options.js
+++ b/src/components/SlateEditor/plugins/blockPicker/options.js
@@ -1,15 +1,6 @@
 const defaultOptions = {
-  allowedPickAreas: ['paragraph', 'heading-one', 'heading-two', 'heading-three'],
-  illegalAreas: [
-    'quote',
-    'list-item',
-    'numbered-list',
-    'aside',
-    'bodybox',
-    'summary',
-    'table',
-    'details',
-  ],
+  allowedPickAreas: ['paragraph', 'heading-one', 'heading-two', 'heading-three', 'list-text'],
+  illegalAreas: ['quote', 'aside', 'bodybox', 'summary', 'table', 'details'],
 };
 
 const options = opts => ({

--- a/src/components/SlateEditor/plugins/listText/actions.js
+++ b/src/components/SlateEditor/plugins/listText/actions.js
@@ -25,5 +25,10 @@ export function onEnter(evt, editor, next) {
    throughout the document to enable positioning the cursor between element with no
    spacing (i.e two images).
    */
-  return editor.insertText('\n');
+
+  return editor
+    .delete()
+    .insertBlock('br')
+    .insertBlock('br')
+    .insertBlock('list-text');
 }


### PR DESCRIPTION
Oppgaven er satt på vent.

Fixes NDLANO/Issues#2481

Muliggjør å legge inn embeds i en liste i slate.

Ting som skal fungere i en liste:
1. Shift+enter for å lage en ny linje. Her skal man kunne skrive et til avsnitt eller trykke på (+) for å legge til embed dersom linjen er tom.