### PR TITLE
Wrap table-render with custom div

### DIFF
--- a/src/components/SlateEditor/slateRendering.jsx
+++ b/src/components/SlateEditor/slateRendering.jsx
@@ -42,6 +42,10 @@ export const renderBlock = (props, editor, next) => {
       return <blockquote {...attributes}>{children}</blockquote>;
     case 'div':
       return <div {...attributes}>{children}</div>;
+    case 'table':
+      // Let table-plugin render itself, then wrap with custom div.
+      const rendered = next();
+      return <div className="c-table__wrapper c-table__content">{rendered}</div>;
     default:
       return next();
   }


### PR DESCRIPTION
Wrapper tabell-rendering med egen div slik at tabeller vises likt som i frontend.

Test.
Rediger artikkel og legg inn en tabell. Sammenlign artikkelen med forhåndsvisninga og sjekk at dei ser like ut. Breie tabeller med masse tekst skal kunne bli like breie som bilder og kodeblokker.