### PR TITLE
Removing cors proxy and adding magical param.

### DIFF
--- a/src/modules/translate/translateApi.js
+++ b/src/modules/translate/translateApi.js
@@ -20,7 +20,7 @@ export const fetchNnTranslation = ({ id, ...articleContents }) =>
     body: JSON.stringify({
       token: config.npkToken,
       guid: config.ndlaEnvironment + '_' + id,
-      prefs: { x: true },
+      prefs: { x: true }, // Hack to tell the service to use old html-parser, ref jo.christian.oterhals@ntb.no
       document: articleContents,
     }),
   }).then(resolveJsonOrRejectWithError);

--- a/src/modules/translate/translateApi.js
+++ b/src/modules/translate/translateApi.js
@@ -9,10 +9,7 @@
 import { resolveJsonOrRejectWithError } from '../../util/apiHelpers';
 import config from '../../config';
 
-const corsAnywhereUrl = `${
-  config.ndlaEnvironment === 'test' ? 'https://cors-anywhere.herokuapp.com/' : ''
-}`;
-const baseUrl = corsAnywhereUrl + 'https://nynorsk.cloud/translate';
+const baseUrl = 'https://nynorsk.cloud/translate';
 
 export const fetchNnTranslation = ({ id, ...articleContents }) =>
   fetch(baseUrl, {
@@ -23,6 +20,7 @@ export const fetchNnTranslation = ({ id, ...articleContents }) =>
     body: JSON.stringify({
       token: config.npkToken,
       guid: config.ndlaEnvironment + '_' + id,
+      prefs: { x: true },
       document: articleContents,
     }),
   }).then(resolveJsonOrRejectWithError);


### PR DESCRIPTION
Oversettelsestjenesten har en bug som fjerner whitespace i payloaden. Ved å legge på paramter x:true forteller vi tjenesten å bruke en anna html-parser.

Test
Rediger en artikkel på bokmål og sett inn en forklaring inni en setning. Oversett til nynorsk med tjenesten og sjekk at formateringa ser korrekt ut. Uten ekstra parameter vil mellomrom rundt forklaringa bli sletta.