### PR TITLE
Do not convert å to &aring;

### DIFF
--- a/src/modules/translate/translateApi.js
+++ b/src/modules/translate/translateApi.js
@@ -22,5 +22,6 @@ export const fetchNnTranslation = ({ id, ...articleContents }) =>
       guid: config.ndlaEnvironment + '_' + id,
       prefs: { x: true }, // Hack to tell the service to use old html-parser, ref jo.christian.oterhals@ntb.no
       document: articleContents,
+      fileType: 'htmlp', // Tells old html-parser to skip changing æøå to entities.
     }),
   }).then(resolveJsonOrRejectWithError);


### PR DESCRIPTION
Omgår feil i oversettelsestjeneste der æøå gjøres om til html entitieter.

Test:
Lag en artikkel med æøå i ingress. Lagre og bruk knapp Oversett til nynorsk. Ny variant skal ha æøå i ingress fremdeles.