### PR TITLE
Preventing \n in codeblock to be stripped from html

### DIFF
--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -59,9 +59,9 @@ const MonacoEditor = React.lazy(() => import('../../components/MonacoEditor'));
 // Also useful for detecting validation issues.
 function standardizeContent(content: string): string {
   const trimmedContent = content
-    .split('\n')
+    .split('>\n')
     .map(s => s.trim())
-    .join('');
+    .join('>');
   const converted = learningResourceContentToEditorValue(trimmedContent);
   return learningResourceContentToHTML(converted);
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2519

Marc rapporterte at linjeskift i kodeblokk forsvinner ved lagring av html. Dette er på grunn av håndteringa av formatert html der vi stripper bort nettopp \n. oppdatere koden litt slik at kun linjeskift rett etter en > blir fjerna.

Test.
Lag en kodeblokk med mange linjer i en artikkel. Rediger html og gjør en liten endring slik at du får lagra. Kodeblokken skal ha fått beholde linjeskifta sine.