### PR TITLE
2460 upgrade monaco editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.21.3",
+    "monaco-editor": "0.22.3",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "^0.17.1",
+    "monaco-editor": "0.18.1",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.18.1",
+    "monaco-editor": "0.19.0",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.19.3",
+    "monaco-editor": "0.20.0",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.20.0",
+    "monaco-editor": "0.21.3",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.22.3",
+    "monaco-editor": "0.23.0",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "jwks-rsa": "^1.6.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
-    "monaco-editor": "0.19.0",
+    "monaco-editor": "0.19.3",
     "ndla-slate-edit-list": "^0.13.4",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",

--- a/src/components/MonacoEditor/MonacoEditor.jsx
+++ b/src/components/MonacoEditor/MonacoEditor.jsx
@@ -18,7 +18,6 @@ import 'monaco-editor/esm/vs/editor/contrib/find/findController';
 import 'monaco-editor/esm/vs/editor/contrib/links/links';
 import 'monaco-editor/esm/vs/editor/contrib/suggest/suggestController';
 import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/wordHighlighter';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickOpen/quickCommand';
 import 'monaco-editor/esm/vs/editor/contrib/multicursor/multicursor';
 import 'monaco-editor/esm/vs/editor/contrib/linesOperations/linesOperations';
 import 'monaco-editor/esm/vs/editor/contrib/fontZoom/fontZoom';

--- a/src/components/MonacoEditor/MonacoEditor.jsx
+++ b/src/components/MonacoEditor/MonacoEditor.jsx
@@ -30,15 +30,6 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import './html.contribution';
 import { createFormatAction, createSaveAction } from './editorActions';
 
-window.MonacoEnvironment = {
-  getWorkerUrl: function(moduleId, label) {
-    if (label === 'html') {
-      return '/static/js/html.worker.js';
-    }
-    return '/static/js/editor.worker.js';
-  },
-};
-
 monaco.editor.defineTheme('myCustomTheme', {
   base: 'vs',
   inherit: false,

--- a/src/components/MonacoEditor/MonacoEditor.jsx
+++ b/src/components/MonacoEditor/MonacoEditor.jsx
@@ -17,6 +17,7 @@ import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/bracketMatching';
 import 'monaco-editor/esm/vs/editor/contrib/find/findController';
 import 'monaco-editor/esm/vs/editor/contrib/links/links';
 import 'monaco-editor/esm/vs/editor/contrib/suggest/suggestController';
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess';
 import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/wordHighlighter';
 import 'monaco-editor/esm/vs/editor/contrib/multicursor/multicursor';
 import 'monaco-editor/esm/vs/editor/contrib/linesOperations/linesOperations';

--- a/src/containers/EditMarkupPage/EditMarkupPage.jsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.jsx
@@ -29,6 +29,16 @@ import { toEditMarkup } from '../../util/routeHelpers';
 import { FormikAlertModalWrapper, formClasses } from '../FormikForm';
 import SaveButton from '../../components/SaveButton';
 
+window.MonacoEnvironment = {
+  getWorkerUrl: function(moduleId, label) {
+    if (label === 'html') {
+      return '/static/js/html.worker.js';
+    }
+    return '/static/js/editor.worker.js';
+  },
+  globalAPI: true,
+};
+
 const MonacoEditor = React.lazy(() => import('../../components/MonacoEditor'));
 
 // Serialize and deserialize content using slate helpers

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.19.0.tgz#c6e774210f3b292ff739e96f45a1cc78bf5ac2e7"
-  integrity sha512-ida++HI/s9V8ma8yYS9CAS0UJEFwW1gbt9G6oviEdv/aHhFd/kV3sXrINqC63TVdKzOZdKjPRRCOPJJ80zvLbw==
+monaco-editor@0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.19.3.tgz#1c994b3186c00650dbcd034d5370d46bf56c0663"
+  integrity sha512-2n1vJBVQF2Hhi7+r1mMeYsmlf18hjVb6E0v5SoMZyb4aeOmYPKun+CE3gYpiNA1KEvtSdaDHFBqH9d7Wd9vREg==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
-  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
+monaco-editor@0.22.3:
+  version "0.22.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.22.3.tgz#69b42451d3116c6c08d9b8e052007ff891fd85d7"
+  integrity sha512-RM559z2CJbczZ3k2b+ouacMINkAYWwRit4/vs0g2X/lkYefDiu0k2GmgWjAuiIpQi+AqASPOKvXNmYc8KUSvVQ==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.19.3:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.19.3.tgz#1c994b3186c00650dbcd034d5370d46bf56c0663"
-  integrity sha512-2n1vJBVQF2Hhi7+r1mMeYsmlf18hjVb6E0v5SoMZyb4aeOmYPKun+CE3gYpiNA1KEvtSdaDHFBqH9d7Wd9vREg==
+monaco-editor@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
+  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.18.1.tgz#ced7c305a23109875feeaf395a504b91f6358cfc"
-  integrity sha512-fmL+RFZ2Hrezy+X/5ZczQW51LUmvzfcqOurnkCIRFTyjdVjzR7JvENzI6+VKBJzJdPh6EYL4RoWl92b2Hrk9fw==
+monaco-editor@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.19.0.tgz#c6e774210f3b292ff739e96f45a1cc78bf5ac2e7"
+  integrity sha512-ida++HI/s9V8ma8yYS9CAS0UJEFwW1gbt9G6oviEdv/aHhFd/kV3sXrINqC63TVdKzOZdKjPRRCOPJJ80zvLbw==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
-  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
+monaco-editor@0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
+  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@0.22.3:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.22.3.tgz#69b42451d3116c6c08d9b8e052007ff891fd85d7"
-  integrity sha512-RM559z2CJbczZ3k2b+ouacMINkAYWwRit4/vs0g2X/lkYefDiu0k2GmgWjAuiIpQi+AqASPOKvXNmYc8KUSvVQ==
+monaco-editor@0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.23.0.tgz#24844ba5640c7adb3a2a3ff3b520cf2d7170a6f0"
+  integrity sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg==
 
 moo@^0.4.3:
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9650,10 +9650,10 @@ moment@^2.10.6:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
-monaco-editor@^0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.17.1.tgz#8fbe96ca54bfa75262706e044f8f780e904aa45c"
-  integrity sha512-JAc0mtW7NeO+0SwPRcdkfDbWLgkqL9WfP1NbpP9wNASsW6oWqgZqNIWt4teymGjZIXTElx3dnQmUYHmVrJ7HxA==
+monaco-editor@0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.18.1.tgz#ced7c305a23109875feeaf395a504b91f6358cfc"
+  integrity sha512-fmL+RFZ2Hrezy+X/5ZczQW51LUmvzfcqOurnkCIRFTyjdVjzR7JvENzI6+VKBJzJdPh6EYL4RoWl92b2Hrk9fw==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
Fixes NDLANO/Issues#2460

Oppgradert monaco-editor til siste versjon.

To endringer har blitt gjort i koden for å få dette til å fungere:
- F1-shortcut var tidligere importert som ´quickCommand´. Importeres nå som `standaloneCommandsQuickAccess`.
- monaco er ikke lenger tilgjengelig global som default. La til `globalApi: true` i `window.MonacoEnvironment` som beskrevet i changelogen til monaco-editor. Denne kodeblokken måtte også flyttes for at den skulle fungere.

Hvordan teste:
1. https://editorial-frontend-pr-927.ndla.sh/
2. Åpne en artikkel og sjekk at funksjonalitet i HTML-editor fungerer som normalt.
