### PR TITLE
Slate: Handle pure text in <li> in serializing and serializing

### DIFF
--- a/src/components/SlateEditor/plugins/list/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/list/__tests__/serializer-test.ts
@@ -111,4 +111,65 @@ describe('paragraph serializing tests', () => {
     const res = learningResourceContentToEditorValue(html);
     expect(res).toEqual(editor);
   });
+
+  test('deserializing <li> with plaintext as children', () => {
+    const html =
+      '<section><ol data-type="letters"><li>abc<strong>123</strong>def<p>paragraph</p>456</li></ol></section>';
+    const expected: Descendant[][] = [
+      [
+        {
+          type: 'section',
+          children: [
+            {
+              type: 'list',
+              listType: 'letter-list',
+              data: {},
+              children: [
+                {
+                  type: 'list-item',
+                  children: [
+                    {
+                      type: 'paragraph',
+                      serializeAsText: true,
+                      children: [
+                        {
+                          text: 'abc',
+                        },
+                        {
+                          bold: true,
+                          text: '123',
+                        },
+                        {
+                          text: 'def',
+                        },
+                      ],
+                    },
+                    {
+                      type: 'paragraph',
+                      children: [
+                        {
+                          text: 'paragraph',
+                        },
+                      ],
+                    },
+                    {
+                      type: 'paragraph',
+                      serializeAsText: true,
+                      children: [
+                        {
+                          text: '456',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    ];
+    const res = learningResourceContentToEditorValue(html);
+    expect(res).toEqual(expected);
+  });
 });

--- a/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
+++ b/src/components/SlateEditor/plugins/list/handlers/onEnter.ts
@@ -45,6 +45,9 @@ const onEnter = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEv
 
   // Split current listItem at selection.
   Editor.withoutNormalizing(editor, () => {
+    Transforms.unsetNodes(editor, 'serializeAsText', {
+      match: node => Element.isElement(node) && node.type === TYPE_PARAGRAPH,
+    });
     Transforms.splitNodes(editor, {
       always: true,
       match: node => Element.isElement(node) && node.type === TYPE_LIST_ITEM,

--- a/src/components/SlateEditor/plugins/list/index.tsx
+++ b/src/components/SlateEditor/plugins/list/index.tsx
@@ -37,6 +37,31 @@ export interface ListItemElement {
 export const listSerializer: SlateSerializer = {
   deserialize(el: HTMLElement, children: (Descendant | null)[]) {
     const tag = el.tagName.toLowerCase();
+
+    children = children.reduce((acc, cur) => {
+      const lastElement = acc[acc.length - 1];
+      if (!cur) {
+        return acc;
+      } else if (Element.isElement(cur)) {
+        acc.push(cur);
+        return acc;
+      } else if (Text.isText(cur)) {
+        if (
+          Element.isElement(lastElement) &&
+          lastElement.type === TYPE_PARAGRAPH &&
+          lastElement.serializeAsText
+        ) {
+          lastElement.children.push(cur);
+          return acc;
+        } else {
+          acc.push(jsx('element', { type: TYPE_PARAGRAPH, serializeAsText: true }, cur));
+          return acc;
+        }
+      }
+      acc.push(cur);
+      return acc;
+    }, [] as Descendant[]);
+
     if (tag === 'ul') {
       return jsx('element', { type: TYPE_LIST, listType: 'bulleted-list', data: {} }, children);
     }

--- a/src/util/__tests__/content-converter-integration-tests/mixedArticle/__snapshots__/mixedArticle-test.js.snap
+++ b/src/util/__tests__/content-converter-integration-tests/mixedArticle/__snapshots__/mixedArticle-test.js.snap
@@ -18,7 +18,7 @@ exports[`serializing article with many diffrent tags and embeds 1`] = `
     <li>Alpha 1</li>
     <li>Alpha 2</li>
     <li>
-      <p>Alpha 3</p>
+      Alpha 3
       <ol data-type=\\"letters\\">
         <li>Alpha 3.1</li>
         <li>Alpha 3.2</li>


### PR DESCRIPTION
Fikser et problem der tekst som er lagret i liste-element i html, feks  `<li>abc<\>`, blir til  `<li><p>abc</p><\>` ved lagring.

Løsning:
- Lagt til et parameter i paragraph: `serializeAsText`. Ved serialisering vil teksten rendres uten `<p>`.
- Ved deserialisering av list-item endres `children` slik at alle tekstnoder wrappes i paragraph med `serializeAsText: true`
