### PR TITLE
Slate: Show placeholder for title in Details box

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -9,7 +9,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React, { useEffect, useMemo, useRef } from 'react';
-import { createEditor, Descendant, Editor } from 'slate';
+import { createEditor, Descendant, Editor, NodeEntry } from 'slate';
 import {
   Slate,
   Editable,
@@ -136,6 +136,13 @@ const RichTextEditor = ({
     return <span {...attributes}>{children}</span>;
   };
 
+  const decorations = (entry: NodeEntry) => {
+    if (editor.decorations) {
+      return editor.decorations(editor, entry);
+    }
+    return [];
+  };
+
   return (
     <article>
       <SlateProvider isSubmitted={submitted}>
@@ -156,6 +163,7 @@ const RichTextEditor = ({
               })}
             />
             <Editable
+              decorate={entry => decorations(entry)}
               onBlur={(event: React.FocusEvent<HTMLDivElement>) => onBlur(event, editor)}
               onKeyDown={editor.onKeyDown}
               placeholder={placeholder}

--- a/src/components/SlateEditor/interfaces.ts
+++ b/src/components/SlateEditor/interfaces.ts
@@ -1,4 +1,4 @@
-import { Editor, Descendant, BaseEditor } from 'slate';
+import { Editor, Descendant, BaseEditor, NodeEntry, BaseRange } from 'slate';
 import { HistoryEditor } from 'slate-history';
 import { ReactEditor, RenderElementProps, RenderLeafProps } from 'slate-react';
 import React from 'react';
@@ -34,6 +34,7 @@ export type CustomEditor = {
   renderLeaf?: (props: RenderLeafProps) => JSX.Element | undefined;
   removeSection?: () => void;
   shouldShowToolbar: () => boolean;
+  decorations?: (editor: Editor, entry: NodeEntry) => BaseRange[];
 };
 
 declare module 'slate' {

--- a/src/components/SlateEditor/plugins/break/index.tsx
+++ b/src/components/SlateEditor/plugins/break/index.tsx
@@ -37,7 +37,12 @@ export const breakPlugin = (editor: Editor) => {
   editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
     if (element.type === TYPE_BREAK) {
       // Children of br tag is not rendered.
-      return <br {...attributes} contentEditable={false} />;
+      return (
+        <div {...attributes} contentEditable={false}>
+          <br />
+          {children}
+        </div>
+      );
     } else if (nextRenderELement) {
       return nextRenderELement({ attributes, children, element });
     }

--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -8,7 +8,7 @@
 
 import React, { KeyboardEvent, KeyboardEventHandler } from 'react';
 import { Element, Descendant, Editor, Path, Transforms, Node, Text, Range, Location } from 'slate';
-import { RenderElementProps } from 'slate-react';
+import { ReactEditor, RenderElementProps, RenderLeafProps } from 'slate-react';
 import { jsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
 import Details from './Details';
@@ -152,6 +152,34 @@ export const detailsPlugin = (editor: Editor) => {
       return nextRenderElement({ attributes, children, element });
     }
   };
+
+  editor.renderLeaf = (props: RenderLeafProps) => {
+    const { attributes, children, leaf, text } = props;
+    const path = ReactEditor.findPath(editor, text);
+
+    const [parent] = Editor.node(editor, Path.parent(path));
+    if (Element.isElement(parent) && parent.type === TYPE_SUMMARY && Node.string(leaf) === '') {
+      return (
+        <span style={{ position: 'relative' }}>
+          <span {...attributes}>{children}</span>
+          <span
+            style={{
+              position: 'absolute',
+              top: 0,
+              opacity: 0.3,
+              pointerEvents: 'none',
+              userSelect: 'none',
+              display: 'inline-block',
+            }}
+            contentEditable={false}>
+            Tittel
+          </span>
+        </span>
+      );
+    }
+    return;
+  };
+
   editor.normalizeNode = entry => {
     const [node, path] = entry;
 

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -8,7 +8,6 @@
  */
 
 import React from 'react';
-import { Dictionary } from 'lodash';
 import { Descendant, Editor, Element, NodeEntry, Path, Transforms } from 'slate';
 import { ReactEditor, RenderElementProps } from 'slate-react';
 import { HistoryEditor } from 'slate-history';
@@ -29,8 +28,8 @@ import {
   TYPE_TABLE_ROW,
 } from './utils';
 import getCurrentBlock from '../../utils/getCurrentBlock';
-import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
-import { defaultParagraphBlock, TYPE_PARAGRAPH } from '../paragraph/utils';
+import { addSurroundingParagraphs } from '../../utils/normalizationHelpers';
+import { defaultParagraphBlock } from '../paragraph/utils';
 
 export const KEY_ARROW_UP = 'ArrowUp';
 export const KEY_ARROW_DOWN = 'ArrowDown';
@@ -208,38 +207,9 @@ export const tablePlugin = (editor: Editor) => {
             );
           }
         });
-        const nextPath = Path.next(path);
 
-        if (Editor.hasPath(editor, nextPath)) {
-          const [nextNode] = Editor.node(editor, nextPath);
-          if (
-            !Element.isElement(nextNode) ||
-            !afterOrBeforeTextBlockElement.includes(nextNode.type)
-          ) {
-            Transforms.insertNodes(editor, jsx('element', { type: TYPE_PARAGRAPH }), {
-              at: nextPath,
-            });
-
-            return;
-          }
-        }
-
-        if (Path.hasPrevious(path)) {
-          const previousPath = Path.previous(path);
-
-          if (Editor.hasPath(editor, previousPath)) {
-            const [previousNode] = Editor.node(editor, previousPath);
-            if (
-              !Element.isElement(previousNode) ||
-              !afterOrBeforeTextBlockElement.includes(previousNode.type)
-            ) {
-              Transforms.insertNodes(editor, jsx('element', { type: TYPE_PARAGRAPH }), {
-                at: path,
-              });
-
-              return;
-            }
-          }
+        if (addSurroundingParagraphs(editor, path)) {
+          return;
         }
       } else if (node.type === TYPE_TABLE_CELL) {
         if (!Element.isElementList(node.children)) {

--- a/src/components/SlateEditor/utils/normalizationHelpers.ts
+++ b/src/components/SlateEditor/utils/normalizationHelpers.ts
@@ -1,6 +1,6 @@
 import { Editor, Element, NodeEntry, Node, Transforms, Text, Path } from 'slate';
 import { jsx } from 'slate-hyperscript';
-import { TYPE_PARAGRAPH } from '../plugins/paragraph/utils';
+import { defaultParagraphBlock, TYPE_PARAGRAPH } from '../plugins/paragraph/utils';
 
 export const firstTextBlockElement: Element['type'][] = ['paragraph', 'heading'];
 
@@ -109,12 +109,18 @@ export const addSurroundingParagraphs = (editor: Editor, path: Path) => {
   if (Editor.hasPath(editor, nextPath)) {
     const [nextNode] = Editor.node(editor, nextPath);
     if (!Element.isElement(nextNode) || !afterOrBeforeTextBlockElement.includes(nextNode.type)) {
-      Transforms.insertNodes(editor, jsx('element', { type: TYPE_PARAGRAPH }), {
+      Transforms.insertNodes(editor, defaultParagraphBlock(), {
         at: nextPath,
       });
 
       return true;
     }
+  } else {
+    Transforms.insertNodes(editor, defaultParagraphBlock(), {
+      at: nextPath,
+    });
+
+    return true;
   }
 
   if (Path.hasPrevious(path)) {


### PR DESCRIPTION
Lagt til placeholder for tittel i ekspanderende boks. 

Hvordan teste:
- Åpne PR-installasjon.
- Åpne eller lag en ny artikkel.
- Sjekk blant annet at:
   - Placeholder vises i tittelfeltet i ekspanderende boks
   - Lagring og redigering fungerer
   - Markør plasseres og vises riktig