### PR TITLE
Slate: onEnter, only unwrap list when list-item is empty

### DIFF
--- a/src/components/SlateEditor/interfaces.ts
+++ b/src/components/SlateEditor/interfaces.ts
@@ -27,7 +27,7 @@ export type SlatePlugin = (editor: Editor) => Editor;
 
 export interface SlateSerializer {
   deserialize: (el: HTMLElement, children: Descendant[]) => Descendant | Descendant[] | undefined;
-  serialize: (node: Descendant, children: (JSX.Element | null)[]) => JSX.Element | null | undefined;
+  serialize: (node: Descendant, children: JSX.Element[]) => JSX.Element | null | undefined;
 }
 
 export type CustomEditor = {

--- a/src/components/SlateEditor/plugins/aside/index.tsx
+++ b/src/components/SlateEditor/plugins/aside/index.tsx
@@ -30,7 +30,7 @@ export const asideSerializer: SlateSerializer = {
     if (el.tagName.toLowerCase() !== 'aside') return;
     return jsx('element', { type: TYPE_ASIDE, data: getAsideType(el) }, children);
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type !== 'aside') return;
     return <aside data-type={node.data.type || ''}>{children}</aside>;

--- a/src/components/SlateEditor/plugins/blockquote/index.tsx
+++ b/src/components/SlateEditor/plugins/blockquote/index.tsx
@@ -29,7 +29,7 @@ export const blockQuoteSerializer: SlateSerializer = {
       return jsx('element', { type: TYPE_QUOTE }, children);
     }
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type === TYPE_QUOTE) {
       return <blockquote>{children}</blockquote>;

--- a/src/components/SlateEditor/plugins/bodybox/index.tsx
+++ b/src/components/SlateEditor/plugins/bodybox/index.tsx
@@ -28,7 +28,7 @@ export const bodyboxSerializer: SlateSerializer = {
       return jsx('element', { type: TYPE_BODYBOX }, children);
     }
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node) || node.type !== TYPE_BODYBOX) return;
     return <div className="c-bodybox">{children}</div>;
   },

--- a/src/components/SlateEditor/plugins/codeBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/index.tsx
@@ -34,14 +34,14 @@ export interface CodeblockElement {
 }
 
 export const codeblockSerializer: SlateSerializer = {
-  deserialize(el: HTMLElement, children: (Descendant | null)[]) {
+  deserialize(el: HTMLElement) {
     if (!el.tagName.toLowerCase().startsWith('embed')) return;
     const embed = el as HTMLEmbedElement;
     const embedAttributes = reduceElementDataAttributes(embed);
     if (embedAttributes.resource !== 'code-block') return;
     return jsx('element', { type: TYPE_CODEBLOCK, data: { ...embedAttributes } }, [{ text: '' }]);
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant) {
     if (!Element.isElement(node) || node.type !== 'code-block') return;
 
     const { data } = node;

--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -99,7 +99,7 @@ export const detailsSerializer: SlateSerializer = {
     }
     return;
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type === TYPE_SUMMARY) {
       return <summary>{children}</summary>;

--- a/src/components/SlateEditor/plugins/div/index.tsx
+++ b/src/components/SlateEditor/plugins/div/index.tsx
@@ -34,7 +34,7 @@ export const divSerializer: SlateSerializer = {
       children,
     );
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type !== TYPE_DIV) return;
 

--- a/src/components/SlateEditor/plugins/heading/index.tsx
+++ b/src/components/SlateEditor/plugins/heading/index.tsx
@@ -46,7 +46,7 @@ export const headingSerializer: SlateSerializer = {
       return jsx('element', { type: TYPE_HEADING, level: 3 }, children);
     }
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type === TYPE_HEADING) {
       return React.createElement('h' + node.level, [], [children]);

--- a/src/components/SlateEditor/plugins/link/index.tsx
+++ b/src/components/SlateEditor/plugins/link/index.tsx
@@ -76,7 +76,7 @@ export const linkSerializer: SlateSerializer = {
     }
     return;
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type === TYPE_LINK) {
       return (

--- a/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
+++ b/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
@@ -1,4 +1,4 @@
-import { Editor, Node, Element, Range, Transforms, Path, Text } from 'slate';
+import { Editor, Node, Element, Range, Transforms, Path } from 'slate';
 
 import { TYPE_LIST_ITEM } from '..';
 import getCurrentBlock from '../../../utils/getCurrentBlock';

--- a/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
+++ b/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
@@ -35,12 +35,8 @@ const onEnter = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEv
     Editor.deleteForward(editor);
   }
 
-  // If paragraph is empty, remove list item and jump out of list.
-  if (
-    Node.string(currentParagraph) === '' &&
-    currentParagraph.children.length === 1 &&
-    Text.isText(currentParagraph.children[0])
-  ) {
+  // If list-item is empty, remove list item and jump out of list.
+  if (Node.string(currentListItem) === '') {
     Editor.withoutNormalizing(editor, () => {
       Transforms.unwrapNodes(editor, { at: currentListItemPath });
       Transforms.liftNodes(editor, { at: currentListItemPath });

--- a/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
+++ b/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
@@ -3,7 +3,6 @@ import { Editor, Node, Element, Range, Transforms, Path } from 'slate';
 import { TYPE_LIST_ITEM } from '..';
 import getCurrentBlock from '../../../utils/getCurrentBlock';
 import { TYPE_PARAGRAPH } from '../../paragraph/utils';
-import { defaultListItemBlock } from '../utils/defaultBlocks';
 
 const onEnter = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEvent) => void) => {
   if (event.shiftKey && next) return next(event);
@@ -45,13 +44,12 @@ const onEnter = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEv
   }
 
   // Split current listItem at selection.
-  const liftPath = Editor.hasPath(editor, Path.next(currentParagraphPath))
-    ? currentParagraphPath
-    : Path.next(currentParagraphPath);
   Editor.withoutNormalizing(editor, () => {
-    Transforms.splitNodes(editor, { always: true });
-    Transforms.wrapNodes(editor, defaultListItemBlock(), { at: liftPath });
-    Transforms.liftNodes(editor, { at: liftPath });
+    Transforms.splitNodes(editor, {
+      always: true,
+      match: node => Element.isElement(node) && node.type === TYPE_LIST_ITEM,
+      mode: 'lowest',
+    });
   });
 };
 

--- a/src/components/SlateEditor/plugins/list/index.tsx
+++ b/src/components/SlateEditor/plugins/list/index.tsx
@@ -66,8 +66,9 @@ export const listSerializer: SlateSerializer = {
       return jsx('element', { type: TYPE_LIST_ITEM }, children);
     }
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
+
     if (node.type === TYPE_LIST) {
       if (node.listType === 'bulleted-list') {
         return <ul>{children}</ul>;
@@ -87,7 +88,16 @@ export const listSerializer: SlateSerializer = {
       }
     }
     if (node.type === TYPE_LIST_ITEM) {
-      return <li>{children}</li>;
+      // If first child of list-item is a list, it means that an empty paragraph has been removed by
+      // paragraph serializer. This should not be removed, therefore inserting it when serializing.
+      const firstChild = children[0];
+      const test = firstChild && ['ol', 'ul'].includes(firstChild.type);
+      return (
+        <li>
+          {test && <p></p>}
+          {children}
+        </li>
+      );
     }
   },
 };

--- a/src/components/SlateEditor/plugins/paragraph/index.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/index.tsx
@@ -84,7 +84,7 @@ export const paragraphSerializer: SlateSerializer = {
       children,
     );
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type !== TYPE_PARAGRAPH /*&& node.type !== 'line'*/) return;
 

--- a/src/components/SlateEditor/plugins/section/index.tsx
+++ b/src/components/SlateEditor/plugins/section/index.tsx
@@ -36,7 +36,7 @@ export const sectionSerializer: SlateSerializer = {
     }
     return;
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type === TYPE_SECTION) {
       return <section>{children}</section>;

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -94,7 +94,7 @@ export const tableSerializer: SlateSerializer = {
     }
     return jsx('element', { type: tableTag, data }, children);
   },
-  serialize(node: Descendant, children: (JSX.Element | null)[]) {
+  serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node)) return;
     if (node.type !== TYPE_TABLE && node.type !== TYPE_TABLE_ROW && node.type !== TYPE_TABLE_CELL)
       return;

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -7,6 +7,7 @@
  */
 import escapeHtml from 'escape-html';
 import React from 'react';
+import { compact } from 'lodash';
 import { Descendant, Element, Node, Text } from 'slate';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Plain } from './slatePlainSerializer';
@@ -160,11 +161,11 @@ export const learningResourceContentToEditorValue = (html?: string) => {
 
 export function learningResourceContentToHTML(contentValues: Descendant[][]) {
   const serialize = (node: Descendant): JSX.Element | null => {
-    let children: (JSX.Element | null)[];
+    let children: JSX.Element[];
     if (Text.isText(node)) {
       children = [escapeHtml(node.text)];
     } else {
-      children = node.children.map((n: Descendant) => serialize(n));
+      children = compact(node.children.map((n: Descendant) => serialize(n)));
     }
 
     for (const rule of learningResourceRules) {
@@ -241,11 +242,11 @@ export function topicArticleContentToEditorValue(html: string) {
 
 export function topicArticleContentToHTML(value: Descendant[]) {
   const serialize = (node: Descendant): JSX.Element | null => {
-    let children: (JSX.Element | null)[];
+    let children: JSX.Element[];
     if (Text.isText(node)) {
       children = [escapeHtml(node.text)];
     } else {
-      children = node.children.map((n: Descendant) => serialize(n));
+      children = compact(node.children.map((n: Descendant) => serialize(n)));
     }
 
     for (const rule of topicArticleRules) {


### PR DESCRIPTION
Dersom man har markøren som plassert i bildet og trykker enter, så skal man hoppe til neste linje hvor det opprettes et nytt liste-element. Tidligere ble hoppet den heller ut av listen i en tom paragraf.


![image](https://user-images.githubusercontent.com/17144211/128015527-a329f8f9-d2c5-45e0-aa24-3942b4eeaccb.png)


