### PR TITLE
Adding history-parameter to open cloned article

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
@@ -161,6 +161,7 @@ const LearningResourceForm = props => {
           translateArticle={translateArticle}
           setTranslateOnContinue={setTranslateOnContinue}
           type="standard"
+          history={history}
           {...rest}
         />
         {translating ? (

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.jsx
@@ -184,6 +184,7 @@ const TopicArticleForm = props => {
           translateArticle={translateArticle}
           setTranslateOnContinue={setTranslateOnContinue}
           type="topic-article"
+          history={history}
           {...rest}
         />
         {translating ? (


### PR DESCRIPTION
Fixes NDLANO/Issues#2557

Fikser slik at klona artikler åpnes i editoren etter kloning.

Test:
Åpne en artikkel og klikk på Kopier artikkel i toppen. Editoren skal oppdateres til å ha ny artikkel.