### PR TITLE
Revert loadable h5ppage

### DIFF
--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -27,6 +27,7 @@ import ErrorBoundary from '../../components/ErrorBoundary';
 import Zendesk from './Zendesk';
 import { LocaleType, ReduxState } from '../../interfaces';
 import { LOCALE_VALUES } from '../../constants';
+import H5PPage from '../H5PPage/H5PPage';
 const Login = loadable(() => import('../Login/Login'));
 const Logout = loadable(() => import('../Logout/Logout'));
 const PrivateRoute = loadable(() => import('../PrivateRoute/PrivateRoute'));
@@ -42,7 +43,6 @@ const EditMarkupPage = loadable(() => import('../EditMarkupPage/EditMarkupPage')
 const PreviewDraftPage = loadable(() => import('../PreviewDraftPage/PreviewDraftPage'));
 const NdlaFilm = loadable(() => import('../NdlaFilm/NdlaFilm'));
 const ConceptPage = loadable(() => import('../ConceptPage/ConceptPage'));
-const H5PPage = loadable(() => import('../H5PPage/H5PPage'));
 const Subjectpage = loadable(() => import('../EditSubjectFrontpage/Subjectpage'));
 
 export const FirstLoadContext = React.createContext(true);


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2637

Problemet kan se ut til å henge sammen med emotion. En forskjell fra H5PPage i forhold til andre komponenter i ed er at det brukes @emotion/react. I andre komponenter brukes @emotion/css eller styled eller core. Det kan være en årsak til feilen. 

En løsning på feilen kunne ha vært å inkludere chunkExtractor (se https://emotion.sh/docs/ssr), men tror det er nå mer jobb enn det man får ut. Fikk samme resultat fra lighthouse med og uten h5ppage som chunk nå, og den utgjør bare 6 kb. 

Edit: Ser at emotion/core har blitt renamet til emotion/react. Så skal undersøke forskjeller mer. (se https://emotion.sh/docs/emotion-11#package-renaming) 