### PR TITLE
Add spinner when changing between language version

### DIFF
--- a/src/containers/AudioUploader/EditAudio.tsx
+++ b/src/containers/AudioUploader/EditAudio.tsx
@@ -13,6 +13,7 @@ import * as audioApi from '../../modules/audio/audioApi';
 import { transformAudio } from '../../util/audioHelpers';
 import { createFormData } from '../../util/formDataHelper';
 import { toEditPodcast } from '../../util/routeHelpers';
+import Spinner from '../../components/Spinner';
 import { License, LocaleType } from '../../interfaces';
 import {
   FlattenedAudioApiType,
@@ -36,6 +37,7 @@ const EditAudio = ({
   ...rest
 }: Props) => {
   const [audio, setAudio] = useState<FlattenedAudioApiType | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(false);
 
   const onUpdate = async (
     newAudio: UpdatedAudioMetaInformation,
@@ -50,8 +52,10 @@ const EditAudio = ({
   useEffect(() => {
     async function fetchAudio() {
       if (audioId) {
+        setLoading(true);
         const apiAudio = await audioApi.fetchAudio(audioId, audioLanguage);
         setAudio(transformAudio(apiAudio, audioLanguage));
+        setLoading(false);
       }
     }
 
@@ -60,6 +64,10 @@ const EditAudio = ({
 
   if (audioId && !audio?.id) {
     return null;
+  }
+
+  if (loading) {
+    return <Spinner withWrapper />;
   }
 
   if (audio?.audioType === 'podcast') {

--- a/src/containers/Podcast/EditPodcast.tsx
+++ b/src/containers/Podcast/EditPodcast.tsx
@@ -13,6 +13,7 @@ import { createFormData } from '../../util/formDataHelper';
 import { transformAudio } from '../../util/audioHelpers';
 import { toEditAudio } from '../../util/routeHelpers';
 import PodcastForm from './components/PodcastForm';
+import Spinner from '../../components/Spinner';
 import {
   UpdatedPodcastMetaInformation,
   FlattenedAudioApiType,
@@ -29,6 +30,7 @@ interface Props {
 const EditPodcast = ({ licenses, podcastId, podcastLanguage, isNewlyCreated }: Props) => {
   const locale: string = useContext(LocaleContext);
   const [podcast, setPodcast] = useState<FlattenedAudioApiType | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(false);
 
   const onUpdate = async (
     newPodcast: UpdatedPodcastMetaInformation,
@@ -43,8 +45,10 @@ const EditPodcast = ({ licenses, podcastId, podcastLanguage, isNewlyCreated }: P
   useEffect(() => {
     async function fetchPodcast() {
       if (podcastId) {
+        setLoading(true);
         const apiPodcast = await audioApi.fetchAudio(podcastId, podcastLanguage);
         setPodcast(transformAudio(apiPodcast, podcastLanguage));
+        setLoading(false);
       }
     }
 
@@ -53,6 +57,10 @@ const EditPodcast = ({ licenses, podcastId, podcastLanguage, isNewlyCreated }: P
 
   if (podcastId && !podcast?.id) {
     return null;
+  }
+
+  if (loading) {
+    return <Spinner withWrapper />;
   }
 
   if (podcast?.audioType === 'standard') {


### PR DESCRIPTION
Virker litt forvirrende at skjema for audio ikkje endres ved bytte mellom språk. La til spinner for å gjøre det litt meir tydelig.

test: Finn lyd/podcast og bytt mellom språkversjoner. Dette skal trigge spinner.