### PR TITLE
Slate upgrade toolbar styling

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -16,7 +16,6 @@ import { toggleMark } from '../mark/utils';
 import { handleClickInline, handleClickBlock } from './handleMenuClicks';
 import hasNodeWithProps from '../../utils/hasNodeWithProps';
 import { isMarkActive } from '../mark';
-import { TYPE_SUMMARY } from '../details';
 // import { listTypes } from '../externalPlugins';
 
 const topicArticleElements: { [key: string]: string[] } = {

--- a/src/components/SlateEditor/plugins/toolbar/ToolbarButton.jsx
+++ b/src/components/SlateEditor/plugins/toolbar/ToolbarButton.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectT } from '@ndla/i18n';
-import Button from '@ndla/button';
+import { colors } from '@ndla/core';
 import {
   Bold,
   Code,
@@ -62,22 +62,55 @@ const toolbarIcon = t => ({
 });
 /* eslint-enable jsx-a11y/anchor-is-valid */
 
-const toolbarButtonStyle = css`
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+const toolbarButtonStyle = isActive => css`
   display: inline-block;
+  background: ${isActive ? colors.background.dark : colors.white};
+  cursor: pointer;
+  padding: 8px 0.5rem 8px 0.5rem;
+  border-width: 0px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  border-style: solid;
+  border-color: ${isActive ? colors.background.darker : colors.background.dark};
+
+  .c-toolbar__button--active + & {
+    border-left-width: 0px;
+  }
+
+  ${isActive && 'border-width: 1px;'}
+
+  .c-toolbar__button--active + .c-toolbar__button--active {
+    border-left-width: 0px;
+  }
+
+  :first-child {
+    border-left-width: 1px;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+  :last-child {
+    border-right-width: 1px;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  :hover {
+    background: ${colors.background.dark};
+  }
 `;
+
 const ToolbarButton = ({ isActive, type, kind, handleOnClick, t }) => {
   const onMouseDown = e => handleOnClick(e, kind, type);
   return (
-    <Button
-      stripped
+    <button
+      {...toolbarClasses('button', isActive ? 'active' : '')}
       onMouseDown={onMouseDown}
       data-testid={`toolbar-button-${type}`}
       data-active={isActive}
-      css={toolbarButtonStyle}>
+      css={toolbarButtonStyle(isActive)}>
       <span {...toolbarClasses('icon', isActive ? 'active' : '')}>{toolbarIcon(t)[type]}</span>
-    </Button>
+    </button>
   );
 };
 

--- a/src/components/SlateEditor/plugins/toolbar/ToolbarButton.jsx
+++ b/src/components/SlateEditor/plugins/toolbar/ToolbarButton.jsx
@@ -64,7 +64,7 @@ const toolbarIcon = t => ({
 
 const toolbarButtonStyle = isActive => css`
   display: inline-block;
-  background: ${isActive ? colors.background.dark : colors.white};
+  background: ${isActive ? colors.brand.lightest : colors.white};
   cursor: pointer;
   padding: 8px 0.5rem 8px 0.5rem;
   border-width: 0px;
@@ -72,7 +72,7 @@ const toolbarButtonStyle = isActive => css`
   border-bottom-width: 1px;
   border-left-width: 1px;
   border-style: solid;
-  border-color: ${isActive ? colors.background.darker : colors.background.dark};
+  border-color: ${isActive ? colors.brand.tertiary : colors.brand.greyLighter};
 
   .c-toolbar__button--active + & {
     border-left-width: 0px;
@@ -96,7 +96,7 @@ const toolbarButtonStyle = isActive => css`
   }
 
   :hover {
-    background: ${colors.background.dark};
+    background: ${colors.brand.lightest};
   }
 `;
 

--- a/src/style/toolbar.css
+++ b/src/style/toolbar.css
@@ -7,7 +7,7 @@
  */
 
 .c-toolbar {
-  padding: 8px 7px 6px;
+  border-radius: 4px;
   position: absolute;
   z-index: 11;
   top: -10000px;
@@ -16,10 +16,6 @@
   opacity: 0;
   color: black;
   background-color: white;
-  border-width: 1px;
-  border-style: solid;
-  border-color: rgba(204, 204, 204, 1);
-  border-radius: 4px;
   transition: opacity 0.75s;
   box-shadow: 3px 3px 5px rgba(153, 153, 153, 0.349019607843137);
 
@@ -32,10 +28,6 @@
     white-space: nowrap;
     word-wrap: normal;
     direction: ltr;
-  }
-
-  &__icon--active {
-    color: var(--brand-color);
   }
 
   &__link-overlay {


### PR DESCRIPTION
Avventer https://github.com/NDLANO/editorial-frontend/pull/1034

Oppdatert styling av toolbar som dukker opp ved markering av tekst. Hver knapp er nå adskilt av en border og aktive knapper får mørkere bakgrunn og border.

Hvordan teste:
1. Åpne PR-installasjon
2. Åpne eller opprett en artikkel
3. Marker tekst og trykk på noen av knappene.
4. Sjekk at:
   - Aktiverte knapper har blå bakgrunn og en noe mørkere border.
   - Ingen knapper har dobbel eller manglende border
   - Eventuelt andre kommentarer på styling

