### PR TITLE
Fjerner space fra start og slutten av selektert tekst

### DIFF
--- a/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
+++ b/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
@@ -92,7 +92,7 @@ function stripSpacesFromSelectedText(editor) {
   if (selectedStartText.startsWith(' ')) {
     editor.moveStartForward(1);
   }
-  const selectedEndText = endText.text.slice(value.selection.end.offset -1);
+  const selectedEndText = endText.text.slice(value.selection.end.offset - 1);
   if (selectedEndText.startsWith(' ')) {
     editor.moveEndBackward(1);
   }

--- a/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
+++ b/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
@@ -13,6 +13,8 @@ const DEFAULT_NODE = 'paragraph';
 
 export function handleClickBlock(event, editor, type) {
   event.preventDefault();
+  stripSpacesFromSelectedText(editor);
+
   const { document, blocks } = editor.value;
   const isActive = hasNodeOfType(editor, type);
   if (type === 'quote') {
@@ -43,11 +45,13 @@ export function handleClickBlock(event, editor, type) {
 
 export function handleClickMark(event, editor, type) {
   event.preventDefault();
+  stripSpacesFromSelectedText(editor);
   editor.toggleMark(type);
 }
 
 export function handleClickInline(event, editor, type) {
   event.preventDefault();
+  stripSpacesFromSelectedText(editor);
 
   if (type === 'footnote') {
     addTextAndWrapIntype(editor, '#', type);
@@ -71,4 +75,25 @@ function addTextAndWrapIntype(editor, text, type) {
     .insertText(text)
     .moveFocusForward(-text.length)
     .wrapInline(type);
+}
+
+/**
+ * Default windows behaviour when selecting text via double click is to select the word + the following space.
+ * This function checks the selected text and removes 1 space from each end.
+ * Selections spanning more than one text is supported.
+ */
+function stripSpacesFromSelectedText(editor) {
+  const { value } = editor;
+  if (value.selection.start.offset === value.selection.end.offset) {
+    return;
+  }
+  const { startText, endText } = value;
+  const selectedStartText = startText.text.slice(value.selection.start.offset);
+  if (selectedStartText.startsWith(' ')) {
+    editor.moveStartForward(1);
+  }
+  const selectedEndText = endText.text.slice(-value.selection.end.offset);
+  if (selectedEndText.endsWith(' ')) {
+    editor.moveEndBackward(1);
+  }
 }

--- a/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
+++ b/src/components/SlateEditor/plugins/SlateToolbar/handleMenuClicks.js
@@ -92,8 +92,8 @@ function stripSpacesFromSelectedText(editor) {
   if (selectedStartText.startsWith(' ')) {
     editor.moveStartForward(1);
   }
-  const selectedEndText = endText.text.slice(-value.selection.end.offset);
-  if (selectedEndText.endsWith(' ')) {
+  const selectedEndText = endText.text.slice(value.selection.end.offset -1);
+  if (selectedEndText.startsWith(' ')) {
     editor.moveEndBackward(1);
   }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2485
Ref https://trello.com/c/ZbnXGcEw/970-mellomrom-i-formateringsfunksjoner

Stripper space fra kantene av valgt tekst for å unngå windowsproblematikk rundt valg av ord med dobbelklikk.

Test:
På windows: rediger en artikkel og dobbeltklikk på et ord og sjå at mellomrommet er valgt. klikk på feks **<>** i toolbar og sjekk at kun ordet får bakgrunnsfarge.

Alle os: rediger en artikkel og marker tekst som starter med eller slutter med mellomrom og klikk på et valg i toolbar. Mellomromma skal forsvinne etter klikket.