### PR TITLE
Changing label on two statuses

### DIFF
--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -659,7 +659,8 @@ const phrases = {
       published: 'Published',
       unpublished: 'Unpublished',
       awaiting_unpublishing: 'Awaiting unpublishing',
-      archived: 'Archived',
+      awaiting_archiving: 'Delayed archivation',
+      archived: 'Deleted',
       actions: {
         DRAFT: 'Draft',
         PROPOSAL: 'Proposal',
@@ -674,8 +675,8 @@ const phrases = {
         PUBLISHED: 'Publish',
         AWAITING_UNPUBLISHING: 'Queue for unpublishing',
         UNPUBLISHED: 'Unpublish',
-        ARCHIVED: 'Archive',
-        AWAITING_ARCHIVING: 'Archivation-delayed',
+        ARCHIVED: 'Delete',
+        AWAITING_ARCHIVING: 'Delayed archivation',
       },
       learningpath_statuses: {
         private: 'Draft',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -672,8 +672,8 @@ const phrases = {
       published: 'Publisert',
       unpublished: 'Avpublisert',
       awaiting_unpublishing: 'Til avpublisering',
-      awaiting_archiving: 'Arkivering-utsatt',
-      archived: 'Arkivert',
+      awaiting_archiving: 'Utsatt arkivering',
+      archived: 'Slettet',
       actions: {
         DRAFT: 'Kladd',
         PROPOSAL: 'Utkast',
@@ -688,8 +688,8 @@ const phrases = {
         PUBLISHED: 'Publiser',
         AWAITING_UNPUBLISHING: 'Til avpublisering',
         UNPUBLISHED: 'Avpubliser',
-        ARCHIVED: 'Arkiver',
-        AWAITING_ARCHIVING: 'Arkivering-utsatt',
+        ARCHIVED: 'Slett',
+        AWAITING_ARCHIVING: 'Utsatt arkivering',
       },
       learningpath_statuses: {
         private: 'Kladd',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -681,7 +681,8 @@ const phrases = {
       published: 'Publisert',
       unpublished: 'Avpublisert',
       awaiting_unpublishing: 'Til avpublisering',
-      archived: 'Arkivert',
+      awaiting_archiving: 'Utsatt arkivering',
+      archived: 'Slettet',
       actions: {
         DRAFT: 'Kladd',
         PROPOSAL: 'Utkast',
@@ -696,8 +697,8 @@ const phrases = {
         PUBLISHED: 'Publiser',
         AWAITING_UNPUBLISHING: 'Til avpublisering',
         UNPUBLISHED: 'Avpubliser',
-        ARCHIVED: 'Arkiver',
-        AWAITING_ARCHIVING: 'Arkivering-utsatt',
+        ARCHIVED: 'Slett',
+        AWAITING_ARCHIVING: 'Utsatt arkivering',
       },
       learningpath_statuses: {
         private: 'Kladd',


### PR DESCRIPTION
Endrer navn på statuser. Det som tidligere var Arkivert er no Sletta for å skille tydeligere på forskjellen mellom sletta artikler og arkivløsning som kjem etter kvart.

Test:
Søk etter artikler med status Slettet. Disse skal kun dukke opp i dette søket. Statusendringer skal bruke navnet Slett.