### PR TITLE
Setting height on edlib-iframe based on window

### DIFF
--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -19,9 +19,13 @@ const FlexWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledIFrame = styled.iframe`
+interface IframeProps {
+  iframeHeight: number;
+}
+
+const StyledIFrame = styled.iframe<IframeProps>`
   height: 100%;
-  min-height: 1000px;
+  min-height: ${props => props.iframeHeight}px;
 `;
 
 interface OnSelectObject {
@@ -31,6 +35,7 @@ interface OnSelectObject {
 
 interface Props {
   h5pUrl?: string;
+  height?: number;
   onSelect: (selected: OnSelectObject) => void;
   onClose: () => void;
   locale: string;
@@ -112,7 +117,7 @@ class H5PElement extends Component<Props & tType, State> {
 
   render() {
     const { url, fetchFailed } = this.state;
-    const { t } = this.props;
+    const { height = 950, t } = this.props;
     return (
       <FlexWrapper>
         {fetchFailed && (
@@ -129,13 +134,14 @@ class H5PElement extends Component<Props & tType, State> {
             }}
           />
         )}
-        {url && <StyledIFrame src={url} title="H5P" frameBorder="0" />}
+        {url && <StyledIFrame iframeHeight={height} src={url} title="H5P" frameBorder="0" />}
       </FlexWrapper>
     );
   }
 
   static propTypes = {
     h5pUrl: PropTypes.string,
+    height: PropTypes.number,
     onSelect: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     locale: PropTypes.string.isRequired,

--- a/src/containers/H5PPage/H5PPage.jsx
+++ b/src/containers/H5PPage/H5PPage.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import config from '../../config';
 import { LocaleContext } from '../App/App';
 import H5PElement from '../../components/H5PElement';
 import { HistoryShape } from '../../shapes';
 
 const H5PPage = props => {
+  const [height, setHeight] = useState(800);
+
+  useEffect(() => {
+    if (typeof window !== undefined) {
+      setHeight(window.innerHeight - 85);
+    }
+  }, []);
+
   return (
     <LocaleContext.Consumer>
       {locale => (
@@ -16,6 +24,7 @@ const H5PPage = props => {
             props.history.goBack();
           }}
           locale={locale}
+          height={height}
         />
       )}
     </LocaleContext.Consumer>


### PR DESCRIPTION
fixing NDLANO/Issues#2542

Test:
Åpne pr-installasjon og velg Rediger H5P i menyen. Edlib skal ta opp heile høgda på skjermen - header.
Innsetting og redigering av h5p i artikkel skal fremdels funke greit. 