### PR TITLE
2642 concept page refactor

### DIFF
--- a/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
@@ -7,9 +7,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { connect, ConnectedProps } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { Formik, FormikProps, FormikHelpers } from 'formik';
 import { injectT, tType } from '@ndla/i18n';
@@ -34,16 +33,15 @@ import { NewConceptType, PatchConceptType } from '../../../modules/concept/conce
 import { License, SubjectType, SearchResult, ConceptStatusType } from '../../../interfaces';
 import { ConceptFormType, ConceptFormValues } from '../conceptInterfaces';
 
-interface Props {
-  applicationError: (err: string) => void;
+interface BaseProps {
   concept: ConceptFormType;
   conceptChanged: boolean;
   fetchConceptTags: (input: string, language: string) => Promise<SearchResult>;
-  inModal: boolean;
+  inModal?: boolean;
   isNewlyCreated: boolean;
   licenses: License[];
   onClose: () => void;
-  onUpdate: (updateConcept: NewConceptType | PatchConceptType, revision?: string) => void;
+  onUpdate: (updateConcept: PatchConceptType | NewConceptType, revision?: string) => any;
   subjects: SubjectType[];
   translateToNN: () => void;
   updateConceptAndStatus: (
@@ -52,6 +50,8 @@ interface Props {
     dirty: boolean,
   ) => void;
 }
+
+type Props = BaseProps & RouteComponentProps & PropsFromRedux & tType;
 
 const ConceptForm = ({
   concept,
@@ -65,9 +65,9 @@ const ConceptForm = ({
   translateToNN,
   updateConceptAndStatus,
   onUpdate,
-  applicationError,
   t,
-}: Props & tType) => {
+  applicationError,
+}: Props) => {
   const [savedToServer, setSavedToServer] = useState(false);
   const [translateOnContinue, setTranslateOnContinue] = useState(false);
 
@@ -190,5 +190,7 @@ const ConceptForm = ({
 const mapDispatchToProps = {
   applicationError: messageActions.applicationError,
 };
+const reduxConnector = connect(undefined, mapDispatchToProps);
+type PropsFromRedux = ConnectedProps<typeof reduxConnector>;
 
-export default compose(injectT, withRouter, connect(undefined, mapDispatchToProps))(ConceptForm);
+export default reduxConnector(withRouter(injectT(ConceptForm)));

--- a/src/containers/ConceptPage/ConceptPage.tsx
+++ b/src/containers/ConceptPage/ConceptPage.tsx
@@ -7,22 +7,43 @@
  */
 
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { injectT } from '@ndla/i18n';
-import { connect } from 'react-redux';
+import { injectT, tType } from '@ndla/i18n';
+import { connect, ConnectedProps } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
+// @ts-ignore
 import { OneColumn } from '@ndla/ui';
 import loadable from '@loadable/component';
+import { RouteComponentProps } from 'react-router';
 import { actions as licenseActions, getAllLicenses } from '../../modules/license/license';
 import * as messageActions from '../Messages/messagesActions';
 import { getLocale } from '../../modules/locale/locale';
-import { LicensesArrayOf, LocationShape } from '../../shapes';
 import Footer from '../App/components/Footer';
+import { ReduxState } from '../../interfaces';
 const CreateConcept = loadable(() => import('./CreateConcept'));
 const EditConcept = loadable(() => import('./EditConcept'));
 const NotFoundPage = loadable(() => import('../NotFoundPage/NotFoundPage'));
 
-class ConceptPage extends PureComponent {
+interface BaseProps {}
+
+const mapDispatchToProps = {
+  fetchLicenses: licenseActions.fetchLicenses,
+  applicationError: messageActions.applicationError,
+};
+
+const mapStateToProps = (state: ReduxState) => ({
+  locale: getLocale(state),
+  licenses: getAllLicenses(state),
+});
+
+const reduxConnector = connect(mapStateToProps, mapDispatchToProps);
+type PropsFromRedux = ConnectedProps<typeof reduxConnector>;
+type Props = BaseProps & tType & RouteComponentProps & PropsFromRedux;
+
+interface State {
+  previousLocation: string;
+}
+
+class ConceptPage extends PureComponent<Props, State> {
   state = {
     previousLocation: '',
   };
@@ -34,7 +55,7 @@ class ConceptPage extends PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
       this.setState({ previousLocation: prevProps.location.pathname });
     }
@@ -70,30 +91,5 @@ class ConceptPage extends PureComponent {
     );
   }
 }
-
-ConceptPage.propTypes = {
-  match: PropTypes.shape({
-    url: PropTypes.string.isRequired,
-  }).isRequired,
-  licenses: LicensesArrayOf.isRequired,
-  fetchLicenses: PropTypes.func.isRequired,
-  applicationError: PropTypes.func.isRequired,
-  userAccess: PropTypes.string,
-  history: PropTypes.shape({
-    push: PropTypes.func.isRequired,
-  }).isRequired,
-  locale: PropTypes.string.isRequired,
-  location: LocationShape,
-};
-
-const mapDispatchToProps = {
-  fetchLicenses: licenseActions.fetchLicenses,
-  applicationError: messageActions.applicationError,
-};
-
-const mapStateToProps = state => ({
-  locale: getLocale(state),
-  licenses: getAllLicenses(state),
-});
 
 export default injectT(connect(mapStateToProps, mapDispatchToProps)(ConceptPage));

--- a/src/containers/ConceptPage/ConceptPage.tsx
+++ b/src/containers/ConceptPage/ConceptPage.tsx
@@ -25,18 +25,6 @@ const NotFoundPage = loadable(() => import('../NotFoundPage/NotFoundPage'));
 
 interface BaseProps {}
 
-const mapDispatchToProps = {
-  fetchLicenses: licenseActions.fetchLicenses,
-  applicationError: messageActions.applicationError,
-};
-
-const mapStateToProps = (state: ReduxState) => ({
-  locale: getLocale(state),
-  licenses: getAllLicenses(state),
-});
-
-const reduxConnector = connect(mapStateToProps, mapDispatchToProps);
-type PropsFromRedux = ConnectedProps<typeof reduxConnector>;
 type Props = BaseProps & tType & RouteComponentProps & PropsFromRedux;
 
 interface State {
@@ -91,5 +79,18 @@ class ConceptPage extends PureComponent<Props, State> {
     );
   }
 }
+
+const mapDispatchToProps = {
+  fetchLicenses: licenseActions.fetchLicenses,
+  applicationError: messageActions.applicationError,
+};
+
+const mapStateToProps = (state: ReduxState) => ({
+  locale: getLocale(state),
+  licenses: getAllLicenses(state),
+});
+
+const reduxConnector = connect(mapStateToProps, mapDispatchToProps);
+type PropsFromRedux = ConnectedProps<typeof reduxConnector>;
 
 export default injectT(connect(mapStateToProps, mapDispatchToProps)(ConceptPage));

--- a/src/containers/ConceptPage/CreateConcept.tsx
+++ b/src/containers/ConceptPage/CreateConcept.tsx
@@ -7,26 +7,25 @@
  */
 
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { injectT } from '@ndla/i18n';
-import { withRouter } from 'react-router-dom';
+import { injectT, tType } from '@ndla/i18n';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { useFetchConceptData } from '../FormikForm/formikConceptHooks';
 import { toEditConcept } from '../../util/routeHelpers';
 import ConceptForm from './ConceptForm';
-import { LicensesArrayOf } from '../../shapes';
+import { ConceptType, License } from '../../interfaces';
+import { NewConceptType } from '../../modules/concept/conceptApiInterfaces';
 
-const CreateConcept = props => {
-  const {
-    licenses,
-    locale,
-    t,
-    history,
-    initialConcept,
-    inModal,
-    addConceptInModal,
-    ...rest
-  } = props;
+const CreateConcept = ({
+  licenses,
+  locale,
+  t,
+  history,
+  initialConcept,
+  inModal,
+  addConceptInModal,
+  ...rest
+}: Props & tType) => {
   const {
     subjects,
     concept,
@@ -36,8 +35,8 @@ const CreateConcept = props => {
     setConcept,
   } = useFetchConceptData(undefined, locale);
 
-  const createConceptAndPushRoute = async createdConcept => {
-    const savedConcept = await createConcept(createdConcept);
+  const createConceptAndPushRoute = async (createdConcept: NewConceptType): Promise<void> => {
+    const savedConcept: ConceptType = await createConcept(createdConcept);
     if (inModal && addConceptInModal) {
       addConceptInModal(savedConcept);
     } else {
@@ -46,8 +45,9 @@ const CreateConcept = props => {
   };
 
   return (
-    <Fragment>
+    <>
       <HelmetWithTracker title={t(`conceptform.title`)} />
+      {/* @ts-ignore */}
       <ConceptForm
         concept={concept ? concept : { ...initialConcept, language: locale }}
         locale={locale}
@@ -60,22 +60,19 @@ const CreateConcept = props => {
         setConcept={setConcept}
         {...rest}
       />
-    </Fragment>
+    </>
   );
 };
 
-CreateConcept.propTypes = {
-  history: PropTypes.shape({
-    push: PropTypes.func.isRequired,
-  }).isRequired,
-  initialConcept: PropTypes.shape({
-    title: PropTypes.string,
-  }),
-  locale: PropTypes.string.isRequired,
-  licenses: LicensesArrayOf,
-  inModal: PropTypes.bool,
-  addConceptInModal: PropTypes.func,
-};
+interface Props extends RouteComponentProps {
+  initialConcept: {
+    title: string;
+  };
+  locale: string;
+  licenses: License[];
+  inModal: boolean;
+  addConceptInModal: (savedConcept: ConceptType) => void;
+}
 
 CreateConcept.defaultProps = {
   inModal: false,

--- a/src/containers/ConceptPage/CreateConcept.tsx
+++ b/src/containers/ConceptPage/CreateConcept.tsx
@@ -16,6 +16,16 @@ import ConceptForm from './ConceptForm';
 import { ConceptType, License } from '../../interfaces';
 import { NewConceptType } from '../../modules/concept/conceptApiInterfaces';
 
+interface Props extends RouteComponentProps {
+  initialConcept: {
+    title: string;
+  };
+  locale: string;
+  licenses: License[];
+  inModal: boolean;
+  addConceptInModal?: (savedConcept: ConceptType) => void;
+}
+
 const CreateConcept = ({
   licenses,
   locale,
@@ -63,16 +73,6 @@ const CreateConcept = ({
     </>
   );
 };
-
-interface Props extends RouteComponentProps {
-  initialConcept: {
-    title: string;
-  };
-  locale: string;
-  licenses: License[];
-  inModal: boolean;
-  addConceptInModal: (savedConcept: ConceptType) => void;
-}
 
 CreateConcept.defaultProps = {
   inModal: false,

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -14,6 +14,7 @@ import { useTranslateApi } from '../FormikForm/translateFormHooks';
 import Spinner from '../../components/Spinner';
 import { License } from '../../interfaces';
 import ConceptForm from './ConceptForm';
+import { NewConceptType, PatchConceptType } from '../../modules/concept/conceptApiInterfaces';
 
 interface Props {
   conceptId: string;
@@ -21,6 +22,10 @@ interface Props {
   licenses: License[];
   isNewlyCreated: boolean;
 }
+
+const isPatchConceptType = (
+  concept: NewConceptType | PatchConceptType,
+): concept is PatchConceptType => (concept as PatchConceptType).id !== undefined;
 
 const EditConcept = ({
   conceptId,
@@ -32,7 +37,6 @@ const EditConcept = ({
   const {
     concept,
     fetchSearchTags,
-    fetchStatusStateMachine,
     loading,
     setConcept,
     conceptChanged,
@@ -56,20 +60,21 @@ const EditConcept = ({
   return (
     <>
       <HelmetWithTracker title={`${concept.title} ${t('htmlTitles.titleTemplate')}`} />
-      {/* @ts-ignore */}
       <ConceptForm
         concept={concept}
         conceptChanged={conceptChanged}
         fetchConceptTags={fetchSearchTags}
-        fetchStateStatuses={fetchStatusStateMachine}
         isNewlyCreated={isNewlyCreated}
         licenses={licenses}
-        onUpdate={updateConcept}
+        onUpdate={c => {
+          if (isPatchConceptType(c)) {
+            updateConcept(c);
+          }
+        }}
+        onClose={() => null}
         subjects={subjects}
         translateToNN={translateToNN}
-        translating={translating}
         updateConceptAndStatus={updateConceptAndStatus}
-        setConcept={setConcept}
       />
     </>
   );

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -15,6 +15,13 @@ import Spinner from '../../components/Spinner';
 import { License } from '../../interfaces';
 import ConceptForm from './ConceptForm';
 
+interface Props {
+  conceptId: string;
+  selectedLanguage: string;
+  licenses: License[];
+  isNewlyCreated: boolean;
+}
+
 const EditConcept = ({
   conceptId,
   isNewlyCreated,
@@ -67,12 +74,5 @@ const EditConcept = ({
     </>
   );
 };
-
-interface Props {
-  conceptId: string;
-  selectedLanguage: string;
-  licenses: License[];
-  isNewlyCreated: boolean;
-}
 
 export default injectT(EditConcept);

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -7,16 +7,21 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { HelmetWithTracker } from '@ndla/tracker';
-import { injectT } from '@ndla/i18n';
-import ConceptForm from './ConceptForm';
+import { injectT, tType } from '@ndla/i18n';
 import { useFetchConceptData } from '../FormikForm/formikConceptHooks';
-import { LicensesArrayOf } from '../../shapes';
 import { useTranslateApi } from '../FormikForm/translateFormHooks';
 import Spinner from '../../components/Spinner';
+import { License } from '../../interfaces';
+import ConceptForm from './ConceptForm';
 
-const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t, ...rest }) => {
+const EditConcept = ({
+  conceptId,
+  isNewlyCreated,
+  licenses,
+  selectedLanguage,
+  t,
+}: Props & tType) => {
   const {
     concept,
     fetchSearchTags,
@@ -27,7 +32,7 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
     subjects,
     updateConcept,
     updateConceptAndStatus,
-  } = useFetchConceptData(conceptId, selectedLanguage);
+  } = useFetchConceptData(parseInt(conceptId), selectedLanguage);
 
   const { translating, translateToNN } = useTranslateApi(concept, setConcept, [
     'id',
@@ -44,6 +49,7 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
   return (
     <>
       <HelmetWithTracker title={`${concept.title} ${t('htmlTitles.titleTemplate')}`} />
+      {/* @ts-ignore */}
       <ConceptForm
         concept={concept}
         conceptChanged={conceptChanged}
@@ -57,18 +63,16 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
         translating={translating}
         updateConceptAndStatus={updateConceptAndStatus}
         setConcept={setConcept}
-        {...rest}
       />
     </>
   );
 };
 
-EditConcept.propTypes = {
-  conceptId: PropTypes.string,
-  selectedLanguage: PropTypes.string.isRequired,
-  licenses: LicensesArrayOf.isRequired,
-  isNewlyCreated: PropTypes.bool,
-  createMessage: PropTypes.func.isRequired,
-};
+interface Props {
+  conceptId: string;
+  selectedLanguage: string;
+  licenses: License[];
+  isNewlyCreated: boolean;
+}
 
 export default injectT(EditConcept);

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -22,7 +22,7 @@ import { TAXONOMY_CUSTOM_FIELD_SUBJECT_FOR_CONCEPT } from '../../../constants';
 interface Props {
   subjects: SubjectType[];
   fetchTags: (input: string, language: string) => Promise<SearchResult>;
-  inModal: boolean;
+  inModal?: boolean;
 }
 
 const ConceptMetaData = ({ subjects, fetchTags, inModal, t }: Props & tType) => {

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -16,7 +16,7 @@ import handleError from '../../util/handleError';
 import { ArticleType, ConceptStatusType } from '../../interfaces';
 import { ConceptFormType } from '../ConceptPage/conceptInterfaces';
 
-export function useFetchConceptData(conceptId: number, locale: string) {
+export function useFetchConceptData(conceptId: number | undefined, locale: string) {
   const [concept, setConcept] = useState<ConceptFormType>();
   const [conceptChanged, setConceptChanged] = useState(false);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2642
Refaktorerte ConceptPage-mappen til TypeScript. 

`ConceptForm` vil ikke gjenkjennes i hverken `EditConcept` eller `CreateConcept`, men funker likevel. Inntil videre har jeg bare brukt `@ts-ignore`, men det burde finnes en løsning på det.