### PR TITLE
Use correct parameter for content search

### DIFF
--- a/cypress/integration/Search/search_spec.js
+++ b/cypress/integration/Search/search_spec.js
@@ -44,7 +44,7 @@ describe('Search content', () => {
   it('Can use status dropdown', () => {
     cy.apiroute(
       'GET',
-      '/search-api/v1/search/editorial/?fallback=true&language=nb&page=1&page-size=10&sort=-relevance&status=USER_TEST',
+      '/search-api/v1/search/editorial/?draft-status=USER_TEST&fallback=true&language=nb&page=1&page-size=10&sort=-relevance',
       'search',
     );
     cy.get('select[name="status"]').select('Brukertest').blur();

--- a/src/containers/SearchPage/components/form/SearchContentForm.jsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.jsx
@@ -43,7 +43,7 @@ class SearchContentForm extends Component {
       search: {
         subjects: searchObject.subjects || '',
         resourceTypes: searchObject['resource-types'] || '',
-        status: searchObject.status || '',
+        status: searchObject['draft-status'] || '',
         query: searchObject.query || '',
         users: searchObject.users || '',
         lang: searchObject.lang || locale,
@@ -68,7 +68,7 @@ class SearchContentForm extends Component {
         search: {
           subjects: searchObject.subjects || '',
           resourceTypes: searchObject['resource-types'] || '',
-          status: searchObject.status || '',
+          status: searchObject['draft-status'] || '',
           query: searchObject.query || '',
           users: searchObject.users || '',
           lang: searchObject.lang || locale,
@@ -107,7 +107,7 @@ class SearchContentForm extends Component {
     const { search } = this.props;
     search({
       'resource-types': resourceTypes,
-      status,
+      'draft-status': status,
       subjects,
       query,
       users,
@@ -251,7 +251,7 @@ SearchContentForm.propTypes = {
     query: PropTypes.string,
     subjects: PropTypes.string,
     'resource-types': PropTypes.string,
-    status: PropTypes.string,
+    'draft-status': PropTypes.string,
     users: PropTypes.string,
     lang: PropTypes.string,
     fallback: PropTypes.bool,

--- a/src/containers/SearchPage/components/form/SearchForm.jsx
+++ b/src/containers/SearchPage/components/form/SearchForm.jsx
@@ -40,6 +40,7 @@ SearchForm.propTypes = {
     query: PropTypes.string,
     subjects: PropTypes.string,
     'resource-types': PropTypes.string,
+    'draft-status': PropTypes.string,
     status: PropTypes.string,
     users: PropTypes.string,
     language: PropTypes.string,


### PR DESCRIPTION
Fikser søk etter status igjen.

Test
Søk etter innhold og filtrer på status og sjekk at antall treff oppdateres. Endring av søketerm skal ikkje nullstille statusen. 
Søk etter forklaring og sjekk at du også der kan filtrere på status.