### PR TITLE
Added translating of audio from bokmål to nynorsk.

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.jsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.jsx
@@ -69,7 +69,7 @@ const HeaderActions = ({
   const emptyLanguages = languages.filter(
     lang => lang.key !== language && !supportedLanguages.includes(lang.key) && lang.include,
   );
-  const translatableTypes = ['concept', 'standard', 'topic-article', 'podcast'];
+  const translatableTypes = ['audio', 'concept', 'standard', 'topic-article', 'podcast'];
 
   if (id) {
     return (

--- a/src/containers/AudioUploader/EditAudio.tsx
+++ b/src/containers/AudioUploader/EditAudio.tsx
@@ -14,6 +14,7 @@ import { transformAudio } from '../../util/audioHelpers';
 import { createFormData } from '../../util/formDataHelper';
 import { toEditPodcast } from '../../util/routeHelpers';
 import Spinner from '../../components/Spinner';
+import { useTranslateApi } from '../FormikForm/translateFormHooks';
 import { License, LocaleType } from '../../interfaces';
 import {
   FlattenedAudioApiType,
@@ -39,6 +40,11 @@ const EditAudio = ({
 }: Props) => {
   const [audio, setAudio] = useState<FlattenedAudioApiType | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
+  const { translating, translateToNN } = useTranslateApi(
+    audio,
+    (audio: FlattenedAudioApiType) => setAudio(audio),
+    ['id', 'manuscript', 'title'],
+  );
 
   const onUpdate = async (
     newAudio: UpdatedAudioMetaInformation,
@@ -84,6 +90,8 @@ const EditAudio = ({
       audioLanguage={audioLanguage}
       isNewlyCreated={isNewlyCreated}
       licenses={licenses}
+      translating={translating}
+      translateToNN={translateToNN}
       {...rest}
     />
   );

--- a/src/containers/AudioUploader/components/AudioForm.tsx
+++ b/src/containers/AudioUploader/components/AudioForm.tsx
@@ -17,6 +17,7 @@ import {
   editorValueToPlainText,
 } from '../../../util/articleContentConverter';
 import Field from '../../../components/Field';
+import Spinner from '../../../components/Spinner';
 import SaveButton from '../../../components/SaveButton';
 import {
   DEFAULT_LICENSE,
@@ -131,6 +132,8 @@ interface BaseProps extends PropsFromRedux {
   audioLanguage: string;
   revision?: number;
   isNewlyCreated?: boolean;
+  translating?: boolean;
+  translateToNN?: () => void;
 }
 
 interface State {
@@ -187,7 +190,7 @@ class AudioForm extends Component<Props, State> {
   };
 
   render() {
-    const { t, licenses, audio, isNewlyCreated } = this.props;
+    const { t, licenses, audio, isNewlyCreated, translating, translateToNN } = this.props;
     const { savedToServer } = this.state;
 
     const initialValues = getInitialValues(audio);
@@ -224,37 +227,42 @@ class AudioForm extends Component<Props, State> {
                   if (values.id) return toEditAudio(values.id, lang);
                   else return toCreateAudioFile();
                 }}
+                translateToNN={translateToNN}
               />
-              <Accordions>
-                <AccordionSection
-                  id="audio-upload-content"
-                  className="u-4/6@desktop u-push-1/6@desktop"
-                  title={t('form.contentSection')}
-                  hasError={hasError(['title', 'audioFile'])}
-                  startOpen>
-                  <AudioContent classes={formClasses} />
-                </AccordionSection>
-                <AccordionSection
-                  id="podcast-upload-podcastmanus"
-                  title={t('podcastForm.fields.manuscript')}
-                  className="u-4/6@desktop u-push-1/6@desktop"
-                  hasError={[].some(field => field in errors)}>
-                  <AudioManuscript classes={formClasses} />
-                </AccordionSection>
-                <AccordionSection
-                  id="audio-upload-metadataSection"
-                  className="u-4/6@desktop u-push-1/6@desktop"
-                  title={t('form.metadataSection')}
-                  hasError={hasError([
-                    'tags',
-                    'creators',
-                    'rightsholders',
-                    'processors',
-                    'license',
-                  ])}>
-                  <AudioMetaData classes={formClasses} licenses={licenses} />
-                </AccordionSection>
-              </Accordions>
+              {translating ? (
+                <Spinner withWrapper />
+              ) : (
+                <Accordions>
+                  <AccordionSection
+                    id="audio-upload-content"
+                    className="u-4/6@desktop u-push-1/6@desktop"
+                    title={t('form.contentSection')}
+                    hasError={hasError(['title', 'audioFile'])}
+                    startOpen>
+                    <AudioContent classes={formClasses} />
+                  </AccordionSection>
+                  <AccordionSection
+                    id="podcast-upload-podcastmanus"
+                    title={t('podcastForm.fields.manuscript')}
+                    className="u-4/6@desktop u-push-1/6@desktop"
+                    hasError={[].some(field => field in errors)}>
+                    <AudioManuscript classes={formClasses} />
+                  </AccordionSection>
+                  <AccordionSection
+                    id="audio-upload-metadataSection"
+                    className="u-4/6@desktop u-push-1/6@desktop"
+                    title={t('form.metadataSection')}
+                    hasError={hasError([
+                      'tags',
+                      'creators',
+                      'rightsholders',
+                      'processors',
+                      'license',
+                    ])}>
+                    <AudioMetaData classes={formClasses} licenses={licenses} />
+                  </AccordionSection>
+                </Accordions>
+              )}
 
               <Field right>
                 <AbortButton outline disabled={isSubmitting}>
@@ -297,6 +305,8 @@ class AudioForm extends Component<Props, State> {
     applicationError: PropTypes.func.isRequired,
     audioLanguage: PropTypes.string.isRequired,
     isNewlyCreated: PropTypes.bool,
+    translating: PropTypes.bool,
+    translateToNN: PropTypes.func.isRequired,
   };
 }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2681

Oversetter lyd-manuskript .

Test:
Finn en lydfil med bokmål og ikkje nynorsk. Skriv gjerne inn tekst i tekstversjonfeltet. Klikk på Oversett til nynorsk. Sjekk at både tittel og tekstversjon oversettes.