### PR TITLE
Alternativ løsning for redirect

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.jsx
@@ -5,16 +5,18 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { Fragment } from 'react';
+import React, { Fragment, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { injectT } from '@ndla/i18n';
+import { LocaleContext } from '../../App/App';
 import { LicensesArrayOf } from '../../../shapes';
 import LearningResourceForm from './components/LearningResourceForm';
 import { useFetchArticleData } from '../../FormikForm/formikDraftHooks';
 import { toEditArticle } from '../../../util/routeHelpers';
 
-const CreateLearningResource = ({ locale, t, history, ...rest }) => {
+const CreateLearningResource = ({ t, history, ...rest }) => {
+  const locale = useContext(LocaleContext);
   const { createArticle } = useFetchArticleData(undefined, locale);
 
   const createArticleAndPushRoute = async createdArticle => {
@@ -39,7 +41,6 @@ CreateLearningResource.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
-  locale: PropTypes.string.isRequired,
 };
 
 export default injectT(CreateLearningResource);

--- a/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.jsx
@@ -51,7 +51,6 @@ const EditLearningResource = ({ selectedLanguage, articleId, t, isNewlyCreated, 
 EditLearningResource.propTypes = {
   articleId: PropTypes.string.isRequired,
   licenses: LicensesArrayOf,
-  locale: PropTypes.string.isRequired,
   selectedLanguage: PropTypes.string.isRequired,
   isNewlyCreated: PropTypes.bool,
 };

--- a/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
@@ -24,7 +24,7 @@ interface Props {
   };
   previousLocation: string;
 }
-const EditResourceRedirect = ({ match, previousLocation }: Props) => {
+const EditResourceRedirect = ({ match, previousLocation, ...rest }: Props) => {
   const locale = useContext(LocaleContext);
   const { articleId } = match.params;
   const [supportedLanguage, setSupportedLanguage] = useState<string>();
@@ -46,6 +46,7 @@ const EditResourceRedirect = ({ match, previousLocation }: Props) => {
             articleId={articleId}
             selectedLanguage={props.match.params.selectedLanguage}
             isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
+            {...rest}
           />
         )}
       />

--- a/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
@@ -19,9 +19,6 @@ interface Props {
       articleId: string;
     };
   };
-  location: {
-    pathname: string;
-  };
 }
 const EditResourceRedirect = ({ match, ...rest }: Props) => {
   const locale = useContext(LocaleContext);

--- a/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState, useRef, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import EditLearningResource from './EditLearningResource';
 import { LocaleContext } from '../../App/App';

--- a/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { useState, useRef, useContext, useEffect } from 'react';
+import { Route, Redirect, Switch } from 'react-router-dom';
+import EditLearningResource from './EditLearningResource';
+import { LocaleContext } from '../../App/App';
+import { fetchDraft } from '../../../modules/draft/draftApi';
+
+interface Props {
+  match: {
+    url: string;
+    params: {
+      articleId: string;
+    };
+  };
+  location: {
+    pathname: string;
+  };
+  previousLocation: string;
+}
+const EditResourceRedirect = ({ match, previousLocation }: Props) => {
+  const locale = useContext(LocaleContext);
+  const { articleId } = match.params;
+  const [supportedLanguage, setSupportedLanguage] = useState<string>();
+
+  useEffect(() => {
+    fetchDraft(parseInt(articleId)).then(article => {
+      const lang =
+        article.supportedLanguages.find(l => l === locale) || article.supportedLanguages[0];
+      setSupportedLanguage(lang);
+    });
+  }, [articleId, locale]);
+
+  return (
+    <Switch>
+      <Route
+        path={`${match.url}/:selectedLanguage`}
+        render={props => (
+          <EditLearningResource
+            articleId={articleId}
+            selectedLanguage={props.match.params.selectedLanguage}
+            isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
+          />
+        )}
+      />
+      {supportedLanguage && (
+        <Redirect push from={match.url} to={`${match.url}/${supportedLanguage}`} />
+      )}
+    </Switch>
+  );
+};
+
+export default EditResourceRedirect;

--- a/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditResourceRedirect.tsx
@@ -22,9 +22,8 @@ interface Props {
   location: {
     pathname: string;
   };
-  previousLocation: string;
 }
-const EditResourceRedirect = ({ match, previousLocation, ...rest }: Props) => {
+const EditResourceRedirect = ({ match, ...rest }: Props) => {
   const locale = useContext(LocaleContext);
   const { articleId } = match.params;
   const [supportedLanguage, setSupportedLanguage] = useState<string>();
@@ -45,7 +44,6 @@ const EditResourceRedirect = ({ match, previousLocation, ...rest }: Props) => {
           <EditLearningResource
             articleId={articleId}
             selectedLanguage={props.match.params.selectedLanguage}
-            isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
             {...rest}
           />
         )}

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -19,15 +19,7 @@ import { LicensesArrayOf } from '../../../shapes';
 import * as messageActions from '../../Messages/messagesActions';
 import { LocationShape } from '../../../shapes';
 
-const LearningResourcePage = ({
-  fetchLicenses,
-  licenses,
-  location,
-  match,
-  history,
-  locale,
-  ...rest
-}) => {
+const LearningResourcePage = ({ fetchLicenses, licenses, location, match, history }) => {
   const previousLocation = useRef(location.pathname).current;
   useEffect(() => {
     if (!licenses.length) {
@@ -41,7 +33,7 @@ const LearningResourcePage = ({
         <Switch>
           <Route
             path={`${match.url}/new`}
-            render={() => <CreateLearningResource history={history} {...rest} />}
+            render={() => <CreateLearningResource history={history} licenses={licenses} />}
           />
           <Route
             path={`${match.url}/:articleId/edit/`}

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -11,7 +11,6 @@ import { Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { OneColumn } from '@ndla/ui';
 import { actions as licenseActions, getAllLicenses } from '../../../modules/license/license';
-import { getLocale } from '../../../modules/locale/locale';
 import EditResourceRedirect from './EditResourceRedirect';
 import CreateLearningResource from './CreateLearningResource';
 import NotFoundPage from '../../NotFoundPage/NotFoundPage';
@@ -19,7 +18,16 @@ import { LicensesArrayOf } from '../../../shapes';
 import * as messageActions from '../../Messages/messagesActions';
 import { LocationShape } from '../../../shapes';
 
-const LearningResourcePage = ({ fetchLicenses, licenses, location, match, history, ...rest }) => {
+const LearningResourcePage = ({
+  fetchLicenses,
+  licenses,
+  applicationError,
+  createMessage,
+  location,
+  match,
+  history,
+}) => {
+  const resourceFormProps = { applicationError, licenses, createMessage };
   const previousLocation = useRef(location.pathname).current;
   useEffect(() => {
     if (!licenses.length) {
@@ -33,21 +41,18 @@ const LearningResourcePage = ({ fetchLicenses, licenses, location, match, histor
         <Switch>
           <Route
             path={`${match.url}/new`}
-            render={() => (
-              <CreateLearningResource history={history} licenses={licenses} {...rest} />
-            )}
+            render={() => <CreateLearningResource history={history} {...resourceFormProps} />}
           />
-          <Route
-            path={`${match.url}/:articleId/edit/`}
-            render={props => (
+          <Route path={`${match.url}/:articleId/edit/`}>
+            {params => (
               <EditResourceRedirect
-                previousLocation={previousLocation}
-                licenses={licenses}
-                {...props}
-                {...rest}
+                match={params.match}
+                isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
+                {...resourceFormProps}
               />
             )}
-          />
+          </Route>
+
           <Route component={NotFoundPage} />
         </Switch>
       </OneColumn>
@@ -68,7 +73,6 @@ LearningResourcePage.propTypes = {
   }).isRequired,
   licenses: LicensesArrayOf,
   fetchLicenses: PropTypes.func.isRequired,
-  locale: PropTypes.string.isRequired,
   userAccess: PropTypes.string,
   createMessage: PropTypes.func.isRequired,
   applicationError: PropTypes.func.isRequired,
@@ -82,7 +86,6 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = state => ({
-  locale: getLocale(state),
   licenses: getAllLicenses(state),
   userAccess: state.session.user.scope,
 });

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -27,7 +27,6 @@ const LearningResourcePage = ({
   match,
   history,
 }) => {
-  const resourceFormProps = { applicationError, licenses, createMessage };
   const previousLocation = useRef(location.pathname).current;
   useEffect(() => {
     if (!licenses.length) {
@@ -35,6 +34,7 @@ const LearningResourcePage = ({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const resourceFormProps = { applicationError, licenses, createMessage };
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <OneColumn>

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -7,18 +7,16 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { OneColumn } from '@ndla/ui';
 import { actions as licenseActions, getAllLicenses } from '../../../modules/license/license';
 import { getLocale } from '../../../modules/locale/locale';
-import { fetchDraft } from '../../../modules/draft/draftApi';
 import EditLearningResource from './EditLearningResource';
 import CreateLearningResource from './CreateLearningResource';
 import NotFoundPage from '../../NotFoundPage/NotFoundPage';
 import { LicensesArrayOf } from '../../../shapes';
 import * as messageActions from '../../Messages/messagesActions';
-import { toEditArticle } from '../../../util/routeHelpers';
 import { LocationShape } from '../../../shapes';
 
 class LearningResourcePage extends PureComponent {
@@ -37,11 +35,6 @@ class LearningResourcePage extends PureComponent {
     if (this.props.location.pathname !== prevProps.location.pathname) {
       this.setState({ previousLocation: prevProps.location.pathname });
     }
-  }
-
-  async getDraft(id) {
-    const draft = await fetchDraft(id);
-    this.setState({ draft });
   }
 
   render() {
@@ -67,18 +60,9 @@ class LearningResourcePage extends PureComponent {
                 />
               )}
             />
-            <Route
-              path={`${match.url}/:articleId/edit`}
-              render={props => {
-                this.getDraft(props.match.params.articleId);
-                const draft = this.state.draft;
-                const language =
-                  draft && draft.supportedLanguages.find(lang => lang === this.props.locale);
-                draft &&
-                  history.push(
-                    toEditArticle(draft.id, 'standard', language || draft.supportedLanguages[0]),
-                  );
-              }}
+            <Redirect
+              from={`${match.url}/:articleId/edit`}
+              to={`${match.url}/:articleId/edit/${this.props.locale}`}
             />
             <Route component={NotFoundPage} />
           </Switch>

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -19,7 +19,7 @@ import { LicensesArrayOf } from '../../../shapes';
 import * as messageActions from '../../Messages/messagesActions';
 import { LocationShape } from '../../../shapes';
 
-const LearningResourcePage = ({ fetchLicenses, licenses, location, match, history }) => {
+const LearningResourcePage = ({ fetchLicenses, licenses, location, match, history, ...rest }) => {
   const previousLocation = useRef(location.pathname).current;
   useEffect(() => {
     if (!licenses.length) {
@@ -33,12 +33,19 @@ const LearningResourcePage = ({ fetchLicenses, licenses, location, match, histor
         <Switch>
           <Route
             path={`${match.url}/new`}
-            render={() => <CreateLearningResource history={history} licenses={licenses} />}
+            render={() => (
+              <CreateLearningResource history={history} licenses={licenses} {...rest} />
+            )}
           />
           <Route
             path={`${match.url}/:articleId/edit/`}
             render={props => (
-              <EditResourceRedirect previousLocation={previousLocation} {...props} />
+              <EditResourceRedirect
+                previousLocation={previousLocation}
+                licenses={licenses}
+                {...props}
+                {...rest}
+              />
             )}
           />
           <Route component={NotFoundPage} />

--- a/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.jsx
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React, { Fragment } from 'react';
+import React, { useContext, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
 import { HelmetWithTracker } from '@ndla/tracker';
+import { LocaleContext } from '../../App/App';
 import TopicArticleForm from './components/TopicArticleForm';
 import { useFetchArticleData } from '../../FormikForm/formikDraftHooks';
 import { toEditArticle } from '../../../util/routeHelpers';
 
-const CreateTopicArticle = props => {
-  const { locale, t, history, ...rest } = props;
+const CreateTopicArticle = ({ history, t, ...rest }) => {
+  const locale = useContext(LocaleContext);
   const { createArticle } = useFetchArticleData(undefined, locale);
 
   const createArticleAndPushRoute = async createdArticle => {
@@ -41,7 +42,6 @@ CreateTopicArticle.propTypes = {
     push: PropTypes.func.isRequired,
   }).isRequired,
   createMessage: PropTypes.func.isRequired,
-  locale: PropTypes.string.isRequired,
 };
 
 export default injectT(CreateTopicArticle);

--- a/src/containers/ArticlePage/TopicArticlePage/EditArticleRedirect.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/EditArticleRedirect.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { useState, useContext, useEffect } from 'react';
+import { Route, Redirect, Switch } from 'react-router-dom';
+import EditTopicArticle from './EditTopicArticle';
+import { LocaleContext } from '../../App/App';
+import { fetchDraft } from '../../../modules/draft/draftApi';
+
+interface Props {
+  match: {
+    url: string;
+    params: {
+      articleId: string;
+    };
+  };
+}
+const EditArticleRedirect = ({ match, ...rest }: Props) => {
+  const locale = useContext(LocaleContext);
+  const { articleId } = match.params;
+  const [supportedLanguage, setSupportedLanguage] = useState<string>();
+
+  useEffect(() => {
+    fetchDraft(parseInt(articleId)).then(article => {
+      const lang =
+        article.supportedLanguages.find(l => l === locale) || article.supportedLanguages[0];
+      setSupportedLanguage(lang);
+    });
+  }, [articleId, locale]);
+
+  return (
+    <Switch>
+      <Route
+        path={`${match.url}/:selectedLanguage`}
+        render={props => (
+          <EditTopicArticle
+            articleId={articleId}
+            selectedLanguage={props.match.params.selectedLanguage}
+            {...rest}
+          />
+        )}
+      />
+      {supportedLanguage && (
+        <Redirect push from={match.url} to={`${match.url}/${supportedLanguage}`} />
+      )}
+    </Switch>
+  );
+};
+
+export default EditArticleRedirect;

--- a/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
@@ -5,83 +5,59 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { OneColumn } from '@ndla/ui';
 import * as messageActions from '../../Messages/messagesActions';
-import { getLocale } from '../../../modules/locale/locale';
-import { fetchDraft } from '../../../modules/draft/draftApi';
-import EditTopicArticle from './EditTopicArticle';
+import EditArticleRedirect from './EditArticleRedirect';
 import CreateTopicArticle from './CreateTopicArticle';
 import NotFoundPage from '../../NotFoundPage/NotFoundPage';
 import { actions as licenseActions, getAllLicenses } from '../../../modules/license/license';
-import { toEditArticle } from '../../../util/routeHelpers';
 import { LocationShape } from '../../../shapes';
 
-class TopicArticlePage extends React.Component {
-  constructor(props) {
-    super();
-    this.state = { previousLocation: '' };
-  }
-  componentDidMount() {
-    const { fetchLicenses, licenses } = this.props;
+const TopicArticlePage = ({
+  location,
+  match,
+  history,
+  licenses,
+  fetchLicenses,
+  applicationError,
+  createMessage,
+}) => {
+  const previousLocation = useRef(location.pathname).current;
+
+  useEffect(() => {
     if (!licenses.length) {
       fetchLicenses();
     }
-  }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
-      this.setState({ previousLocation: prevProps.location.pathname });
-    }
-  }
+  const articleFormProps = { applicationError, licenses, createMessage };
 
-  async getDraft(id) {
-    const draft = await fetchDraft(id);
-    this.setState({ draft });
-  }
+  return (
+    <OneColumn>
+      <Switch>
+        <Route
+          path={`${match.url}/new`}
+          render={() => <CreateTopicArticle history={history} {...articleFormProps} />}
+        />
+        <Route path={`${match.url}/:articleId/edit/`}>
+          {params => (
+            <EditArticleRedirect
+              match={params.match}
+              isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
+              {...articleFormProps}
+            />
+          )}
+        </Route>
+        <Route component={NotFoundPage} />
+      </Switch>
+    </OneColumn>
+  );
+};
 
-  render() {
-    const { match, history, ...rest } = this.props;
-    return (
-      <OneColumn>
-        <Switch>
-          <Route
-            path={`${match.url}/new`}
-            render={() => <CreateTopicArticle history={history} {...rest} />}
-          />
-          <Route
-            path={`${match.url}/:articleId/edit/:selectedLanguage`}
-            render={routeProps => (
-              <EditTopicArticle
-                articleId={routeProps.match.params.articleId}
-                selectedLanguage={routeProps.match.params.selectedLanguage}
-                isNewlyCreated={this.state.previousLocation === '/subject-matter/topic-article/new'}
-                {...rest}
-              />
-            )}
-          />
-          <Route
-            path={`${match.url}/:articleId/edit`}
-            render={routeProps => {
-              this.getDraft(routeProps.match.params.articleId);
-              const draft = this.state.draft;
-              const language =
-                draft && draft.supportedLanguages.find(lang => lang === this.props.locale);
-              draft &&
-                history.push(
-                  toEditArticle(draft.id, 'topic-article', language || draft.supportedLanguages[0]),
-                );
-            }}
-          />
-          <Route component={NotFoundPage} />
-        </Switch>
-      </OneColumn>
-    );
-  }
-}
 TopicArticlePage.propTypes = {
   match: PropTypes.shape({
     url: PropTypes.string.isRequired,
@@ -89,7 +65,6 @@ TopicArticlePage.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
-  locale: PropTypes.string.isRequired,
   licenses: PropTypes.arrayOf(
     PropTypes.shape({
       description: PropTypes.string,
@@ -110,7 +85,6 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = state => ({
-  locale: getLocale(state),
   licenses: getAllLicenses(state),
   userAccess: state.session.user.scope,
 });


### PR DESCRIPTION
Fikk en feilmelding om changing state i render 
`Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.`
Tror denne redirecten vil få til det samme som history.push, bare med bruk av react router Redirect

Når vi henter fra backend så vil den finne en mulig språk fallback automatisk tror jeg? vi behøver ikke finne den før vi kommer inn