### PR TITLE
2666 external link url validation

### DIFF
--- a/src/components/SlateEditor/plugins/related/EditRelated.jsx
+++ b/src/components/SlateEditor/plugins/related/EditRelated.jsx
@@ -20,7 +20,7 @@ import { search } from '../../../../modules/search/searchApi';
 import AsyncDropdown from '../../../Dropdown/asyncDropdown/AsyncDropdown';
 import Overlay from '../../../Overlay';
 import RelatedArticle from './RelatedArticle';
-import TaxonomyLightbox from '../../../Taxonomy/TaxonomyLightbox';
+import ContentLink from '../../../../containers/ArticlePage/components/ContentLink';
 import { Portal } from '../../../Portal';
 import DeleteButton from '../../../DeleteButton';
 import { ARTICLE_EXTERNAL } from '../../../../constants';
@@ -136,7 +136,6 @@ class EditRelated extends React.PureComponent {
       t,
       ...rest
     } = this.props;
-    const { title, url } = this.state;
 
     return (
       <div>
@@ -258,8 +257,8 @@ class EditRelated extends React.PureComponent {
               <DeleteButton stripped onClick={onRemoveClick} />
             </StyledBorderDiv>
             {this.state.showAddExternal && (
-              <TaxonomyLightbox
-                onSelect={() => {
+              <ContentLink
+                onAddLink={(title, url) => {
                   if (this.state.tempId) {
                     updateArticles(
                       articles.map(a =>
@@ -267,7 +266,6 @@ class EditRelated extends React.PureComponent {
                       ),
                     );
                     this.setState({
-                      showAddExternal: false,
                       tempId: undefined,
                       url: '',
                       title: '',
@@ -276,27 +274,10 @@ class EditRelated extends React.PureComponent {
                     insertExternal(url, title);
                   }
                 }}
-                title={t('form.content.relatedArticle.searchExternal')}
-                onClose={this.toggleAddExternal}>
-                <input
-                  type="text"
-                  id="url"
-                  data-testid="addExternalUrlInput"
-                  onChange={this.handleInputChange}
-                  onClick={e => e.stopPropagation()}
-                  value={url}
-                  placeholder={t('form.content.relatedArticle.urlPlaceholder')}
-                />
-                <input
-                  type="text"
-                  id="title"
-                  data-testid="addExternalTitleInput"
-                  value={title}
-                  onChange={this.handleInputChange}
-                  onClick={e => e.stopPropagation()}
-                  placeholder={t('form.content.relatedArticle.titlePlaceholder')}
-                />
-              </TaxonomyLightbox>
+                onClose={this.toggleAddExternal}
+                initialTitle={this.state.title}
+                initialUrl={this.state.url}
+              />
             )}
           </Portal>
         </div>

--- a/src/components/SlateEditor/plugins/related/EditRelated.jsx
+++ b/src/components/SlateEditor/plugins/related/EditRelated.jsx
@@ -274,7 +274,14 @@ class EditRelated extends React.PureComponent {
                     insertExternal(url, title);
                   }
                 }}
-                onClose={this.toggleAddExternal}
+                onClose={() => {
+                  this.setState({
+                    tempId: undefined,
+                    url: '',
+                    title: '',
+                  });
+                  this.toggleAddExternal();
+                }}
                 initialTitle={this.state.title}
                 initialUrl={this.state.url}
               />

--- a/src/components/Taxonomy/TaxonomyLightbox.tsx
+++ b/src/components/Taxonomy/TaxonomyLightbox.tsx
@@ -19,7 +19,7 @@ import Spinner from '../Spinner';
 interface Props {
   children: JSX.Element;
   onClose: () => void;
-  loading: boolean;
+  loading?: boolean;
   title: string;
   onSelect: () => void;
 }

--- a/src/containers/ArticlePage/components/ContentField.tsx
+++ b/src/containers/ArticlePage/components/ContentField.tsx
@@ -7,12 +7,9 @@
 
 import React, { useState } from 'react';
 import { injectT, tType } from '@ndla/i18n';
-import styled from '@emotion/styled';
-import { spacing } from '@ndla/core';
 import { FieldHeader } from '@ndla/forms';
 import Button from '@ndla/button';
 import { FormikHelpers, FormikValues } from 'formik';
-import Modal, { ModalCloseButton, ModalHeader, ModalBody } from '@ndla/modal';
 import { fetchDraft, searchDrafts } from '../../../modules/draft/draftApi';
 import ElementList from '../../FormikForm/components/ElementList';
 import { AsyncDropdown } from '../../../components/Dropdown';
@@ -35,6 +32,7 @@ const ContentField = ({ locale, t, values, field, form }: Props & tType) => {
   const [relatedContent, setRelatedContent] = useState<ConvertedRelatedContent[]>(
     values.relatedContent,
   );
+  const [showAddExternal, setShowAddExternal] = useState(false);
 
   const onAddArticleToList = async (article: ContentResultType) => {
     try {
@@ -103,28 +101,14 @@ const ContentField = ({ locale, t, values, field, form }: Props & tType) => {
         disableSelected
         clearInputField
       />
-      <StyledButtonWrapper>
-        <Modal
-          backgroundColor="white"
-          activateButton={<Button>{t('form.relatedContent.addExternal')}</Button>}>
-          {(onClose: () => void) => (
-            <>
-              <ModalHeader>
-                <ModalCloseButton onClick={onClose} title={t('dialog.close')} />
-              </ModalHeader>
-              <ModalBody>
-                <ContentLink onAddLink={addExternalLink} onClose={onClose} />
-              </ModalBody>
-            </>
-          )}
-        </Modal>
-      </StyledButtonWrapper>
+      <Button onClick={() => setShowAddExternal(true)}>
+        {t('form.relatedContent.addExternal')}
+      </Button>
+      {showAddExternal && (
+        <ContentLink onAddLink={addExternalLink} onClose={() => setShowAddExternal(false)} />
+      )}
     </>
   );
 };
-
-const StyledButtonWrapper = styled.div`
-  margin: ${spacing.small} 0;
-`;
 
 export default injectT(ContentField);

--- a/src/containers/ArticlePage/components/ContentField.tsx
+++ b/src/containers/ArticlePage/components/ContentField.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState } from 'react';
 import { injectT, tType } from '@ndla/i18n';
+import styled from '@emotion/styled';
+import { spacing } from '@ndla/core';
 import { FieldHeader } from '@ndla/forms';
 import Button from '@ndla/button';
 import { FormikHelpers, FormikValues } from 'formik';
@@ -101,14 +103,20 @@ const ContentField = ({ locale, t, values, field, form }: Props & tType) => {
         disableSelected
         clearInputField
       />
-      <Button onClick={() => setShowAddExternal(true)}>
-        {t('form.relatedContent.addExternal')}
-      </Button>
+      <StyledButtonWrapper>
+        <Button onClick={() => setShowAddExternal(true)}>
+          {t('form.relatedContent.addExternal')}
+        </Button>
+      </StyledButtonWrapper>
       {showAddExternal && (
         <ContentLink onAddLink={addExternalLink} onClose={() => setShowAddExternal(false)} />
       )}
     </>
   );
 };
+
+const StyledButtonWrapper = styled.div`
+  margin: ${spacing.small} 0;
+`;
 
 export default injectT(ContentField);

--- a/src/containers/ArticlePage/components/ContentLink.tsx
+++ b/src/containers/ArticlePage/components/ContentLink.tsx
@@ -26,11 +26,19 @@ const StyledContent = styled.div`
 interface Props {
   onAddLink: (title: string, url: string) => void;
   onClose: () => void;
+  initialTitle?: string;
+  initialUrl?: string;
 }
 
-const ContentLink = ({ t, onAddLink, onClose }: Props & tType) => {
-  const [title, setTitle] = useState('');
-  const [url, setUrl] = useState('');
+const ContentLink = ({
+  t,
+  onAddLink,
+  onClose,
+  initialTitle = '',
+  initialUrl = '',
+}: Props & tType) => {
+  const [title, setTitle] = useState(initialTitle);
+  const [url, setUrl] = useState(initialUrl);
   const [showError, setShowError] = useState(false);
 
   const isEmpty = (title: string) => {
@@ -38,8 +46,7 @@ const ContentLink = ({ t, onAddLink, onClose }: Props & tType) => {
   };
 
   const isUrl = (field: string) => {
-    var pattern = /^((http:|https:)\/\/)/;
-
+    const pattern = /^((http:|https:)\/\/)/;
     return pattern.test(field);
   };
 

--- a/src/containers/ArticlePage/components/ContentLink.tsx
+++ b/src/containers/ArticlePage/components/ContentLink.tsx
@@ -6,11 +6,22 @@
  */
 
 import React, { useState } from 'react';
-import { injectT, tType } from '@ndla/i18n';
 import styled from '@emotion/styled';
-import { spacing } from '@ndla/core';
+import { injectT, tType } from '@ndla/i18n';
 import { Input } from '@ndla/forms';
-import Button from '@ndla/button';
+import TaxonomyLightbox from '../../../components/Taxonomy/TaxonomyLightbox';
+
+const StyledContent = styled.div`
+  width: 100%;
+
+  > * {
+    width: 100%;
+  }
+
+  & form {
+    background-color: white;
+  }
+`;
 
 interface Props {
   onAddLink: (title: string, url: string) => void;
@@ -42,32 +53,30 @@ const ContentLink = ({ t, onAddLink, onClose }: Props & tType) => {
   };
 
   return (
-    <>
-      <Input
-        warningText={showError && isEmpty(title) && t('form.relatedContent.link.missingTitle')}
-        container="div"
-        type="text"
-        placeholder={t('form.relatedContent.link.titlePlaceholder')}
-        value={title}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
-      />
-      <Input
-        warningText={showError && !isUrl(url) && t('form.relatedContent.link.missingUrl')}
-        container="div"
-        type="text"
-        placeholder={t('form.relatedContent.link.urlPlaceholder')}
-        value={url}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)}
-      />
-      <StyledButtonWrapper>
-        <Button onClick={handleSubmit}>{t('form.relatedContent.link.addLink')}</Button>
-      </StyledButtonWrapper>
-    </>
+    <TaxonomyLightbox
+      title={t('form.content.relatedArticle.searchExternal')}
+      onSelect={handleSubmit}
+      onClose={onClose}>
+      <StyledContent>
+        <Input
+          warningText={showError && isEmpty(title) && t('form.relatedContent.link.missingTitle')}
+          container="div"
+          type="text"
+          placeholder={t('form.relatedContent.link.titlePlaceholder')}
+          value={title}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+        />
+        <Input
+          warningText={showError && !isUrl(url) && t('form.relatedContent.link.missingUrl')}
+          container="div"
+          type="text"
+          placeholder={t('form.relatedContent.link.urlPlaceholder')}
+          value={url}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)}
+        />
+      </StyledContent>
+    </TaxonomyLightbox>
   );
 };
-
-const StyledButtonWrapper = styled.div`
-  margin: ${spacing.small} 0;
-`;
 
 export default injectT(ContentLink);

--- a/src/containers/ArticlePage/components/ContentLink.tsx
+++ b/src/containers/ArticlePage/components/ContentLink.tsx
@@ -67,6 +67,7 @@ const ContentLink = ({
       <StyledContent>
         <Input
           warningText={showError && isEmpty(title) && t('form.relatedContent.link.missingTitle')}
+          data-testid="addExternalTitleInput"
           container="div"
           type="text"
           placeholder={t('form.relatedContent.link.titlePlaceholder')}
@@ -75,6 +76,7 @@ const ContentLink = ({
         />
         <Input
           warningText={showError && !isUrl(url) && t('form.relatedContent.link.missingUrl')}
+          data-testid="addExternalUrlInput"
           container="div"
           type="text"
           placeholder={t('form.relatedContent.link.urlPlaceholder')}

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -740,7 +740,7 @@ const phrases = {
         addExternal: 'Add external article',
         removeExternal: 'Delete external article',
         changeExternal: 'Edit external article',
-        searchExternal: 'Write the url and title of the external article',
+        searchExternal: 'Write the title and url of the external article',
       },
       concept: {
         remove: 'Remove concept',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -753,7 +753,7 @@ const phrases = {
         addExternal: 'Legg til ekstern artikkel',
         removeExternal: 'Slett ekstern artikkel',
         changeExternal: 'Endre ekstern artikkel',
-        searchExternal: 'Skriv inn url og tittel på ekstern artikkel',
+        searchExternal: 'Skriv inn tittel og url på ekstern artikkel',
       },
       concept: {
         remove: 'Fjern forklaring',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -762,7 +762,7 @@ const phrases = {
         addExternal: 'Legg til ekstern artikkel',
         removeExternal: 'Slett ekstern artikkel',
         changeExternal: 'Endre ekstern artikkel',
-        searchExternal: 'Skriv inn url og tittel på ekstern artikkel',
+        searchExternal: 'Skriv inn tittel og url på ekstern artikkel',
       },
       concept: {
         remove: 'Fjern forklaring',


### PR DESCRIPTION
Fixes NDLANO/Issues#2666

Legger til validering når man setter inn relatert, ekstern artikkel i en artikkel. Endrer også på modalen som brukes når man gjør det samme under "Relatert innhold" tabben til å være lik den som brukes i editoren.

Test:
* Åpne blockpicker og velg Relatert innhold
* Trykk "Legg til ekstern artikkel"
* Det skal ikke gå an å lagre med en ugyldig url 