### PR TITLE
Adding extra parameters to translate service.

### DIFF
--- a/src/modules/translate/translateApi.js
+++ b/src/modules/translate/translateApi.js
@@ -20,7 +20,19 @@ export const fetchNnTranslation = ({ id, ...content }) =>
     body: JSON.stringify({
       token: config.npkToken,
       guid: config.ndlaEnvironment + '_' + id,
-      prefs: { x: true }, // Hack to tell the service to use old html-parser, ref jo.christian.oterhals@ntb.no
+      prefs: {
+        vi: 'vi',
+        infinitive: 'e',
+        gg: false,
+        k: false,
+        skilnad: false,
+        enten: true,
+        dokker: false,
+        mens: true,
+        einig: true,
+        blant: false,
+        loven: false,
+      },
       document: content,
       fileType: 'htmlp', // Tells old html-parser to skip changing æøå to entities.
     }),


### PR DESCRIPTION
Fixes NDLANO/Issues#2607

Legger på ekstra parameter på oversettelsestjenesten. Har laga en artikkel som har mesteparten av tinga som kan spesifiseres.
http://localhost:3000/subject-matter/learning-resource/31108/edit/nb

Test:
* Forsøk å oversette artikkel til nynorsk.

Merk. Det ser ut til å være en feil i oversettelsestjenesten som ikkje behandler "vi" korrekt. Det er tjenesten sin feil og ikkje vår.