### PR TITLE
Fixed deletion of concept metadata images.

### DIFF
--- a/src/containers/ConceptPage/conceptUtil.ts
+++ b/src/containers/ConceptPage/conceptUtil.ts
@@ -100,7 +100,7 @@ export const getPatchApiConcept = (
         id: values.metaImageId,
         alt: values.metaImageAlt,
       }
-    : undefined,
+    : null,
   source: values.source,
   subjectIds: values.subjects.map(subject => subject.id),
   tags: values.tags,

--- a/src/modules/concept/conceptApiInterfaces.ts
+++ b/src/modules/concept/conceptApiInterfaces.ts
@@ -68,7 +68,7 @@ interface UpdateConceptType {
   articleIds?: number[];
   content?: string;
   copyright?: Copyright;
-  metaImage?: { id: string; alt: string };
+  metaImage?: { id: string; alt: string } | null;
   source?: string;
   subjectIds?: string[];
   tags?: string[];


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2628
Bugen oppsto fordi `metaImage` ble satt til undefined istedenfor null.