### PR TITLE
Fikser slik at det går an å sortere også på første nivå.

### DIFF
--- a/src/containers/StructurePage/StructureContainer.jsx
+++ b/src/containers/StructurePage/StructureContainer.jsx
@@ -286,8 +286,10 @@ export class StructureContainer extends React.PureComponent {
       params,
       allTopics: this.state.topics,
     });
-    const topics = getSubtopics(currentTopic.id, this.state.topics) || currentSubject.topics;
-    const currentRank = topics[source.index].rank;
+    const topics = currentTopic.id
+      ? getSubtopics(currentTopic.id, this.state.topics)
+      : currentSubject.topics;
+    const currentRank = topics[source.index]?.rank;
     const destinationRank = topics[destination.index].rank;
     const newRank = currentRank > destinationRank ? destinationRank : destinationRank + 1;
     if (currentRank === destinationRank) return;

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -810,7 +810,7 @@ const phrases = {
     },
     categories: {
       label: 'Liste og filter',
-      description: 'Format: liste:filter1:filter2',
+      description: 'Format: Liste:Filter1:Filter2',
       searchPlaceholder: 'Søk etter lister',
     },
     grepCodes: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -819,7 +819,7 @@ const phrases = {
     },
     categories: {
       label: 'Liste og filter',
-      description: 'Format: liste:filter1:filter2',
+      description: 'Format: Liste:Filter1:Filter2',
       searchPlaceholder: 'Søk etter lister',
     },
     grepCodes: {


### PR DESCRIPTION
Fixes NDLANO/Issues#2658

Forrige fiks fjerna muligheten for å sortere på første nivå. Dette fikser det, men er kanskje ikkje mest elegant.

Test: 
Det skal gå an å sortere emner på alle nivå i strukturredigeringa.