### PR TITLE
Reinstating missing html-edit link.

### DIFF
--- a/cypress/integration/Editor/full_resource_spec.js
+++ b/cypress/integration/Editor/full_resource_spec.js
@@ -61,4 +61,8 @@ describe('Edit article with everything', () => {
       .click();
     cy.apiwait('@saveLearningResource');
   });
+
+  it('Has access to the html-editor', () => {
+    cy.get('a[data-testid=edit-markup-link]').should('be.visible');
+  });
 });

--- a/cypress/integration/Editor/topic_article_spec.js
+++ b/cypress/integration/Editor/topic_article_spec.js
@@ -39,4 +39,8 @@ describe('Language handling', () => {
       .contains('Legg til')
       .click({ force: true });
   });
+
+  it('Has access to the html-editor', () => {
+    cy.get('a[data-testid=edit-markup-link]').should('be.visible');
+  });
 });

--- a/src/components/EditMarkupLink.jsx
+++ b/src/components/EditMarkupLink.jsx
@@ -47,6 +47,7 @@ export const EditMarkupLink = ({ title, to, inHeader }) => {
   return (
     <Link
       css={linkStyle}
+      data-testid="edit-markup-link"
       to={{
         pathname: to,
         state: {

--- a/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/LearningResourcePage.jsx
@@ -24,6 +24,7 @@ const LearningResourcePage = ({
   applicationError,
   createMessage,
   location,
+  userAccess,
   match,
   history,
 }) => {
@@ -34,7 +35,7 @@ const LearningResourcePage = ({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const resourceFormProps = { applicationError, licenses, createMessage };
+  const resourceFormProps = { applicationError, licenses, createMessage, userAccess };
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <OneColumn>

--- a/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
@@ -25,6 +25,7 @@ const TopicArticlePage = ({
   fetchLicenses,
   applicationError,
   createMessage,
+  userAccess,
 }) => {
   const previousLocation = useRef(location.pathname).current;
 
@@ -34,7 +35,7 @@ const TopicArticlePage = ({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const articleFormProps = { applicationError, licenses, createMessage };
+  const articleFormProps = { applicationError, licenses, createMessage, userAccess };
 
   return (
     <OneColumn>


### PR DESCRIPTION
userAccess forsvant fra props til artikkelredigering så måtte legge det inn igjen for å få html-tilgang.

Test: Sjekk at du har html-lenka tilgjengelig på en tilfeldig artikkel.