### PR TITLE
Slate upgrade dialog styling

### DIFF
--- a/src/components/SlateEditor/plugins/footnote/EditFootnote.tsx
+++ b/src/components/SlateEditor/plugins/footnote/EditFootnote.tsx
@@ -61,14 +61,16 @@ const EditFootnote = (props: Props & tType) => {
   return (
     <Portal isOpened>
       <Lightbox display appearance="big" onClose={onClose}>
-        <h2>{t(`form.content.footnote.${isEdit ? 'editTitle' : 'addTitle'}`)}</h2>
-        <FootnoteForm
-          footnote={existingFootnote}
-          onClose={onClose}
-          isEdit={isEdit}
-          onRemove={handleRemove}
-          onSave={handleSave}
-        />
+        <div>
+          <h2>{t(`form.content.footnote.${isEdit ? 'editTitle' : 'addTitle'}`)}</h2>
+          <FootnoteForm
+            footnote={existingFootnote}
+            onClose={onClose}
+            isEdit={isEdit}
+            onRemove={handleRemove}
+            onSave={handleSave}
+          />
+        </div>
       </Lightbox>
     </Portal>
   );

--- a/src/components/SlateEditor/plugins/footnote/FootnoteForm.jsx
+++ b/src/components/SlateEditor/plugins/footnote/FootnoteForm.jsx
@@ -64,7 +64,7 @@ class FootnoteForm extends Component {
             <FormikField name="title" type="text" label={t('form.content.footnote.title')} />
             <FormikField name="year" type="text" label={t('form.content.footnote.year')} />
             <FormikField name="authors" label={t('form.content.footnote.authors.label')} obligatory>
-              {({ field }) => <MultiSelectDropdown showCreateOption {...field} />}
+              {({ field }) => <MultiSelectDropdown idField="" showCreateOption {...field} />}
             </FormikField>
             <FormikField name="edition" type="text" label={t('form.content.footnote.edition')} />
 

--- a/src/components/SlateEditor/plugins/link/EditLink.tsx
+++ b/src/components/SlateEditor/plugins/link/EditLink.tsx
@@ -177,15 +177,17 @@ const EditLink = (props: Props & tType) => {
   return (
     <Portal isOpened>
       <Lightbox display appearance="big" onClose={onClose}>
-        <h2>{t(`form.content.link.${isEdit ? 'changeTitle' : 'addTitle'}`)}</h2>
-        <LinkForm
-          onClose={onClose}
-          link={model}
-          node={element}
-          isEdit={isEdit}
-          onRemove={handleRemove}
-          onSave={handleSave}
-        />
+        <div>
+          <h2>{t(`form.content.link.${isEdit ? 'changeTitle' : 'addTitle'}`)}</h2>
+          <LinkForm
+            onClose={onClose}
+            link={model}
+            node={element}
+            isEdit={isEdit}
+            onRemove={handleRemove}
+            onSave={handleSave}
+          />
+        </div>
       </Lightbox>
     </Portal>
   );


### PR DESCRIPTION
Tittelen i modal for redigering av lenke og fotnote var tidligere plassert til venstre for skjemaet. Denne PRen fikser det så tittelen er plassert ovenfor.

Hvordan teste:
- Åpne PR-installasjon
- Opprett/åpne artikkel
- Legg til fotnote og lenke. Se at tittel er plassert riktig.