### PR TITLE
Add ebok as valid domain

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,7 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
     url: ['liste.ndla.no', 'liste.test.ndla.no', 'liste.staging.ndla.no'],
     height: '398px',
   },
+  { name: 'ebok', url: ['ebok.no'] },
 ];
 
 export const SearchTypeValues = [

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -165,6 +165,8 @@ const frameSrc = (() => {
     '*.worldbank.org',
     'embed.molview.org',
     'embed.ted.com',
+    'reader.pubfront.com',
+    'ebok.no',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2625

Måtte legge til ebok i contentsecuritypolicy og whitelist. reader.pubfront.com ser ut til å bli brukt av ebok for embedded code, så det måtte også bli lagt til i contentsecuritypolicy. 

Istedenfor å hente ut full embeded code fra gratis utdrag (se eksempelbok https://ebok.no/ebok/hvem-sa-hva_helene-uri-2/), hentes heller src-lenken fra iframe i embedded code.

**Kan testes ved å:**
- gå inn på pr-instansen
- gå inn på artikkel
- legg til innhold: Ressurs som lenke
- lim inn lenke fra iframe src , for eksempel `https://ebok.no/market/sample/1419092/
`
Bilde fra hvordan innholdet bør vises:

![image](https://user-images.githubusercontent.com/54741055/126748767-bb521a9d-e47c-452e-ad1c-48e97ade465b.png)
