### PR TITLE
#2667: Fix non-null assertion where there can be a `undefined` value

### DIFF
--- a/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
@@ -155,7 +155,7 @@ const PodcastSeriesForm = ({
       enableReinitialize
       validate={values => {
         const errors = validateFormik(values, podcastRules, t);
-        const metaImageErrors = validateMetaImage(size.current!);
+        const metaImageErrors = size.current ? validateMetaImage(size.current) : {};
         return { ...errors, ...metaImageErrors };
       }}>
       {formikProps => {


### PR DESCRIPTION
Fixes NDLANO/Issues#2667

Kan testes ved å forsøke å lagre en podcast serie uten metabilde.