### PR TITLE
2498 fix expanding box title with scroll

### DIFF
--- a/src/components/SlateEditor/plugins/details/DetailsBox.tsx
+++ b/src/components/SlateEditor/plugins/details/DetailsBox.tsx
@@ -81,14 +81,16 @@ const DetailsBox = ({ t, attributes, children, editor, node }: Props & tType) =>
     const currentScroll = window.scrollY;
     editor.replaceNodeByKey(summaryTextNode.key, newTextNode);
     setShowEditModal(false);
-    window.scrollTo(0, currentScroll);
+    setTimeout(() => window.scrollTo(0, currentScroll), 0);
   };
 
   const toggleShowEditModal = (evt: MouseEvent) => {
     const currentScroll = window.scrollY;
     evt.preventDefault();
     setShowEditModal(!showEditModal);
-    window.scrollTo(0, currentScroll);
+    if (showEditModal) {
+      setTimeout(() => window.scrollTo(0, currentScroll), 0);
+    }
   };
 
   const editSummaryButton = (

--- a/src/components/SlateEditor/plugins/details/DetailsBox.tsx
+++ b/src/components/SlateEditor/plugins/details/DetailsBox.tsx
@@ -78,13 +78,17 @@ const DetailsBox = ({ t, attributes, children, editor, node }: Props & tType) =>
     const newTextNode = Text.create({
       text: inputValue,
     });
+    const currentScroll = window.scrollY;
     editor.replaceNodeByKey(summaryTextNode.key, newTextNode);
     setShowEditModal(false);
+    window.scrollTo(0, currentScroll);
   };
 
   const toggleShowEditModal = (evt: MouseEvent) => {
+    const currentScroll = window.scrollY;
     evt.preventDefault();
     setShowEditModal(!showEditModal);
+    window.scrollTo(0, currentScroll);
   };
 
   const editSummaryButton = (


### PR DESCRIPTION
Fixes NDLANO/Issues#2498

Ser ut som den beste løsningen på sikt er å skrive om tittel-feltet til å være redigerbart inline, men det blir dobbelt arbeid om det skal gjøres nå siden slate oppgraderes.

Har løst problemet her med scrolling, men man ser at den blinker til toppen av nettsiden et kort øyeblikk før scroll går tilbake til riktig posisjon.