### PR TITLE
Fixed a bug where adding a resource to an empty resource group would crash the app

### DIFF
--- a/src/containers/StructurePage/resourceComponents/ResourceGroup.jsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceGroup.jsx
@@ -88,7 +88,7 @@ class ResourceGroup extends PureComponent {
             topicId={topicId}
             refreshResources={refreshResources}
             onClose={this.toggleAddModal}
-            existingResourceIds={topicResource.resources.map(r => r.id)}
+            existingResourceIds={topicResource?.resources?.map(r => r.id) ?? []}
           />
         )}
       </React.Fragment>


### PR DESCRIPTION
Bugen er live i test. Man kan teste den ved å legge til en ressurs i en tom ressursgruppe i struktur. Den oppstår fordi det passeres inn et tomt objekt til `ResourceGroup` i `StructureResources`.