### PR TITLE
2335 bugfix html editor changes code

### DIFF
--- a/src/containers/EditMarkupPage/EditMarkupPage.jsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.jsx
@@ -35,7 +35,11 @@ const MonacoEditor = React.lazy(() => import('../../components/MonacoEditor'));
 // to ensure standarized markup.
 // Also useful for detecting validation issues.
 function standardizeContent(content) {
-  const converted = learningResourceContentToEditorValue(content);
+  const trimmedContent = content
+    .split('\n')
+    .map(s => s.trim())
+    .join('');
+  const converted = learningResourceContentToEditorValue(trimmedContent);
   return learningResourceContentToHTML(converted);
 }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2335

Ved lagring av artikkel i HTML-editor dukket det opp nye tags ved lagring. Dette skjedde spesielt når brukeren la inn linjeskift i koden.

Hvordan er problemet løst: Trimmer hver linje for whitespaces og fjerner alle linjeskift. 

Ved noen tilfeller dukker det fortsatt opp `<p>`-tag rundt tekst. Dette skjer i følgende tilfelle:
`<section><p>noe tekst</p>tekst uten p</section>` -> `<section><p>noe tekst</p><p>tekst uten p</p></section>`
men ikke i dette tilfellet:
`<section>noe tekst</section>` -> `<section>noe tekst</section>`


Hvordan teste:
1. PR-installasjon
2. Åpne en artikkel i HTML-editor
3. Prøv å lagre linjeskift og andre endringer på koden. Resultatet skal være likt bortsett fra at det slås sammen til én linje.