### PR TITLE
Adding language to Article to fix labels.

### DIFF
--- a/src/components/PreviewDraft/PreviewDraft.tsx
+++ b/src/components/PreviewDraft/PreviewDraft.tsx
@@ -12,13 +12,14 @@ import { Remarkable } from 'remarkable';
 //@ts-ignore
 import { Article, ContentTypeBadge } from '@ndla/ui';
 import { injectT, tType } from '@ndla/i18n';
-import { ArticleType } from '../../interfaces';
+import { ArticleType, LocaleType } from '../../interfaces';
 //@ts-ignore
 import { transformArticle } from '../../util/articleUtil';
 
 interface Props {
   article: ArticleType;
   label: string;
+  language: LocaleType;
   contentType?: string;
 }
 
@@ -28,7 +29,7 @@ class PreviewDraft extends Component<Props & tType, {}> {
   }
 
   render() {
-    const { article, contentType, label, t } = this.props;
+    const { article, contentType, label, language, t } = this.props;
     if (!article) {
       return null;
     }
@@ -52,6 +53,7 @@ class PreviewDraft extends Component<Props & tType, {}> {
         article={formatted}
         icon={icon}
         contentType={contentType}
+        locale={language}
         messages={{
           lastUpdated: t('article.lastUpdated'),
           edition: t('article.edition'),

--- a/src/components/PreviewDraft/PreviewDraftLightbox.jsx
+++ b/src/components/PreviewDraft/PreviewDraftLightbox.jsx
@@ -196,7 +196,12 @@ class PreviewDraftLightbox extends React.Component {
               onChangePreviewLanguage={this.onChangePreviewLanguage}
               previewLanguage={previewLanguage}
               getEntityPreview={(article, label, contentType) => (
-                <PreviewDraft article={article} label={label} contentType={contentType} />
+                <PreviewDraft
+                  article={article}
+                  label={label}
+                  contentType={contentType}
+                  language={previewLanguage}
+                />
               )}
             />
           </Lightbox>

--- a/src/components/PreviewDraft/PreviewProduction.jsx
+++ b/src/components/PreviewDraft/PreviewProduction.jsx
@@ -13,20 +13,30 @@ import PreviewDraft from './PreviewDraft';
 import StyledPreviewTwoArticles from './StyledPreviewTwoArticles';
 
 const PreviewProduction = props => {
-  const { firstEntity, secondEntity, label, contentType, t } = props;
+  const { firstEntity, secondEntity, label, previewLanguage, contentType, t } = props;
   return (
     <Fragment>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
           {t('form.previewProductionArticle.draft')}
         </h2>
-        <PreviewDraft article={firstEntity} label={label} contentType={contentType} />
+        <PreviewDraft
+          article={firstEntity}
+          label={label}
+          contentType={contentType}
+          language={previewLanguage}
+        />
       </StyledPreviewTwoArticles>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
           {t('form.previewProductionArticle.article')}
         </h2>
-        <PreviewDraft article={secondEntity} label={label} contentType={contentType} />
+        <PreviewDraft
+          article={secondEntity}
+          label={label}
+          contentType={contentType}
+          language={previewLanguage}
+        />
       </StyledPreviewTwoArticles>
     </Fragment>
   );
@@ -47,6 +57,7 @@ PreviewProduction.propTypes = {
   }),
   contentType: PropTypes.string,
   label: PropTypes.string.isRequired,
+  previewLanguage: PropTypes.string.isRequired,
 };
 
 export default injectT(PreviewProduction);

--- a/src/containers/PreviewDraftPage/PreviewDraftPage.jsx
+++ b/src/containers/PreviewDraftPage/PreviewDraftPage.jsx
@@ -67,7 +67,12 @@ const PreviewDraftPage = ({
         </Hero>
         <HelmetWithTracker title={`${draft.title} ${t('htmlTitles.titleTemplate')}`} />
         <OneColumn>
-          <PreviewDraft article={draft} resource={resource} contentType={contentType} />
+          <PreviewDraft
+            article={draft}
+            resource={resource}
+            contentType={contentType}
+            language={language}
+          />
         </OneColumn>
       </div>
     </Fragment>


### PR DESCRIPTION
Article må ha locale for å rendre labels i audoplayer korrekt. 

Test.
Åpne en artikkel med lyd/podkast. Forhåndsvis artikkelen. Om du hovrer over knappene i lydavspilleren skal det vises tekster og ikkje phrase-ider.