### PR TITLE
Tar vare på valgt status ved endring av andre søkeparametre.

### DIFF
--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -28,6 +28,7 @@ const emptySearchState: SearchState = {
   subjects: '',
   resourceTypes: '',
   status: '',
+  includeOtherStatuses: false,
   users: '',
   lang: '',
 };
@@ -40,10 +41,11 @@ interface Props {
   locale: string;
 }
 
-export interface SearchState extends Record<string, string | undefined> {
+export interface SearchState extends Record<string, string | boolean | undefined> {
   subjects: string;
   resourceTypes?: string;
   status: string;
+  includeOtherStatuses: boolean;
   query: string;
   users: string;
   // This field is called `lang` instead of `language` to NOT match with tag in `SearchTagGroup.tsx`
@@ -83,6 +85,7 @@ class SearchContentForm extends Component<Props & tType, State> {
         subjects: searchObject.subjects || '',
         resourceTypes: searchObject['resource-types'] || '',
         status: searchObject['draft-status'] || '',
+        includeOtherStatuses: searchObject['include-other-statuses'] || false,
         query: searchObject.query || '',
         users: searchObject.users || '',
         lang: searchObject.language || locale,
@@ -100,7 +103,7 @@ class SearchContentForm extends Component<Props & tType, State> {
     this.getExternalData();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  /*componentDidUpdate(prevProps: Props) {
     const { searchObject, locale } = this.props;
     if (prevProps.searchObject?.query !== searchObject?.query) {
       this.setState({
@@ -108,20 +111,31 @@ class SearchContentForm extends Component<Props & tType, State> {
           subjects: searchObject.subjects || '',
           resourceTypes: searchObject['resource-types'] || '',
           status: searchObject['draft-status'] || '',
+          includeOtherStatuses: searchObject['include-other-statuses'] || 'false',
           query: searchObject.query || '',
           users: searchObject.users || '',
           lang: searchObject.language || locale,
         },
       });
     }
-  }
+  }*/
 
   onFieldChange(evt: FormEvent<HTMLInputElement>) {
     const { name, value } = evt.currentTarget;
-    this.setState(
-      prevState => ({ search: { ...prevState.search, [name]: value } }),
-      this.handleSearch,
-    );
+    this.setState(prevState => {
+      let includeOtherStatuses = prevState.search.includeOtherStatuses;
+      if (name === 'status') {
+        // HAS_PUBLISHED isn't a status in the backend.
+        includeOtherStatuses = value === 'HAS_PUBLISHED';
+      }
+      return {
+        search: {
+          ...prevState.search,
+          includeOtherStatuses,
+          [name]: value,
+        },
+      };
+    }, this.handleSearch);
   }
 
   async getExternalData() {
@@ -139,18 +153,17 @@ class SearchContentForm extends Component<Props & tType, State> {
 
   handleSearch() {
     const {
-      search: { resourceTypes, status, subjects, query, users, lang },
+      search: { resourceTypes, status, includeOtherStatuses, subjects, query, users, lang },
     } = this.state;
     const { search } = this.props;
 
     // HAS_PUBLISHED isn't a status in the backend.
     const newStatus = status === 'HAS_PUBLISHED' ? 'PUBLISHED' : status;
-    const shouldFilterOthers = status === 'HAS_PUBLISHED';
 
     search({
       'resource-types': resourceTypes,
       'draft-status': newStatus,
-      'include-other-statuses': shouldFilterOthers.toString(),
+      'include-other-statuses': includeOtherStatuses,
       subjects,
       query,
       users,

--- a/src/containers/SearchPage/components/form/SearchForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchForm.tsx
@@ -24,7 +24,7 @@ export const searchFormClasses = new BEMHelper({
 export interface SearchParams {
   query?: string | null;
   'draft-status'?: string | null;
-  'include-other-statuses'?: string | null;
+  'include-other-statuses'?: boolean | null;
   'page-size'?: string | null;
   'resource-types'?: string | null;
   fallback?: boolean | null;


### PR DESCRIPTION
componentDidUpdate nullstillte søket basert på urlen, men det førte til at valgt syntetisk status blei borte. Endring av parameter er uansett håndtert i onFieldChange så eg kommenterte ut metoden. Er det åpenbare feil med måten eg har tenkt her?

Test:
Søk etter innhold med status Har publisert og endre søkeordet. Statusen skal bli stående og includeOtherStatuses skal fortsatt være true.