### PR TITLE
Add missing translations for files

### DIFF
--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -100,6 +100,7 @@ const allowedFiles = [
   '.xls',
   '.xlsx',
   '.xml',
+  '.f3d',
 ];
 
 export default injectT(FileUploader);

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -972,6 +972,13 @@ const phrases = {
       missingTitle: '[Missing filename]',
       missingFileTooltip:
         'This file does not seem to exist on the server. It might have been deleted from another article.',
+      missingFilename: 'File type is not supported',
+      dragdrop: {
+        main: 'Drag and drop',
+        sub: 'or click to upload file(s)',
+        ariaLabel: 'Drag and drop or click to upload file(s)',
+        noFilesAdded: 'No files are added',
+      },
       showPdf: 'Show expanded',
       showPdfTooltip: 'Show expanded PDF in article',
     },

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -984,6 +984,7 @@ const phrases = {
       missingTitle: '[Mangler filnavn]',
       missingFileTooltip:
         'Ser ikke ut til å eksistere på serveren. Den kan ha blitt slettet fra en annen artikkel.',
+      missingFilename: 'Filtypen støttes ikke',
       dragdrop: {
         main: 'Dra og slipp',
         sub: 'eller trykk for å laste opp file(r)',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -990,6 +990,13 @@ const phrases = {
       missingTitle: '[Mangler filnamn]',
       missingFileTooltip:
         'Ser ikkje ut til å eksistere på serveren. Den kan ha blitt sletta frå ein annan artikkel.',
+      missingFilename: 'Filtypen støttes ikke',
+      dragdrop: {
+        main: 'Dra og slipp',
+        sub: 'eller trykk for å laste opp file(r)',
+        ariaLabel: 'Dra og slipp eller trykk for å laste opp file(r)',
+        noFilesAdded: 'Ingen filer er lagt til',
+      },
       showPdf: 'Vis ekspandert',
       showPdfTooltip: 'Vis ekspandert PDF i artikkel',
     },


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2601

Deployet [fix i draft-api](https://github.com/NDLANO/draft-api/pull/272), og da fungerte det å laste opp f3d i ed. Trengte ikke å legge til .f3d i `src/components/FileUploader/FileUploader.tsx` for å få det til å fungere, så jeg vet ikke hva `allowedFiles` her egentlig gjør. 

Gjerne dobbeltsjekk at filopplastning av typen .f3d fungerer i ed.

Lagt til manglende oversettelser. 