### PR TITLE
Math should always be inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint-es": "eslint --cache --cache-location '.eslintcache/' --ext .js,.jsx,.ts,.tsx --max-warnings=0 src",
     "format-check": "node prettier.js lint",
     "format": "node prettier.js write",
-    "start": "razzle start  --inspect --inspect-port 9230",
+    "start": "NODE_OPTIONS='--max-old-space-size=2048' razzle start --inspect --inspect-port 9230",
     "start-with-local-converter": "LOCAL_CONVERTER=true razzle start",
     "start-prod": "cross-env NODE_ENV=production node build/server | bunyan",
     "now-start": "cross-env NODE_ENV=production NOW=true node build/server | bunyan",

--- a/src/util/slateHelpers.jsx
+++ b/src/util/slateHelpers.jsx
@@ -83,7 +83,6 @@ const canParentElementContainBlock = el => {
       tagName === 'section' ||
       tagName === 'div' ||
       tagName === 'aside' ||
-      tagName === 'li' ||
       BLOCK_TAGS[tagName] !== undefined
     );
   }
@@ -268,7 +267,7 @@ export const mathRules = {
     const tagName = el.tagName.toLowerCase();
     if (tagName !== 'math') return;
     return {
-      object: canParentElementContainBlock(el) ? 'block' : 'inline',
+      object: 'inline',
       type: 'mathml',
       data: { ...reduceElementDataAttributes(el), innerHTML: el.innerHTML },
       nodes: [

--- a/src/util/slateHelpers.jsx
+++ b/src/util/slateHelpers.jsx
@@ -83,6 +83,7 @@ const canParentElementContainBlock = el => {
       tagName === 'section' ||
       tagName === 'div' ||
       tagName === 'aside' ||
+      tagName === 'li' ||
       BLOCK_TAGS[tagName] !== undefined
     );
   }


### PR DESCRIPTION
Matte som ligger direkte inni en li, div eller aside vises ikkje. Det er fordi det i disse tilfeller tolkes som block. Det kan ha fungert i en tidligere versjon av slate, men med skillet mellom inline og block som finnes i slate i dag så funker ikkje det.

Artikkelen https://ed.test.ndla.no/subject-matter/learning-resource/59231/edit/nb har matte i det andre listepunktet men det vises ikkje på grunn av denne regelen. 

Test
Tilsvarende [artikkel i pr-installasjon](https://editorial-frontend-pr-939.ndla.sh/subject-matter/learning-resource/59231/edit/nb) skal vise matte korrekt. Lagreknappen kan være blå fordi matten wrappes i p ved lagring. Ikkje lagre artikkelen.