### PR TITLE
Show notfoundpage if no data

### DIFF
--- a/src/containers/AudioUploader/EditAudio.tsx
+++ b/src/containers/AudioUploader/EditAudio.tsx
@@ -19,6 +19,7 @@ import {
   FlattenedAudioApiType,
   UpdatedAudioMetaInformation,
 } from '../../modules/audio/audioApiInterfaces';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 
 interface Props {
   locale: LocaleType;
@@ -62,12 +63,12 @@ const EditAudio = ({
     fetchAudio();
   }, [audioId, audioLanguage]);
 
-  if (audioId && !audio?.id) {
-    return null;
-  }
-
   if (loading) {
     return <Spinner withWrapper />;
+  }
+
+  if (audioId && !audio?.id) {
+    return <NotFoundPage />;
   }
 
   if (audio?.audioType === 'podcast') {

--- a/src/containers/ConceptPage/EditConcept.jsx
+++ b/src/containers/ConceptPage/EditConcept.jsx
@@ -19,7 +19,6 @@ import Spinner from '../../components/Spinner';
 
 const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t, ...rest }) => {
   const {
-    error,
     concept,
     fetchSearchTags,
     fetchStatusStateMachine,
@@ -41,12 +40,8 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
     return <Spinner withWrapper />;
   }
 
-  if (error?.status === 404) {
-    return <NotFoundPage />;
-  }
-
   if (!concept) {
-    return null;
+    return <NotFoundPage />;
   }
 
   return (

--- a/src/containers/ConceptPage/EditConcept.jsx
+++ b/src/containers/ConceptPage/EditConcept.jsx
@@ -19,6 +19,7 @@ import Spinner from '../../components/Spinner';
 
 const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t, ...rest }) => {
   const {
+    error,
     concept,
     fetchSearchTags,
     fetchStatusStateMachine,
@@ -40,8 +41,12 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
     return <Spinner withWrapper />;
   }
 
-  if (!concept?.created) {
+  if (error?.status === 404) {
     return <NotFoundPage />;
+  }
+
+  if (!concept) {
+    return null;
   }
 
   return (

--- a/src/containers/ConceptPage/EditConcept.jsx
+++ b/src/containers/ConceptPage/EditConcept.jsx
@@ -36,15 +36,11 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
     'content',
   ]);
 
-  if (!concept) {
-    return null;
-  }
-
   if (loading || translating) {
     return <Spinner withWrapper />;
   }
 
-  if (!concept.created) {
+  if (!concept?.created) {
     return <NotFoundPage />;
   }
 

--- a/src/containers/ConceptPage/EditConcept.jsx
+++ b/src/containers/ConceptPage/EditConcept.jsx
@@ -14,6 +14,7 @@ import ConceptForm from './ConceptForm';
 import { useFetchConceptData } from '../FormikForm/formikConceptHooks';
 import { LicensesArrayOf } from '../../shapes';
 import { useTranslateApi } from '../FormikForm/translateFormHooks';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import Spinner from '../../components/Spinner';
 
 const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t, ...rest }) => {
@@ -38,9 +39,15 @@ const EditConcept = ({ conceptId, isNewlyCreated, licenses, selectedLanguage, t,
   if (!concept) {
     return null;
   }
+
   if (loading || translating) {
     return <Spinner withWrapper />;
   }
+
+  if (!concept.created) {
+    return <NotFoundPage />;
+  }
+
   return (
     <>
       <HelmetWithTracker title={`${concept.title} ${t('htmlTitles.titleTemplate')}`} />

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -38,6 +38,7 @@ export function useFetchConceptData(conceptId: number, locale: string) {
           setLoading(false);
         }
       } catch (e) {
+        setLoading(false);
         handleError(e);
       }
     };

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -21,7 +21,6 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const [conceptChanged, setConceptChanged] = useState(false);
   const [loading, setLoading] = useState(false);
   const [subjects, setSubjects] = useState([]);
-  const [error, setError] = useState<{ status: number } | undefined>(undefined);
 
   useEffect(() => {
     const fetchConcept = async (): Promise<void> => {
@@ -39,7 +38,6 @@ export function useFetchConceptData(conceptId: number, locale: string) {
           setLoading(false);
         }
       } catch (e) {
-        setError({ status: e.status });
         setLoading(false);
         handleError(e);
       }
@@ -106,7 +104,6 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   };
 
   return {
-    error,
     concept,
     createConcept,
     fetchSearchTags,

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -21,6 +21,7 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   const [conceptChanged, setConceptChanged] = useState(false);
   const [loading, setLoading] = useState(false);
   const [subjects, setSubjects] = useState([]);
+  const [error, setError] = useState<{ status: number } | undefined>(undefined);
 
   useEffect(() => {
     const fetchConcept = async (): Promise<void> => {
@@ -38,6 +39,7 @@ export function useFetchConceptData(conceptId: number, locale: string) {
           setLoading(false);
         }
       } catch (e) {
+        setError({ status: e.status });
         setLoading(false);
         handleError(e);
       }
@@ -104,6 +106,7 @@ export function useFetchConceptData(conceptId: number, locale: string) {
   };
 
   return {
+    error,
     concept,
     createConcept,
     fetchSearchTags,

--- a/src/containers/ImageUploader/EditImage.tsx
+++ b/src/containers/ImageUploader/EditImage.tsx
@@ -16,6 +16,7 @@ import { actions, FlatReduxImage, getImage } from '../../modules/image/image';
 import { UpdatedImageMetadata } from '../../modules/image/imageApiInterfaces';
 import { License, ReduxState } from '../../interfaces';
 import { LocaleContext } from '../App/App';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 
 interface ImageType extends UpdatedImageMetadata {
   revision?: number;
@@ -100,6 +101,11 @@ class EditImage extends Component<Props> {
       isNewlyCreated,
       ...rest
     } = this.props;
+
+    if (!imageData) {
+      return <NotFoundPage />;
+    }
+
     return (
       <LocaleContext.Consumer>
         {locale => (

--- a/src/containers/PodcastSeries/EditPodcastSeries.tsx
+++ b/src/containers/PodcastSeries/EditPodcastSeries.tsx
@@ -12,6 +12,7 @@ import { transformSeries } from '../../util/audioHelpers';
 import Spinner from '../../components/Spinner';
 import { FlattenedPodcastSeries, NewPodcastSeries } from '../../modules/audio/audioApiInterfaces';
 import PodcastSeriesForm from './components/PodcastSeriesForm';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 
 interface Props {
   podcastSeriesId: number;
@@ -47,8 +48,8 @@ const EditPodcastSeries = ({ podcastSeriesId, podcastSeriesLanguage, isNewlyCrea
     return <Spinner />;
   }
 
-  if (podcastSeries === undefined) {
-    return null;
+  if (!podcastSeries) {
+    return <NotFoundPage />;
   }
 
   const language = podcastSeriesLanguage ?? locale;

--- a/src/util/audioHelpers.ts
+++ b/src/util/audioHelpers.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import _ from 'lodash';
 import { convertFieldWithFallback } from './convertFieldWithFallback';
 import {
   AudioApiType,
@@ -18,6 +19,10 @@ export const transformAudio = (
   audio: AudioApiType,
   language: string,
 ): FlattenedAudioApiType | undefined => {
+  if (_.isEmpty(audio)) {
+    return undefined;
+  }
+
   const audioLanguage =
     audio && audio.supportedLanguages && audio.supportedLanguages.includes(language)
       ? language
@@ -27,20 +32,22 @@ export const transformAudio = (
   const manuscript = convertFieldWithFallback<'manuscript'>(audio, 'manuscript', '', audioLanguage);
   const tags = convertFieldWithFallback<'tags', string[]>(audio, 'tags', [], audioLanguage);
 
-  return audio
-    ? {
-        ...audio,
-        title,
-        manuscript,
-        tags,
-      }
-    : undefined;
+  return {
+    ...audio,
+    title,
+    manuscript,
+    tags,
+  };
 };
 
 export const transformSeries = (
   series: PodcastSeriesApiType,
   language: string,
-): FlattenedPodcastSeries => {
+): FlattenedPodcastSeries | undefined => {
+  if (_.isEmpty(series)) {
+    return undefined;
+  }
+
   const seriesLanguage = series.supportedLanguages.includes(language) ? language : undefined;
   const title = convertFieldWithFallback<'title'>(series, 'title', '', seriesLanguage);
   const description = convertFieldWithFallback<'description'>(

--- a/src/util/resolveJsonOrRejectWithError.js
+++ b/src/util/resolveJsonOrRejectWithError.js
@@ -26,6 +26,10 @@ export function resolveJsonOrRejectWithError(res, options = { taxonomy: false, i
       return resolve({});
     }
 
+    if (res.status === 404) {
+      return resolve({});
+    }
+
     res
       .json()
       .then(json => {

--- a/src/util/resolveJsonOrRejectWithError.js
+++ b/src/util/resolveJsonOrRejectWithError.js
@@ -26,10 +26,6 @@ export function resolveJsonOrRejectWithError(res, options = { taxonomy: false, i
       return resolve({});
     }
 
-    if (res.status === 404) {
-      return resolve({});
-    }
-
     res
       .json()
       .then(json => {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2641

Lagt til notfoundpage ved manglende id på hver av ressursene. Screenshot av ressurser;
![image](https://user-images.githubusercontent.com/54741055/125278892-8fb7c000-e313-11eb-8a07-b89e9ce32ee4.png)


Kan testes ved å trykke inn på en ressurs og legge til en random id, e.g. http://localhost:3000/media/podcast-series/344444/edit/nb 

Kræsjet lokalt ved uhåndtert promise ved status 404, så la til resolve ved `src/util/resolveJsonOrRejectWithError.js `. Tar gjerne feedback på om det er gjort riktig. 

