### PR TITLE
Slate: Add debounce to concept plugin modal

### DIFF
--- a/src/components/SlateEditor/plugins/concept/ConceptModal.jsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModal.jsx
@@ -25,6 +25,7 @@ import SearchConceptResults from './SearchConceptResults';
 import ConceptForm from '../../../../containers/ConceptPage/ConceptForm';
 import { ConceptShape, SubjectShape } from '../../../../shapes';
 import * as messageActions from '../../../../containers/Messages/messagesActions';
+import { debounce } from 'lodash';
 
 const type = 'concept';
 
@@ -131,7 +132,7 @@ const ConceptModal = ({
                         </h2>
                         <SearchForm
                           type={type}
-                          search={searchConcept}
+                          search={debounce(searchConcept, 400)}
                           searchObject={searchObject}
                           locale={locale}
                           location={window.location}

--- a/src/components/SlateEditor/plugins/concept/ConceptModal.jsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModal.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import Modal from '@ndla/modal/lib/Modal';
 import { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
@@ -25,7 +26,6 @@ import SearchConceptResults from './SearchConceptResults';
 import ConceptForm from '../../../../containers/ConceptPage/ConceptForm';
 import { ConceptShape, SubjectShape } from '../../../../shapes';
 import * as messageActions from '../../../../containers/Messages/messagesActions';
-import { debounce } from 'lodash';
 
 const type = 'concept';
 


### PR DESCRIPTION
Problemet som er løst:
Ved innsetting av forklaring i editor (via inline toolbar) så åpnes en modal. Søkefeltet fungerer dårlig når man skriver raskt. Trenger delay etter hvert trykk slik at man kan skrive ferdig ordet før den søker.

Løste det ved å legge inn debounce for å utsette søk til 400ms etter man er ferdig med å skrive

Hvordan teste:
- Åpne artikkel
- Skriv noe tekst, marker den og velg "forklaring" i toolbar (eller ctrl+alt+c).
- Søk etter forklaring i feltet og bekreft at du kan skrive ordet ferdig før den gjør et søk.