### PR TITLE
2540 Displaying search hits from notes

### DIFF
--- a/src/containers/SearchPage/components/results/SearchHighlight.tsx
+++ b/src/containers/SearchPage/components/results/SearchHighlight.tsx
@@ -49,7 +49,10 @@ const SearchHighlight = ({ content, locale, t }: Props & tType) => {
     highlightsToSearch.find(highlight => highlight.field.split('.')[0] === field);
 
   const selectedHighlights =
-    selectHighlights('content') || selectHighlights('embedAttributes') || selectHighlights('tags');
+    selectHighlights('content') ||
+    selectHighlights('embedAttributes') ||
+    selectHighlights('tags') ||
+    selectHighlights('notes');
 
   return selectedHighlights ? (
     <StyledDiv>

--- a/src/containers/SearchPage/components/results/SearchHighlight.tsx
+++ b/src/containers/SearchPage/components/results/SearchHighlight.tsx
@@ -52,7 +52,8 @@ const SearchHighlight = ({ content, locale, t }: Props & tType) => {
     selectHighlights('content') ||
     selectHighlights('embedAttributes') ||
     selectHighlights('tags') ||
-    selectHighlights('notes');
+    selectHighlights('notes') ||
+    selectHighlights('previousVersionsNotes');
 
   return selectedHighlights ? (
     <StyledDiv>

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -156,6 +156,7 @@ const phrases = {
       content: 'Search hits from content',
       tags: 'Search hits from tags',
       embedAttributes: 'Search hits from embedded elements',
+      notes: 'Search hits from version log',
     },
   },
   articleType: {

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -157,6 +157,7 @@ const phrases = {
       tags: 'Search hits from tags',
       embedAttributes: 'Search hits from embedded elements',
       notes: 'Search hits from version log',
+      previousVersionsNotes: 'Search hits from version log',
     },
   },
   articleType: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -157,6 +157,7 @@ const phrases = {
       content: 'Søketreff fra innhold',
       tags: 'Søketreff fra nøkkelord',
       embedAttributes: 'Søketreff fra innebygde elementer',
+      notes: 'Søketreff fra versjonslogg',
     },
   },
   articleType: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -158,6 +158,7 @@ const phrases = {
       tags: 'Søketreff fra nøkkelord',
       embedAttributes: 'Søketreff fra innebygde elementer',
       notes: 'Søketreff fra versjonslogg',
+      previousVersionsNotes: 'Søketreff fra versjonslogg',
     },
   },
   articleType: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -157,6 +157,7 @@ const phrases = {
       content: 'Søketreff frå innhold',
       tags: 'Søketreff frå nøkkelord',
       embedAttributes: 'Søketreff frå innebygde elementer',
+      notes: 'Søketreff frå versjonslogg',
     },
   },
   articleType: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -158,6 +158,7 @@ const phrases = {
       tags: 'Søketreff frå nøkkelord',
       embedAttributes: 'Søketreff frå innebygde elementer',
       notes: 'Søketreff frå versjonslogg',
+      previousVersionsNotes: 'Søketreff frå versjonslogg',
     },
   },
   articleType: {


### PR DESCRIPTION
Fixes NDLANO/Issues#2540

Viser også søketreff fra notes.

Test: Søk etter artikler med feks ordet Oppdatert. Dersom det ikkje er andre treff, skal det vises "Søketreff fra versjonslogg"