### PR TITLE
2543 skjule modalheader for h5p

### DIFF
--- a/cypress/integration/Editor/slate_block_picker_spec.js
+++ b/cypress/integration/Editor/slate_block_picker_spec.js
@@ -117,9 +117,8 @@ describe('can enter both element types SlateBlockPicker and SlateVisualElementPi
 
   it('opens and closes H5P', () => {
     cy.get('[data-cy=create-h5p]').click();
-    cy.get('[data-cy="modal-header"]').should('be.visible');
-    cy.get('[data-cy="modal-body"]').should('be.visible');
-    cy.get('[data-cy="close-modal-button"]').click();
+    cy.get('[data-cy=h5p-editor').should('be.visible');
+    cy.get('[data-testid="closeAlert"]').click();
   });
 
   it('opens and closes url', () => {

--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
-import { css } from '@emotion/react';
+import { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { injectT } from '@ndla/i18n';
 import VisualElementSearch from '../../../containers/VisualElement/VisualElementSearch';
+import { StyledModal } from '../../SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
 
 const DisplayExternalModal = ({
   isEditMode,
@@ -18,14 +18,8 @@ const DisplayExternalModal = ({
     return null;
   }
   return (
-    <Modal
-      css={css`
-        overflow: hidden;
-        .modal-body {
-          height: 90%;
-          overflow: hidden;
-        }
-      `}
+    <StyledModal
+      narrow
       controllable
       isOpen={isEditMode}
       size={allowedProvider.name.toLowerCase() === 'h5p' ? 'fullscreen' : 'large'}
@@ -48,7 +42,7 @@ const DisplayExternalModal = ({
           </ModalBody>
         </Fragment>
       )}
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
@@ -28,9 +28,11 @@ const DisplayExternalModal = ({
       minHeight="85vh">
       {onCloseModal => (
         <Fragment>
-          <ModalHeader>
-            <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
-          </ModalHeader>
+          {allowedProvider.name.toLowerCase() !== 'h5p' && (
+            <ModalHeader>
+              <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
+            </ModalHeader>
+          )}
           <ModalBody>
             <VisualElementSearch
               selectedResource={allowedProvider.name}

--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
@@ -1,9 +1,8 @@
-import React, { Fragment, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { injectT } from '@ndla/i18n';
 import VisualElementSearch from '../../../containers/VisualElement/VisualElementSearch';
-import { StyledVisualElementModal } from '../../SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
+import VisualElementModalWrapper from '../../../containers/VisualElement/VisualElementModalWrapper';
 
 const DisplayExternalModal = ({
   isEditMode,
@@ -14,40 +13,25 @@ const DisplayExternalModal = ({
   src,
   t,
 }) => {
-  const [h5pFetchFail, setH5pFetchFail] = useState(false);
-
   if (!isEditMode) {
     return null;
   }
   return (
-    <StyledVisualElementModal
-      narrow
-      controllable
+    <VisualElementModalWrapper
+      resource={allowedProvider.name.toLowerCase()}
       isOpen={isEditMode}
-      size={allowedProvider.name.toLowerCase() === 'h5p' ? 'fullscreen' : 'large'}
-      backgroundColor="white"
-      onClose={onClose}
-      minHeight="85vh">
-      {onCloseModal => (
-        <Fragment>
-          {(allowedProvider.name.toLowerCase() !== 'h5p' || h5pFetchFail) && (
-            <ModalHeader>
-              <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
-            </ModalHeader>
-          )}
-          <ModalBody>
-            <VisualElementSearch
-              selectedResource={allowedProvider.name}
-              selectedResourceUrl={src}
-              selectedResourceType={type}
-              handleVisualElementChange={onEditEmbed}
-              closeModal={onClose}
-              setH5pFetchFail={setH5pFetchFail}
-            />
-          </ModalBody>
-        </Fragment>
+      onClose={onClose}>
+      {setH5pFetchFail => (
+        <VisualElementSearch
+          selectedResource={allowedProvider.name}
+          selectedResourceUrl={src}
+          selectedResourceType={type}
+          handleVisualElementChange={onEditEmbed}
+          closeModal={onClose}
+          setH5pFetchFail={setH5pFetchFail}
+        />
       )}
-    </StyledVisualElementModal>
+    </VisualElementModalWrapper>
   );
 };
 

--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { injectT } from '@ndla/i18n';
 import VisualElementSearch from '../../../containers/VisualElement/VisualElementSearch';
-import { StyledModal } from '../../SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
+import { StyledVisualElementModal } from '../../SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
 
 const DisplayExternalModal = ({
   isEditMode,
@@ -20,7 +20,7 @@ const DisplayExternalModal = ({
     return null;
   }
   return (
-    <StyledModal
+    <StyledVisualElementModal
       narrow
       controllable
       isOpen={isEditMode}
@@ -47,7 +47,7 @@ const DisplayExternalModal = ({
           </ModalBody>
         </Fragment>
       )}
-    </StyledModal>
+    </StyledVisualElementModal>
   );
 };
 

--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { injectT } from '@ndla/i18n';
@@ -14,6 +14,8 @@ const DisplayExternalModal = ({
   src,
   t,
 }) => {
+  const [h5pFetchFail, setH5pFetchFail] = useState(false);
+
   if (!isEditMode) {
     return null;
   }
@@ -28,7 +30,7 @@ const DisplayExternalModal = ({
       minHeight="85vh">
       {onCloseModal => (
         <Fragment>
-          {allowedProvider.name.toLowerCase() !== 'h5p' && (
+          {(allowedProvider.name.toLowerCase() !== 'h5p' || h5pFetchFail) && (
             <ModalHeader>
               <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
             </ModalHeader>
@@ -40,6 +42,7 @@ const DisplayExternalModal = ({
               selectedResourceType={type}
               handleVisualElementChange={onEditEmbed}
               closeModal={onClose}
+              setH5pFetchFail={setH5pFetchFail}
             />
           </ModalBody>
         </Fragment>

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -17,6 +17,7 @@ import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PMetadata } from './h5pApi'
 const FlexWrapper = styled.div`
   height: 100%;
   width: 100%;
+  data-cy: 'h5p-editor';
 `;
 
 const StyledIFrame = styled.iframe`

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -34,6 +34,7 @@ interface Props {
   onClose: () => void;
   locale: string;
   canReturnResources?: boolean;
+  setH5pFetchFail?: (failed: boolean) => void;
 }
 
 interface State {
@@ -63,7 +64,7 @@ class H5PElement extends Component<Props & tType, State> {
 
   /* eslint-disable react/no-did-mount-set-state -- See: https://github.com/yannickcr/eslint-plugin-react/issues/1110 */
   async componentDidMount() {
-    const { h5pUrl, locale } = this.props;
+    const { h5pUrl, locale, setH5pFetchFail } = this.props;
     window.addEventListener('message', this.handleH5PChange);
     window.addEventListener('message', this.handleH5PClose);
     try {
@@ -73,6 +74,7 @@ class H5PElement extends Component<Props & tType, State> {
       this.setState(() => ({ url: data.url }));
     } catch (e) {
       this.setState({ fetchFailed: true });
+      setH5pFetchFail && setH5pFetchFail(true);
     }
   }
 

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -17,7 +17,6 @@ import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PMetadata } from './h5pApi'
 const FlexWrapper = styled.div`
   height: 100%;
   width: 100%;
-  data-cy: 'h5p-editor';
 `;
 
 const StyledIFrame = styled.iframe`
@@ -116,7 +115,7 @@ class H5PElement extends Component<Props & tType, State> {
     const { url, fetchFailed } = this.state;
     const { t } = this.props;
     return (
-      <FlexWrapper>
+      <FlexWrapper data-cy="h5p-editor">
         {fetchFailed && (
           <ErrorMessage
             illustration={{

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -8,7 +8,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import css from '@emotion/css';
 import styled from '@emotion/styled';
 import { injectT, tType } from '@ndla/i18n';
 import { ErrorMessage } from '@ndla/ui';
@@ -20,17 +19,8 @@ const FlexWrapper = styled.div`
   width: 100%;
 `;
 
-interface StyledProps {
-  setMinHeightForModal?: string;
-}
-
-const StyledIFrame = styled.iframe<StyledProps>`
+const StyledIFrame = styled.iframe`
   height: 100%;
-  ${props =>
-    props.setMinHeightForModal &&
-    css`
-      min-height: 85vh;
-    `};
 `;
 
 interface OnSelectObject {
@@ -45,7 +35,6 @@ interface Props {
   locale: string;
   canReturnResources?: boolean;
   setH5pFetchFail?: (failed: boolean) => void;
-  setMinHeightForModal?: string;
 }
 
 interface State {
@@ -124,7 +113,7 @@ class H5PElement extends Component<Props & tType, State> {
 
   render() {
     const { url, fetchFailed } = this.state;
-    const { t, setMinHeightForModal } = this.props;
+    const { t } = this.props;
     return (
       <FlexWrapper>
         {fetchFailed && (
@@ -141,14 +130,7 @@ class H5PElement extends Component<Props & tType, State> {
             }}
           />
         )}
-        {url && (
-          <StyledIFrame
-            src={url}
-            title="H5P"
-            frameBorder="0"
-            setMinHeightForModal={setMinHeightForModal}
-          />
-        )}
+        {url && <StyledIFrame src={url} title="H5P" frameBorder="0" />}
       </FlexWrapper>
     );
   }

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -8,6 +8,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import css from '@emotion/css';
 import styled from '@emotion/styled';
 import { injectT, tType } from '@ndla/i18n';
 import { ErrorMessage } from '@ndla/ui';
@@ -19,8 +20,17 @@ const FlexWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledIFrame = styled.iframe`
+interface StyledProps {
+  setMinHeightForModal?: string;
+}
+
+const StyledIFrame = styled.iframe<StyledProps>`
   height: 100%;
+  ${props =>
+    props.setMinHeightForModal &&
+    css`
+      min-height: 85vh;
+    `};
 `;
 
 interface OnSelectObject {
@@ -35,6 +45,7 @@ interface Props {
   locale: string;
   canReturnResources?: boolean;
   setH5pFetchFail?: (failed: boolean) => void;
+  setMinHeightForModal?: string;
 }
 
 interface State {
@@ -113,7 +124,7 @@ class H5PElement extends Component<Props & tType, State> {
 
   render() {
     const { url, fetchFailed } = this.state;
-    const { t } = this.props;
+    const { t, setMinHeightForModal } = this.props;
     return (
       <FlexWrapper>
         {fetchFailed && (
@@ -130,7 +141,14 @@ class H5PElement extends Component<Props & tType, State> {
             }}
           />
         )}
-        {url && <StyledIFrame src={url} title="H5P" frameBorder="0" />}
+        {url && (
+          <StyledIFrame
+            src={url}
+            title="H5P"
+            frameBorder="0"
+            setMinHeightForModal={setMinHeightForModal}
+          />
+        )}
       </FlexWrapper>
     );
   }

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -19,14 +19,16 @@ const appearances = {
     max-width: 870px;
   `,
   fullscreen: css`
-    max-width: 95%;
-    height: 90vh;
+    align-self: center;
+    margin: auto;
+    min-width: 95vw;
+    height: 95vh;
   `,
   modal: css`
     border-radius: 0;
     min-height: 210px;
     max-width: 620px;
-    padding-bottom: ${spacing.noraml};
+    padding-bottom: ${spacing.normal};
   `,
 };
 
@@ -58,6 +60,11 @@ const StyledLightbox = styled('div')`
   background-color: rgba(0, 0, 0, 0.8);
   z-index: 1000;
   overflow-x: auto;
+  ${p =>
+    p.appearance === 'fullscreen' &&
+    css`
+      display: flex;
+    `};
 
   @media (max-width: ${breakpoints.tabletWide}) {
     top: 64px;
@@ -124,26 +131,35 @@ class Lightbox extends React.PureComponent {
   }
 
   render() {
-    const { children, closeButton, width, appearance, severity, contentCss } = this.props;
+    const {
+      children,
+      closeButton,
+      width,
+      appearance,
+      severity,
+      contentCss,
+      hideCloseButton,
+    } = this.props;
 
     return this.state.display ? (
-      <StyledLightbox>
+      <StyledLightbox appearance={appearance}>
         <StyledLightboxContent
           maxWidth={width}
           appearance={appearance}
           severity={severity}
           css={contentCss}>
-          {closeButton ? (
-            closeButton
-          ) : (
-            <Button
-              css={closeLightboxButtonStyle}
-              stripped
-              data-testid="closeAlert"
-              onClick={this.onCloseButtonClick}>
-              <StyledCross severity={severity} />
-            </Button>
-          )}
+          {!hideCloseButton &&
+            (closeButton ? (
+              closeButton
+            ) : (
+              <Button
+                css={closeLightboxButtonStyle}
+                stripped
+                data-testid="closeAlert"
+                onClick={this.onCloseButtonClick}>
+                <StyledCross severity={severity} />
+              </Button>
+            ))}
           <ChildWrapper>{children}</ChildWrapper>
         </StyledLightboxContent>
       </StyledLightbox>
@@ -159,6 +175,7 @@ Lightbox.propTypes = {
   appearance: PropTypes.oneOf(['modal', 'big', 'fullscreen']),
   severity: PropTypes.oneOf(['danger', 'info', 'success', 'warning']),
   contentCss: PropTypes.string,
+  hideCloseButton: PropTypes.bool,
 };
 
 export default Lightbox;

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -44,9 +44,11 @@ const SlateVisualElementPicker = ({
       minHeight={resource !== 'file' && '90vh'}>
       {onCloseModal => (
         <Fragment>
-          <ModalHeader>
-            <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
-          </ModalHeader>
+          {resource !== 'h5p' && (
+            <ModalHeader>
+              <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
+            </ModalHeader>
+          )}
           <ModalBody>
             <VisualElementSearch
               articleLanguage={articleLanguage}

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -6,7 +6,7 @@ import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import VisualElementSearch from '../../../../containers/VisualElement/VisualElementSearch';
 import { defaultBlocks } from '../../utils';
 
-export const StyledModal = styled(Modal)`
+export const StyledVisualElementModal = styled(Modal)`
   overflow: hidden;
   .modal-body {
     height: 90%;
@@ -39,7 +39,7 @@ const SlateVisualElementPicker = ({
     onVisualElementClose();
   };
   return (
-    <StyledModal
+    <StyledVisualElementModal
       controllable
       isOpen
       narrow
@@ -65,7 +65,7 @@ const SlateVisualElementPicker = ({
           </ModalBody>
         </Fragment>
       )}
-    </StyledModal>
+    </StyledVisualElementModal>
   );
 };
 

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -10,6 +10,9 @@ export const StyledModal = styled(Modal)`
   overflow: hidden;
   .modal-body {
     height: 90%;
+    h2 {
+      margin-top: 0 !important;
+    }
   }
 `;
 

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -1,20 +1,9 @@
-import React, { Fragment, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { injectT } from '@ndla/i18n';
-import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import VisualElementSearch from '../../../../containers/VisualElement/VisualElementSearch';
 import { defaultBlocks } from '../../utils';
-
-export const StyledVisualElementModal = styled(Modal)`
-  overflow: hidden;
-  .modal-body {
-    height: 90%;
-    h2 {
-      margin-top: 0 !important;
-    }
-  }
-`;
+import VisualElementModalWrapper from '../../../../containers/VisualElement/VisualElementModalWrapper';
 
 const SlateVisualElementPicker = ({
   articleLanguage,
@@ -23,8 +12,6 @@ const SlateVisualElementPicker = ({
   onInsertBlock,
   t,
 }) => {
-  const [h5pFetchFail, setH5pFetchFail] = useState(false);
-
   const onVisualElementAdd = (visualElement, type = 'embed') => {
     if (type === 'embed') {
       const blockToInsert = defaultBlocks.defaultEmbedBlock(visualElement);
@@ -39,33 +26,17 @@ const SlateVisualElementPicker = ({
     onVisualElementClose();
   };
   return (
-    <StyledVisualElementModal
-      controllable
-      isOpen
-      narrow
-      onClose={onVisualElementClose}
-      size={resource === 'h5p' ? 'fullscreen' : 'large'}
-      backgroundColor="white"
-      minHeight={resource !== 'file' && '90vh'}>
-      {onCloseModal => (
-        <Fragment>
-          {(resource !== 'h5p' || h5pFetchFail) && (
-            <ModalHeader>
-              <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
-            </ModalHeader>
-          )}
-          <ModalBody>
-            <VisualElementSearch
-              articleLanguage={articleLanguage}
-              selectedResource={resource}
-              handleVisualElementChange={onVisualElementAdd}
-              closeModal={onVisualElementClose}
-              setH5pFetchFail={setH5pFetchFail}
-            />
-          </ModalBody>
-        </Fragment>
+    <VisualElementModalWrapper resource={resource} isOpen onClose={onVisualElementClose}>
+      {setH5pFetchFail => (
+        <VisualElementSearch
+          articleLanguage={articleLanguage}
+          selectedResource={resource}
+          handleVisualElementChange={onVisualElementAdd}
+          closeModal={onVisualElementClose}
+          setH5pFetchFail={setH5pFetchFail}
+        />
       )}
-    </StyledVisualElementModal>
+    </VisualElementModalWrapper>
   );
 };
 

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { injectT } from '@ndla/i18n';
@@ -20,6 +20,8 @@ const SlateVisualElementPicker = ({
   onInsertBlock,
   t,
 }) => {
+  const [h5pFetchFail, setH5pFetchFail] = useState(false);
+
   const onVisualElementAdd = (visualElement, type = 'embed') => {
     if (type === 'embed') {
       const blockToInsert = defaultBlocks.defaultEmbedBlock(visualElement);
@@ -44,7 +46,7 @@ const SlateVisualElementPicker = ({
       minHeight={resource !== 'file' && '90vh'}>
       {onCloseModal => (
         <Fragment>
-          {resource !== 'h5p' && (
+          {(resource !== 'h5p' || h5pFetchFail) && (
             <ModalHeader>
               <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
             </ModalHeader>
@@ -55,6 +57,7 @@ const SlateVisualElementPicker = ({
               selectedResource={resource}
               handleVisualElementChange={onVisualElementAdd}
               closeModal={onVisualElementClose}
+              setH5pFetchFail={setH5pFetchFail}
             />
           </ModalBody>
         </Fragment>

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -6,7 +6,7 @@ import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import VisualElementSearch from '../../../../containers/VisualElement/VisualElementSearch';
 import { defaultBlocks } from '../../utils';
 
-const StyledModal = styled(Modal)`
+export const StyledModal = styled(Modal)`
   overflow: hidden;
   .modal-body {
     height: 90%;

--- a/src/containers/VisualElement/VisualElementModalWrapper.tsx
+++ b/src/containers/VisualElement/VisualElementModalWrapper.tsx
@@ -1,0 +1,64 @@
+import { injectT, tType } from '@ndla/i18n';
+import React, { useState } from 'react';
+import css from '@emotion/css';
+import styled from '@emotion/styled';
+import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
+import Lightbox from '../../components/Lightbox';
+
+interface Props {
+  resource: string;
+  onClose: () => void;
+  isOpen: boolean;
+  children: (setH5pFetchFail: (failed: boolean) => void) => React.ReactElement;
+}
+
+const h5pContentCss = css`
+  padding: 0;
+`;
+
+const StyledVisualElementModal = styled(Modal)`
+  overflow: hidden;
+  .modal-body {
+    height: 90%;
+    h2 {
+      margin-top: 0 !important;
+    }
+  }
+`;
+
+const VisualElementModalWrapper = ({ resource, children, onClose, isOpen, t }: Props & tType) => {
+  const [h5pFetchFail, setH5pFetchFail] = useState(false);
+
+  if (resource === 'h5p') {
+    return (
+      <Lightbox
+        display={isOpen}
+        appearance={'fullscreen'}
+        onClose={onClose}
+        hideCloseButton={!h5pFetchFail}
+        contentCss={!h5pFetchFail && h5pContentCss}>
+        {children(setH5pFetchFail)}
+      </Lightbox>
+    );
+  }
+  return (
+    <StyledVisualElementModal
+      narrow
+      controllable
+      isOpen={isOpen}
+      size="large"
+      backgroundColor="white"
+      onClose={onClose}>
+      {(onCloseModal: () => void) => (
+        <>
+          <ModalHeader>
+            <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
+          </ModalHeader>
+          <ModalBody>{children(setH5pFetchFail)}</ModalBody>
+        </>
+      )}
+    </StyledVisualElementModal>
+  );
+};
+
+export default injectT(VisualElementModalWrapper);

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -166,6 +166,7 @@ class VisualElementSearch extends Component {
               onClose={closeModal}
               locale={locale}
               setH5pFetchFail={setH5pFetchFail}
+              setMinHeightForModal
             />
           </Fragment>
         );

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -151,7 +151,7 @@ class VisualElementSearch extends Component {
       case 'h5p': {
         return (
           <Fragment>
-            <h1>{titles(t, selectedResource)[selectedResource]}</h1>
+            <h2>{titles(t, selectedResource)[selectedResource]}</h2>
             <H5PElement
               canReturnResources={true}
               h5pUrl={selectedResourceUrl}

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -150,7 +150,7 @@ class VisualElementSearch extends Component {
       case 'h5p': {
         return (
           <Fragment>
-            <h2>{titles(t, selectedResource)[selectedResource]}</h2>
+            <h1>{titles(t, selectedResource)[selectedResource]}</h1>
             <H5PElement
               canReturnResources={true}
               h5pUrl={selectedResourceUrl}

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -67,6 +67,7 @@ class VisualElementSearch extends Component {
       selectedResource,
       selectedResourceUrl,
       selectedResourceType,
+      setH5pFetchFail,
       handleVisualElementChange,
       closeModal,
       articleLanguage,
@@ -164,6 +165,7 @@ class VisualElementSearch extends Component {
               }
               onClose={closeModal}
               locale={locale}
+              setH5pFetchFail={setH5pFetchFail}
             />
           </Fragment>
         );
@@ -245,6 +247,7 @@ VisualElementSearch.propTypes = {
   selectedResource: PropTypes.string.isRequired,
   selectedResourceUrl: PropTypes.string,
   selectedResourceType: PropTypes.string,
+  setH5pFetchFail: PropTypes.func,
   handleVisualElementChange: PropTypes.func.isRequired,
   articleLanguage: PropTypes.string.isRequired,
   locale: PropTypes.string.isRequired,

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -150,25 +150,21 @@ class VisualElementSearch extends Component {
       case 'H5P':
       case 'h5p': {
         return (
-          <Fragment>
-            <h2>{titles(t, selectedResource)[selectedResource]}</h2>
-            <H5PElement
-              canReturnResources={true}
-              h5pUrl={selectedResourceUrl}
-              onSelect={h5p =>
-                handleVisualElementChange({
-                  resource: 'h5p',
-                  path: h5p.path,
-                  title: h5p.title,
-                  metaData: {},
-                })
-              }
-              onClose={closeModal}
-              locale={locale}
-              setH5pFetchFail={setH5pFetchFail}
-              setMinHeightForModal
-            />
-          </Fragment>
+          <H5PElement
+            canReturnResources={true}
+            h5pUrl={selectedResourceUrl}
+            onSelect={h5p =>
+              handleVisualElementChange({
+                resource: 'h5p',
+                path: h5p.path,
+                title: h5p.title,
+                metaData: {},
+              })
+            }
+            onClose={closeModal}
+            locale={locale}
+            setH5pFetchFail={setH5pFetchFail}
+          />
         );
       }
       case 'audio': {

--- a/src/containers/VisualElement/VisualElementSelectField.jsx
+++ b/src/containers/VisualElement/VisualElementSelectField.jsx
@@ -8,8 +8,9 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Lightbox from '../../components/Lightbox';
+import { ModalBody } from '@ndla/modal';
 import VisualElementSearch from './VisualElementSearch';
+import { StyledVisualElementModal } from '../../components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
 
 class VisualElementSelectField extends Component {
   constructor(props) {
@@ -39,18 +40,25 @@ class VisualElementSelectField extends Component {
       return null;
     }
     return (
-      <Lightbox
-        display
-        appearance={selectedResource === 'h5p' ? 'fullscreen' : 'big'}
+      <StyledVisualElementModal
+        narrow
+        controllable
+        isOpen
+        size={selectedResource === 'h5p' ? 'fullscreen' : 'large'}
+        backgroundColor="white"
         onClose={this.onImageLightboxClose}>
-        <VisualElementSearch
-          selectedResource={selectedResource}
-          handleVisualElementChange={this.handleVisualElementChange}
-          closeModal={this.onImageLightboxClose}
-          videoTypes={videoTypes}
-          articleLanguage={articleLanguage}
-        />
-      </Lightbox>
+        {onCloseModal => (
+          <ModalBody>
+            <VisualElementSearch
+              selectedResource={selectedResource}
+              handleVisualElementChange={this.handleVisualElementChange}
+              closeModal={onCloseModal}
+              videoTypes={videoTypes}
+              articleLanguage={articleLanguage}
+            />
+          </ModalBody>
+        )}
+      </StyledVisualElementModal>
     );
   }
 }

--- a/src/containers/VisualElement/VisualElementSelectField.jsx
+++ b/src/containers/VisualElement/VisualElementSelectField.jsx
@@ -8,9 +8,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ModalBody } from '@ndla/modal';
 import VisualElementSearch from './VisualElementSearch';
-import { StyledVisualElementModal } from '../../components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
+import VisualElementModalWrapper from './VisualElementModalWrapper';
 
 class VisualElementSelectField extends Component {
   constructor(props) {
@@ -40,25 +39,21 @@ class VisualElementSelectField extends Component {
       return null;
     }
     return (
-      <StyledVisualElementModal
-        narrow
-        controllable
+      <VisualElementModalWrapper
+        resource={selectedResource}
         isOpen
-        size={selectedResource === 'h5p' ? 'fullscreen' : 'large'}
-        backgroundColor="white"
         onClose={this.onImageLightboxClose}>
-        {onCloseModal => (
-          <ModalBody>
-            <VisualElementSearch
-              selectedResource={selectedResource}
-              handleVisualElementChange={this.handleVisualElementChange}
-              closeModal={onCloseModal}
-              videoTypes={videoTypes}
-              articleLanguage={articleLanguage}
-            />
-          </ModalBody>
+        {setH5pFetchFail => (
+          <VisualElementSearch
+            selectedResource={selectedResource}
+            handleVisualElementChange={this.handleVisualElementChange}
+            closeModal={this.onImageLightboxClose}
+            videoTypes={videoTypes}
+            articleLanguage={articleLanguage}
+            setH5pFetchFail={setH5pFetchFail}
+          />
         )}
-      </StyledVisualElementModal>
+      </VisualElementModalWrapper>
     );
   }
 }


### PR DESCRIPTION
fixes NDLANO/issues#2543

Ved opprettelse og redigering av h5p vises nå headeren med lukkeknapp kun når henting av h5p-editoren feiler. For andre visuelle elementer skal headeren fortsatt vises. Har også overskrevet stylingen på `<h2>` (som blir brukt i video- og h5p-opplasteren) i Modal for disse komponentene for å redusere på mengden luft øverst i modalen. Så nå skal h5p-editoren ha mer plass i modalen den brukes i.

Testing:
- [Artikkel med h5p](https://editorial-frontend-pr-971.ndla.sh/subject-matter/learning-resource/59271/edit/nb)