### PR TITLE
Skjuler header fra podcast-skjema

### DIFF
--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
-  const { caption, copyright, podcastMeta } = audio;
+  const { copyright, podcastMeta } = audio;
 
   useEffect(() => {
     initAudioPlayers(locale);
@@ -49,7 +49,7 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
         src={audio.audioFile.url}
         title={audio.title}
         speech={speech}
-        img={podcastMeta?.coverPhoto && podcastImg}
+        img={podcastImg}
         description={podcastMeta?.introduction}
         textVersion={podcastMeta?.manuscript}
       />
@@ -58,7 +58,7 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
           <FigureCaption
             id={figureLicenseDialogId}
             figureId={`figure-${audio.id}`}
-            caption={caption}
+            caption={audio.caption}
             reuseLabel=""
             licenseRights={license.rights}
             authors={copyright.creators}

--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, { useEffect } from 'react';
-import { Remarkable } from 'remarkable';
 import { injectT, tType } from '@ndla/i18n';
 import { AudioPlayer, initAudioPlayers } from '@ndla/ui';
 // @ts-ignore
@@ -28,12 +27,6 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
     initAudioPlayers(locale);
   }, [locale]);
 
-  const renderMarkdown = (text: string) => {
-    const md = new Remarkable();
-    const rendered = md.render(text);
-    return <span dangerouslySetInnerHTML={{ __html: rendered }}></span>;
-  };
-
   const license = getLicenseByAbbreviation(copyright.license?.license || '', locale);
   const figureLicenseDialogId = `edit-audio-${audio.id}`;
 
@@ -49,8 +42,6 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
     url: `${podcastMeta.coverPhoto.url}?width=200&height=200`,
     alt: podcastMeta.coverPhoto.altText,
   };
-  const description = podcastMeta?.introduction && renderMarkdown(podcastMeta.introduction);
-  const textVersion = podcastMeta?.manuscript && renderMarkdown(podcastMeta.manuscript);
 
   return (
     <div>
@@ -59,9 +50,8 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
         title={audio.title}
         speech={speech}
         img={podcastMeta?.coverPhoto && podcastImg}
-        // @ts-ignore
-        description={description}
-        textVersion={textVersion}
+        description={podcastMeta?.introduction}
+        textVersion={podcastMeta?.manuscript}
       />
       {!speech && (
         <>

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -45,6 +45,7 @@ const podcastRules = {
   },
   introduction: {
     required: true,
+    maxLength: 1000,
   },
   manuscript: {
     required: true,
@@ -67,7 +68,6 @@ const podcastRules = {
     allObjectFieldsRequired: true,
   },
   creators: {
-    minItems: 1,
     allObjectFieldsRequired: true,
   },
   rightsholders: {

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -43,9 +43,6 @@ const podcastRules = {
   audioFile: {
     required: true,
   },
-  header: {
-    required: true,
-  },
   introduction: {
     required: true,
   },
@@ -106,7 +103,7 @@ export const getInitialValues = (audio: PodcastPropType = {}): PodcastFormValues
   rightsholders: parseCopyrightContributors(audio, 'rightsholders'),
   license: audio?.copyright?.license?.license || DEFAULT_LICENSE.license,
   audioType: 'podcast',
-  header: audio.podcastMeta?.header,
+  header: audio.podcastMeta?.header || '',
   introduction: plainTextToEditorValue(audio.podcastMeta?.introduction, true),
   coverPhotoId: audio.podcastMeta?.coverPhoto.id,
   metaImageAlt: audio.podcastMeta?.coverPhoto.altText, // coverPhotoAltText
@@ -229,13 +226,9 @@ const PodcastForm = ({ t, audio, inModal, isNewlyCreated, licenses, onUpdate }: 
                 id="podcast-upload-podcastmeta"
                 title={t('form.podcastSection')}
                 className="u-4/6@desktop u-push-1/6@desktop"
-                hasError={[
-                  'header',
-                  'introduction',
-                  'coverPhotoId',
-                  'metaImageAlt',
-                  'manuscript',
-                ].some(field => field in errors)}>
+                hasError={['introduction', 'coverPhotoId', 'metaImageAlt', 'manuscript'].some(
+                  field => field in errors,
+                )}>
                 <PodcastMetaData
                   handleSubmit={submitForm}
                   onBlur={(event, editor, next) => {

--- a/src/containers/Podcast/components/PodcastMetaData.tsx
+++ b/src/containers/Podcast/components/PodcastMetaData.tsx
@@ -25,7 +25,11 @@ const plugins = [textTransformPlugin()];
 const PodcastMetaData = ({ handleSubmit, onBlur, t }: Props & tType) => {
   return (
     <>
-      <FormikField label={t('podcastForm.fields.introduction')} name="introduction" maxLength={300}>
+      <FormikField
+        label={t('podcastForm.fields.introduction')}
+        name="introduction"
+        maxLength={1000}
+        showMaxLength>
         {({ field }) => (
           <PlainTextEditor
             id={field.name}
@@ -39,7 +43,7 @@ const PodcastMetaData = ({ handleSubmit, onBlur, t }: Props & tType) => {
         )}
       </FormikField>
 
-      <FormikField label={t('podcastForm.fields.manuscript')} name="manuscript" maxLength={300}>
+      <FormikField label={t('podcastForm.fields.manuscript')} name="manuscript">
         {({ field }) => (
           <PlainTextEditor
             id={field.name}

--- a/src/containers/Podcast/components/PodcastMetaData.tsx
+++ b/src/containers/Podcast/components/PodcastMetaData.tsx
@@ -25,8 +25,6 @@ const plugins = [textTransformPlugin()];
 const PodcastMetaData = ({ handleSubmit, onBlur, t }: Props & tType) => {
   return (
     <>
-      <FormikField label={t('podcastForm.fields.header')} name="header" />
-
       <FormikField label={t('podcastForm.fields.introduction')} name="introduction" maxLength={300}>
         {({ field }) => (
           <PlainTextEditor


### PR DESCRIPTION
Skjuler header i podcast. Viser kvadratisk podcast-bilde. Krever oppdatert AudioPlayer for å fikse css.

Test:
* Header-feltet er skjult fordi det ikkje trengs. Slettes i seinare versjon. https://trello.com/c/i5ZULnWd/1087-fjerne-overskrift-feltet-i-podcast
* Introduksjon har maks 1000 tegn, med validering. https://trello.com/c/P7uDI9lV/1086-max-1000-karakterer-p%C3%A5-podcast-vis-mer-lenke
* Krav om opphaver er fjerna. https://trello.com/c/mj8p3nHW/1088-ta-bort-krav-om-opphavsperson-p%C3%A5-podcast
