### PR TITLE
2512 Småfiksing på feilmeldinger i console

### DIFF
--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -17,6 +17,7 @@ import { fetchLicenses } from '../modules/draft/draftApi';
 import ImageForm from '../containers/ImageUploader/components/ImageForm';
 import { ImageSearchQuery } from '../modules/image/imageApiInterfaces';
 import { ImageType, License } from '../interfaces';
+import EditorErrorMessage from './SlateEditor/EditorErrorMessage';
 
 const StyledTitleDiv = styled.div`
   margin-bottom: ${spacing.small};
@@ -97,7 +98,9 @@ const ImageSearchAndUploader = ({
               closeModal={closeModal}
               licenses={licenses}
             />
-          ) : null,
+          ) : (
+            <EditorErrorMessage msg={t('errorMessage.description')} />
+          ),
         },
       ]}
     />

--- a/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.jsx
@@ -30,6 +30,7 @@ const CreateLearningResource = ({ t, history, ...rest }) => {
       <LearningResourceForm
         article={{ language: locale }}
         updateArticle={createArticleAndPushRoute}
+        history={history}
         {...rest}
       />
     </Fragment>

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.jsx
@@ -147,7 +147,6 @@ const LearningResourceForm = props => {
       dirty,
     });
     usePreventWindowUnload(formIsDirty);
-    setSaveAsNewVersion(isNewlyCreated);
     const getArticle = preview => getArticleFromSlate({ values, initialValues, licenses, preview });
     return (
       <Form {...formClasses()}>

--- a/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.jsx
@@ -31,6 +31,7 @@ const CreateTopicArticle = ({ history, t, ...rest }) => {
         staticArticle={{ notes: [] }}
         locale={locale}
         updateArticle={createArticleAndPushRoute}
+        history={history}
         {...rest}
       />
     </Fragment>

--- a/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/TopicArticlePage.jsx
@@ -48,7 +48,7 @@ const TopicArticlePage = ({
           {params => (
             <EditArticleRedirect
               match={params.match}
-              isNewlyCreated={previousLocation === '/subject-matter/learning-resource/new'}
+              isNewlyCreated={previousLocation === '/subject-matter/topic-article/new'}
               {...articleFormProps}
             />
           )}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.jsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.jsx
@@ -168,7 +168,6 @@ const TopicArticleForm = props => {
       dirty,
     });
     usePreventWindowUnload(formIsDirty);
-    setSaveAsNewVersion(isNewlyCreated);
     const getArticle = () => getArticleFromSlate({ values, initialValues, licenses });
     return (
       <Form {...formClasses()}>

--- a/src/containers/FormikForm/articleFormHooks.js
+++ b/src/containers/FormikForm/articleFormHooks.js
@@ -44,11 +44,12 @@ export function useArticleFormHooks({
   updateArticleAndStatus,
   licenses,
   getArticleFromSlate,
+  isNewlyCreated = false,
 }) {
   const { id, revision, language } = article;
   const formikRef = useRef(null);
   const [savedToServer, setSavedToServer] = useState(false);
-  const [saveAsNewVersion, setSaveAsNewVersion] = useState();
+  const [saveAsNewVersion, setSaveAsNewVersion] = useState(isNewlyCreated);
   const initialValues = getInitialValues(article);
 
   useEffect(() => {


### PR DESCRIPTION
Hadde litt tid på tampen av dagen så småfiksa litt på noen av de feilmeldingene som Anders har nevnt.

- Tabs i ImageSearchUploader krever content for hver av tabsene, så i stedet for å returnere `null` hvis man ikke har `licenses` la jeg til en errorMessage.
- Fant en feilmelding i TopicArticle- og LearningResourceForm som kom av at state prøvde å oppdatere seg før formik var rendra, men kunne gjøre den stateoppdateringen direkte i `useArticleFormHooks` i stedet, så gjorde det.
- Sender med prop history fra CreateTopicArticle og -LearningResource inn i formsene