### PR TITLE
Remove duplicates from tags in fetched audio

### DIFF
--- a/src/util/audioHelpers.ts
+++ b/src/util/audioHelpers.ts
@@ -36,7 +36,7 @@ export const transformAudio = (
     ...audio,
     title,
     manuscript,
-    tags,
+    tags: Array.from(new Set(tags)),
   };
 };
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2694

Ved henting av lyd fjernes duplikate tags.

Hvordan teste:
- Åpne PR-instans
- Åpne feks /media/audio-upload/1275/edit/sma (denne innholder per dette tidspunkt duplikater)
- Om du ser i requesten så vil en lydfil med duplikate tags kun vise fram unike tags.