### PR TITLE
Hide panel for mere mortals

### DIFF
--- a/src/containers/LearningResourcePage/components/LearningResourcePanels.jsx
+++ b/src/containers/LearningResourcePage/components/LearningResourcePanels.jsx
@@ -8,6 +8,7 @@ import FormikRelatedContent from '../../FormikForm/FormikRelatedContent';
 import { FormikCopyright, VersionAndNotesPanel, FormikMetadata } from '../../FormikForm';
 import { TAXONOMY_WRITE_SCOPE } from '../../../constants';
 import FormikGrepCodes from '../../FormikForm/FormikGrepCodes';
+import { DRAFT_ADMIN_SCOPE } from '../../../constants';
 
 const panels = [
   {
@@ -52,6 +53,7 @@ const panels = [
     title: 'form.name.relatedContent',
     className: 'u-6/6',
     errorFields: ['conceptIds', 'relatedContent'],
+    showPanel: (values, userAccess) => !!userAccess?.includes(DRAFT_ADMIN_SCOPE),
     component: props => <FormikRelatedContent {...props} />,
   },
   {

--- a/src/containers/TopicArticlePage/components/TopicArticleAccordionPanels.jsx
+++ b/src/containers/TopicArticlePage/components/TopicArticleAccordionPanels.jsx
@@ -8,6 +8,7 @@ import { FormikCopyright, VersionAndNotesPanel, FormikMetadata } from '../../For
 import TopicArticleTaxonomy from './TopicArticleTaxonomy';
 import { TAXONOMY_WRITE_SCOPE } from '../../../constants';
 import FormikGrepCodes from '../../FormikForm/FormikGrepCodes';
+import { DRAFT_ADMIN_SCOPE } from '../../../constants';
 
 const panels = [
   {
@@ -51,6 +52,7 @@ const panels = [
     title: 'form.name.relatedContent',
     className: 'u-6/6',
     errorFields: ['conceptIds', 'relatedContent'],
+    showPanel: (values, userAccess) => !!userAccess?.includes(DRAFT_ADMIN_SCOPE),
     component: props => <FormikRelatedContent {...props} />,
   },
   {


### PR DESCRIPTION
Branch fra versjonen som ligger i staging.

Legger på sjekk om bruker har draft-admin før nytt panel for relatert innhold vises. Må på plass før vi deployer ed i prod. Lager uansett release av denne branchen.

Test: For alle oss skal det sjå som vanlig ut, men alle som ikkje har draft-admin skal ikkje sjå feltet.