### PR TITLE
Add support for showing geogebra. Do not use cors-url for test

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -63,4 +63,5 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
     height: '398px',
   },
   { name: 'MolView', url: ['embed.molview.org'] },
+  { name: 'GeoGebra', url: ['www.geogebra.org'] },
 ];

--- a/src/containers/VisualElement/visualElementApi.js
+++ b/src/containers/VisualElement/visualElementApi.js
@@ -28,7 +28,7 @@ const baseBrightCoveUrlV3 = brightcoveApiResourceUrl(
 const baseGoogleSearchUrl = googleSearchApiResourceUrl('/customsearch/v1/');
 
 const corsAnywhereUrl = `${
-  config.ndlaEnvironment === 'test' ? 'https://cors-anywhere.herokuapp.com/' : ''
+  config.ndlaEnvironment === 'local' ? 'https://cors-anywhere.herokuapp.com/' : ''
 }`;
 
 export const fetchNrkMedia = async mediaId => {


### PR DESCRIPTION
Legger til at embeds fra geogebra kan vises i ed.
Fjerner også at cors-anywhere brukes på test.

Test:
Denne artikkelen skal vise med geogebra: https://editorial-frontend-pr-922.ndla.sh/subject-matter/learning-resource/59218/edit/nb