### PR TITLE
Do not send origin

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
@@ -52,7 +52,7 @@ export const getInitialValues = (article = {}) => {
     metaImageAlt: article.metaImage?.alt || '',
     metaImageId,
     notes: [],
-    origin: article.copyright?.origin || '',
+    origin: article.copyright?.origin,
     processors: parseCopyrightContributors(article, 'processors'),
     published: article.published,
     revision: article.revision,


### PR DESCRIPTION
Det at vi setter origin til '' gjør at det er forskjell på det som sendes inn og det som er lagra for nesten alle artikler. Det vil sei at disse får ny versjon i apiet sjølv om det kun er metadata som endres.

Test:
Alt skal fungere som vanlig. Artikler som ikkje har origin skal kunne oppdateres med metadata uten at status endres.