### PR TITLE
Update ndla-slate-edit-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.19",
     "monaco-editor": "0.23.0",
-    "ndla-slate-edit-list": "^0.13.4",
+    "ndla-slate-edit-list": "0.14.0",
     "polished": "^3.4.1",
     "postcss-cssnext": "^3.1.0",
     "postcss-focus": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9784,10 +9784,10 @@ ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
-ndla-slate-edit-list@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/ndla-slate-edit-list/-/ndla-slate-edit-list-0.13.4.tgz#782747d00a1080d66d1d121c45ffb53155e4ed25"
-  integrity sha512-51nA0KBA2KLa2+xfWJc9eX1BId/4tPLQfWcKJ8/HTteJDWdITDOGGo/lctNwmTYmQs8LbLWIZv97xJ5giUWWmw==
+ndla-slate-edit-list@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/ndla-slate-edit-list/-/ndla-slate-edit-list-0.14.0.tgz#80cf43a2104894258940c9b8da133395015ec765"
+  integrity sha512-s/WlZ9116rdfQop0kIwOhYQmhPv0FcdVXPKaVeDCf9eSC0P0fjbXCWrZDaIoyLxvjq4JAMhinQN/Nx0zuqFRvg==
 
 nearley@^2.7.10:
   version "2.16.0"


### PR DESCRIPTION
Fixes NDLANO/Issues#2502

Det kan oppstå tilfeller i slate der en punktliste har `<li>`-element som inneholder mer enn én node. Slik ndla-slate-edit-list fungerer nå vil kun den første noden bli værende ved unwrapping. De andre nodene forsvinner.

ndla-slate-edit-list er oppdatert slik at den nå skal ta med alle elementene.

Hvordan teste:
1. Åpne PR-installasjon.
2. Åpne artikkel (feks 59229)
3. Marker bendik og trykk punktliste. Punktet skal forsvinne, men teksten skal forbli lik.
4. Trykk ctrl+z og se om det tilbakestilles riktig