### PR TITLE
Supports users created in auth0 dashboard. Connection: undefined lets…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,17 @@ export const getZendeskWidgetSecret = () => {
   return getEnvironmentVariabel('NDLA_ED_ZENDESK_WIDGET_SECRET', 'something');
 };
 
+const usernamePasswordEnabled = () => {
+  switch (ndlaEnvironment) {
+    case 'test':
+    case 'local':
+    case 'dev':
+      return true;
+    default:
+      return false;
+  }
+};
+
 export type ConfigType = {
   brightCoveAccountId: string | undefined;
   checkArticleScript: boolean;
@@ -133,6 +144,7 @@ export type ConfigType = {
   zendeskWidgetKey: string | undefined;
   brightcovePlayerId: string | undefined;
   disableCSP: string | undefined;
+  usernamePasswordEnabled: boolean;
 };
 
 const config: ConfigType = {
@@ -165,6 +177,7 @@ const config: ConfigType = {
   npkToken: getEnvironmentVariabel('NPK_TOKEN'),
   zendeskWidgetKey: getEnvironmentVariabel('NDLA_ED_ZENDESK_WIDGET_KEY'),
   disableCSP: getEnvironmentVariabel('DISABLE_CSP', 'false'),
+  usernamePasswordEnabled: usernamePasswordEnabled(),
 };
 
 export function getUniversalConfig(): ConfigType {

--- a/src/util/authHelpers.ts
+++ b/src/util/authHelpers.ts
@@ -190,8 +190,9 @@ const scheduleRenewal = async () => {
 scheduleRenewal();
 
 export function loginPersonalAccessToken(type: string) {
+  const connection = config.usernamePasswordEnabled ? undefined : type;
   auth.authorize({
-    connection: type,
+    connection,
     state: localStorage.getItem('lastPath') ?? undefined,
     prompt: 'login', // Tells auth0 to always show account selection screen on authorize.
   });


### PR DESCRIPTION
… user select login type.
Only for test/dev/local.

For å kunne logge på med brukernavn/passord må brukeren opprettes i intern database i auth0. Vil kun være tilgjengelig for test/local/now

Eg har oppretta bruker ndla@knowit.no med samme passordet som brukes for brightcove som kan testes med. 