### PR TITLE
Fix import and remove notfoundpage if no data

### DIFF
--- a/src/containers/ImageUploader/EditImage.tsx
+++ b/src/containers/ImageUploader/EditImage.tsx
@@ -16,7 +16,6 @@ import { actions, FlatReduxImage, getImage } from '../../modules/image/image';
 import { UpdatedImageMetadata } from '../../modules/image/imageApiInterfaces';
 import { License, ReduxState } from '../../interfaces';
 import { LocaleContext } from '../App/App';
-import NotFoundPage from '../NotFoundPage/NotFoundPage';
 
 interface ImageType extends UpdatedImageMetadata {
   revision?: number;
@@ -101,10 +100,6 @@ class EditImage extends Component<Props> {
       isNewlyCreated,
       ...rest
     } = this.props;
-
-    if (!imageData) {
-      return <NotFoundPage />;
-    }
 
     return (
       <LocaleContext.Consumer>

--- a/src/containers/ImageUploader/components/ImageForm.tsx
+++ b/src/containers/ImageUploader/components/ImageForm.tsx
@@ -22,7 +22,7 @@ import {
   AlertModalWrapper,
 } from '../../FormikForm';
 import { toCreateImage, toEditImage } from '../../../util/routeHelpers';
-import HeaderWithLanguage from '../../../components/HeaderWithLanguage';
+import HeaderWithLanguage from '../../../components/HeaderWithLanguage/HeaderWithLanguage';
 import { NewImageMetadata, UpdatedImageMetadata } from '../../../modules/image/imageApiInterfaces';
 import { Author, Copyright } from '../../../interfaces';
 

--- a/src/containers/ImageUploader/components/ImageForm.tsx
+++ b/src/containers/ImageUploader/components/ImageForm.tsx
@@ -126,6 +126,7 @@ interface Props {
   inModal?: boolean;
   isNewlyCreated?: boolean;
   closeModal?: () => void;
+  isSaving?: boolean;
 }
 
 interface State {
@@ -181,7 +182,7 @@ class ImageForm extends Component<Props & tType, State> {
   };
 
   render() {
-    const { t, image, licenses, inModal, closeModal, isNewlyCreated } = this.props;
+    const { t, image, licenses, inModal, closeModal, isNewlyCreated, isSaving } = this.props;
     const { savedToServer } = this.state;
     type ErrorFields =
       | 'alttext'
@@ -195,6 +196,7 @@ class ImageForm extends Component<Props & tType, State> {
       | 'title';
 
     const initialValues = getInitialValues(image);
+
     return (
       <Formik
         initialValues={initialValues}
@@ -256,12 +258,12 @@ class ImageForm extends Component<Props & tType, State> {
                     {t('form.abort')}
                   </ActionButton>
                 ) : (
-                  <AbortButton outline disabled={isSubmitting}>
+                  <AbortButton outline disabled={isSubmitting || isSaving}>
                     {t('form.abort')}
                   </AbortButton>
                 )}
                 <SaveButton
-                  isSaving={isSubmitting}
+                  isSaving={isSubmitting || isSaving}
                   showSaved={!formIsDirty && (savedToServer || isNewlyCreated)}
                   formIsDirty={formIsDirty}
                   submit={!inModal}


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2650

- Siden et bilde som ikke er opplastet ennå ikke vil ha `imagedata`, vil ikke opplastning av bilde fungere. Fjernet derfor `notfoundpage` hvis ingen `imagedata`. 
- Forventet at den eksisterende importen av `headerwithlanguage` fungerte siden den har export default i fila `index.js` i samme mappe, men den fungerte ikke. Oppdaterte importen til å peke mer spesifikt. 
- Benyttet isSaving i SaveButton for å klargjøre når bildet lastes opp