### PR TITLE
Removing flex-direction to fix preview of old versions.

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -107,7 +107,6 @@ export const StyledCross = styled(Cross)`
 
 const ChildWrapper = styled.div`
   display: flex;
-  flex-direction: column;
   height: 100%;
 `;
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2560

Forhåndsvisning av gamle versjoner vises etter kvarandre og ikkje ved siden av kvarandre.