### PR TITLE
Flytter tekstversjon til audioform.

### DIFF
--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -51,7 +51,7 @@ const AudioPlayerMounter = ({ t, audio, locale, speech }: Props & tType) => {
         speech={speech}
         img={podcastImg}
         description={podcastMeta?.introduction}
-        textVersion={podcastMeta?.manuscript}
+        textVersion={audio?.manuscript}
       />
       {!speech && (
         <>

--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -17,6 +17,8 @@ import { DeleteForever } from '@ndla/icons/editor';
 import IconButton from '../../../components/IconButton';
 import AudioPlayer from './AudioPlayer';
 import FormikField from '../../../components/FormikField';
+import PlainTextEditor from '../../../components/SlateEditor/PlainTextEditor';
+import textTransformPlugin from '../../../components/SlateEditor/plugins/textTransform';
 import { AudioFormikType } from './AudioForm';
 import { TitleField } from '../../FormikForm';
 
@@ -56,6 +58,8 @@ const getPlayerObject = (
   }
   return undefined;
 };
+
+const plugins = [textTransformPlugin()];
 
 const AudioContent = ({ t, formik }: Props & tType) => {
   const { values, setFieldValue, submitForm, handleBlur } = formik;
@@ -115,6 +119,26 @@ const AudioContent = ({ t, formik }: Props & tType) => {
 
       <FormikField noBorder name="audioFile" label={t('form.audio.file')}>
         {() => <PlayerOrSelector />}
+      </FormikField>
+
+      <FormikField label={t('form.audio.manuscript')} name="manuscript" maxLength={1000}>
+        {({ field }) => (
+          <PlainTextEditor
+            id={field.name}
+            {...field}
+            className={'manuscript'}
+            placeholder={t('form.audio.manuscript')}
+            handleSubmit={submitForm}
+            plugins={plugins}
+            onBlur={(event: Event, editor: unknown, next: Function) => {
+              next();
+              // this is a hack since formik onBlur-handler interferes with slates
+              // related to: https://github.com/ianstormtaylor/slate/issues/2434
+              // formik handleBlur needs to be called for validation to work (and touched to be set)
+              setTimeout(() => handleBlur({ target: { name: 'manuscript' } }), 0);
+            }}
+          />
+        )}
       </FormikField>
     </Fragment>
   );

--- a/src/containers/AudioUploader/components/AudioForm.tsx
+++ b/src/containers/AudioUploader/components/AudioForm.tsx
@@ -45,6 +45,7 @@ export interface AudioFormikType {
   language: string;
   supportedLanguages: string[];
   title: Value;
+  manuscript: Value;
   audioFile: {
     storedFile?: {
       url: string;
@@ -74,6 +75,7 @@ export const getInitialValues = (
     language: audio.language,
     supportedLanguages: audio.supportedLanguages || [],
     title: plainTextToEditorValue(audio.title || '', true),
+    manuscript: plainTextToEditorValue(audio?.manuscript, true),
     audioFile: { storedFile: audio.audioFile },
     tags: audio.tags || [],
     creators: parseCopyrightContributors(audio, 'creators'),
@@ -88,11 +90,13 @@ const rules = {
   title: {
     required: true,
   },
+  manuscript: {
+    required: false,
+  },
   tags: {
     minItems: 3,
   },
   creators: {
-    minItems: 1,
     allObjectFieldsRequired: true,
   },
   processors: {
@@ -157,6 +161,7 @@ class AudioForm extends Component<Props, State> {
         id: values.id,
         revision: revision,
         title: editorValueToPlainText(values.title),
+        manuscript: editorValueToPlainText(values.manuscript),
         language: values.language,
         tags: values.tags,
         audioType: 'standard',

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -41,15 +41,15 @@ const podcastRules = {
   title: {
     required: true,
   },
+  manuscript: {
+    required: false,
+  },
   audioFile: {
     required: true,
   },
   introduction: {
     required: true,
     maxLength: 1000,
-  },
-  manuscript: {
-    required: true,
   },
   coverPhotoId: {
     required: true,
@@ -80,6 +80,7 @@ interface PodcastPropType {
   id?: number;
   revision?: number;
   title?: string;
+  manuscript?: string;
   language?: string;
   supportedLanguages?: string[];
   audioFile?: AudioFile;
@@ -95,6 +96,7 @@ export const getInitialValues = (audio: PodcastPropType = {}): PodcastFormValues
   language: audio.language,
   supportedLanguages: audio.supportedLanguages || [],
   title: plainTextToEditorValue(audio.title || '', true),
+  manuscript: plainTextToEditorValue(audio.manuscript || '', true),
   audioFile: { storedFile: audio.audioFile },
   filepath: '',
   tags: audio.tags || [],
@@ -104,11 +106,9 @@ export const getInitialValues = (audio: PodcastPropType = {}): PodcastFormValues
   rightsholders: parseCopyrightContributors(audio, 'rightsholders'),
   license: audio?.copyright?.license?.license || DEFAULT_LICENSE.license,
   audioType: 'podcast',
-  header: audio.podcastMeta?.header || ' ',
   introduction: plainTextToEditorValue(audio.podcastMeta?.introduction, true),
   coverPhotoId: audio.podcastMeta?.coverPhoto.id,
   metaImageAlt: audio.podcastMeta?.coverPhoto.altText, // coverPhotoAltText
-  manuscript: plainTextToEditorValue(audio.podcastMeta?.manuscript, true),
 });
 
 const FormWrapper = ({ inModal, children }: { inModal?: boolean; children: ReactNode }) => {
@@ -156,14 +156,13 @@ const PodcastForm = ({
     if (
       license === undefined ||
       values.title === undefined ||
+      values.manuscript === undefined ||
       values.language === undefined ||
       values.tags === undefined ||
       values.origin === undefined ||
       values.creators === undefined ||
       values.processors === undefined ||
       values.rightsholders === undefined ||
-      values.header === undefined ||
-      values.manuscript === undefined ||
       values.introduction === undefined ||
       values.coverPhotoId === undefined ||
       values.metaImageAlt === undefined
@@ -178,6 +177,7 @@ const PodcastForm = ({
       id: values.id,
       revision: values.revision,
       title: editorValueToPlainText(values.title),
+      manuscript: editorValueToPlainText(values.manuscript),
       tags: values.tags,
       audioType: 'podcast',
       language: values.language,
@@ -189,11 +189,9 @@ const PodcastForm = ({
         rightsholders: values.rightsholders,
       },
       podcastMeta: {
-        header: values.header,
         introduction: editorValueToPlainText(values.introduction),
         coverPhotoId: values.coverPhotoId,
         coverPhotoAltText: values.metaImageAlt,
-        manuscript: editorValueToPlainText(values.manuscript),
       },
     };
 

--- a/src/containers/Podcast/components/PodcastMetaData.tsx
+++ b/src/containers/Podcast/components/PodcastMetaData.tsx
@@ -43,20 +43,6 @@ const PodcastMetaData = ({ handleSubmit, onBlur, t }: Props & tType) => {
         )}
       </FormikField>
 
-      <FormikField label={t('podcastForm.fields.manuscript')} name="manuscript">
-        {({ field }) => (
-          <PlainTextEditor
-            id={field.name}
-            {...field}
-            className={'manuscript'}
-            placeholder={t('podcastForm.fields.manuscript')}
-            handleSubmit={handleSubmit}
-            plugins={plugins}
-            onBlur={onBlur}
-          />
-        )}
-      </FormikField>
-
       <FormikField name="coverPhotoId">
         {({ field, form }) => (
           <MetaImageSearch

--- a/src/modules/audio/audioApiInterfaces.ts
+++ b/src/modules/audio/audioApiInterfaces.ts
@@ -19,28 +19,25 @@ export interface AudioFile {
 }
 
 export interface NewPodcastMeta {
-  header: string;
   introduction: string;
   coverPhotoId: string;
   coverPhotoAltText: string;
-  manuscript: string;
 }
 
 export interface PodcastMeta {
-  header: string;
   introduction: string;
   coverPhoto: {
     id: string;
     url: string;
     altText: string;
   };
-  manuscript: string;
   language: string;
 }
 
 export interface NewAudioMetaInformation {
   id?: number; // Only used by frontend, ignored by backend
   title: string;
+  manuscript: string;
   language: string;
   copyright: Copyright;
   tags: string[];
@@ -67,6 +64,10 @@ export interface AudioApiType {
     title: string;
     language: string;
   };
+  manuscript: {
+    manuscript: string;
+    language: string;
+  };
   audioFile: AudioFile;
   copyright: Copyright;
   tags: {
@@ -82,12 +83,10 @@ export interface PodcastFormValues extends Omit<AudioFormikType, 'language'> {
   language?: string;
   filepath: '';
   audioType?: 'podcast';
-  header?: string;
   introduction?: string;
   coverPhotoId?: string;
   metaImageAlt?: string;
   metaImageUrl?: string;
-  manuscript?: string;
 }
 
 export interface AudioSearchResultType {
@@ -99,8 +98,9 @@ export interface AudioSearchResultType {
   license: string;
 }
 
-export interface FlattenedAudioApiType extends Omit<AudioApiType, 'title' | 'tags'> {
+export interface FlattenedAudioApiType extends Omit<AudioApiType, 'title' | 'manuscript' | 'tags'> {
   title: string;
+  manuscript: string;
   tags: string[];
   language?: string;
 }

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -924,6 +924,7 @@ const phrases = {
         label: 'Audio title',
         placeholder: 'Audio title',
       },
+      manuscript: 'Text version',
       caption: {
         label: 'Audio caption',
         placeholder: 'Audio caption',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -933,6 +933,7 @@ const phrases = {
         label: 'Lydtittel',
         placeholder: 'Lydtittel',
       },
+      manuscript: 'Tekstversjon',
       caption: {
         label: 'Lydtekst',
         placeholder: 'Lydtekst',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -942,6 +942,7 @@ const phrases = {
         label: 'Lydtittel',
         placeholder: 'Lydtittel',
       },
+      manuscript: 'Tekstversjon',
       caption: {
         label: 'Lydtekst',
         placeholder: 'Lydtekst',

--- a/src/util/audioHelpers.ts
+++ b/src/util/audioHelpers.ts
@@ -19,12 +19,14 @@ export const transformAudio = (
       : undefined;
 
   const title = convertFieldWithFallback<'title'>(audio, 'title', '', audioLanguage);
+  const manuscript = convertFieldWithFallback<'manuscript'>(audio, 'manuscript', '', audioLanguage);
   const tags = convertFieldWithFallback<'tags', string[]>(audio, 'tags', [], audioLanguage);
 
   return audio
     ? {
         ...audio,
         title,
+        manuscript,
         tags,
       }
     : undefined;


### PR DESCRIPTION
Det funker å lagre tekstversjon på vanlige audios, men for podcast kjem melding `Cannot specify podcastMeta fields for audioType other than 'podcast'`. Det må fikses i audio-api.