### PR TITLE
Add button to show a modal with whitelisted urls in external url embed

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,15 @@ export const getNdlaApiUrl = (env: string): string => {
   }
 };
 
+export const ndlaBaseUrl = () => {
+  switch (ndlaEnvironment) {
+    case 'prod':
+      return 'ndla.no';
+    default:
+      return `${ndlaEnvironment}.ndla.no`;
+  }
+};
+
 const ndlaFrontendDomain = () => {
   switch (ndlaEnvironment) {
     case 'local':

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import { ndlaBaseUrl } from './config';
+
 export const NAVIGATION_HEADER_MARGIN = '71px';
 
 export const RESOURCE_TYPE_LEARNING_PATH = 'urn:resourcetype:learningPath';
@@ -82,11 +84,11 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'MolView', url: ['embed.molview.org'] },
   {
     name: 'NDLA Statisk',
-    url: ['statisk.ndla.no', 'statisk.test.ndla.no', 'statisk.staging.ndla.no'],
+    url: [`statisk.${ndlaBaseUrl()}`],
   },
   {
     name: 'NDLA Liste',
-    url: ['liste.ndla.no', 'liste.test.ndla.no', 'liste.staging.ndla.no'],
+    url: [`liste.${ndlaBaseUrl()}`],
     height: '398px',
   },
   { name: 'ebok', url: ['ebok.no'] },

--- a/src/containers/VisualElement/UrlAllowList.tsx
+++ b/src/containers/VisualElement/UrlAllowList.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface Props {
-  allowList: {
-    name: string;
-    url: string[];
-  }[];
+interface AllowListEntry {
+  name: string;
+  url: string[];
 }
+
+interface Props {
+  allowList: AllowListEntry[];
+}
+
+const removeTestDomains = (entry: AllowListEntry) => ({
+  ...entry,
+  url: entry.url.filter(url => !url.includes('test.ndla') && !url.includes('staging.ndla')),
+});
+
+const sortEntries = (a: AllowListEntry, b: AllowListEntry) => a.name.localeCompare(b.name);
 
 const UrlAllowList = ({ allowList }: Props) => {
   const { t } = useTranslation();
 
-  const filteredAllowList = allowList.filter(
-    e => !e.url.find(url => url.includes('test.ndla') || url.includes('staging.ndla')),
-  );
+  const filteredAllowList = allowList.map(removeTestDomains).sort(sortEntries);
   return (
     <table className="c-table">
       <thead>
@@ -23,18 +30,16 @@ const UrlAllowList = ({ allowList }: Props) => {
         </tr>
       </thead>
       <tbody>
-        {filteredAllowList
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .map(provider => (
-            <tr>
-              <td>{provider.name}</td>
-              <td>
-                {provider.url.map(url => (
-                  <div>{url}</div>
-                ))}
-              </td>
-            </tr>
-          ))}
+        {filteredAllowList.map(provider => (
+          <tr>
+            <td>{provider.name}</td>
+            <td>
+              {provider.url.map(url => (
+                <div>{url}</div>
+              ))}
+            </td>
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/src/containers/VisualElement/UrlAllowList.tsx
+++ b/src/containers/VisualElement/UrlAllowList.tsx
@@ -10,17 +10,12 @@ interface Props {
   allowList: AllowListEntry[];
 }
 
-const removeTestDomains = (entry: AllowListEntry) => ({
-  ...entry,
-  url: entry.url.filter(url => !url.includes('test.ndla') && !url.includes('staging.ndla')),
-});
-
 const sortEntries = (a: AllowListEntry, b: AllowListEntry) => a.name.localeCompare(b.name);
 
 const UrlAllowList = ({ allowList }: Props) => {
   const { t } = useTranslation();
 
-  const filteredAllowList = allowList.map(removeTestDomains).sort(sortEntries);
+  const filteredAllowList = allowList.sort(sortEntries);
   return (
     <table className="c-table">
       <thead>

--- a/src/containers/VisualElement/UrlAllowList.tsx
+++ b/src/containers/VisualElement/UrlAllowList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  allowList: {
+    name: string;
+    url: string[];
+  }[];
+}
+
+const UrlAllowList = ({ allowList }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <table className="c-table">
+      <thead>
+        <tr>
+          <th>{t('form.content.link.name')}</th>
+          <th>{t('form.content.link.domains')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {allowList
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map(provider => (
+            <tr>
+              <td>{provider.name}</td>
+              <td>
+                {provider.url.map(url => (
+                  <div>{url}</div>
+                ))}
+              </td>
+            </tr>
+          ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default UrlAllowList;

--- a/src/containers/VisualElement/UrlAllowList.tsx
+++ b/src/containers/VisualElement/UrlAllowList.tsx
@@ -10,6 +10,10 @@ interface Props {
 
 const UrlAllowList = ({ allowList }: Props) => {
   const { t } = useTranslation();
+
+  const filteredAllowList = allowList.filter(
+    e => !e.url.find(url => url.includes('test.ndla') || url.includes('staging.ndla')),
+  );
   return (
     <table className="c-table">
       <thead>
@@ -19,7 +23,7 @@ const UrlAllowList = ({ allowList }: Props) => {
         </tr>
       </thead>
       <tbody>
-        {allowList
+        {filteredAllowList
           .sort((a, b) => a.name.localeCompare(b.name))
           .map(provider => (
             <tr>

--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -15,7 +15,11 @@ import { FieldHeader, FieldSection, Input, FieldSplitter, FieldRemoveButton } fr
 import { Link as LinkIcon } from '@ndla/icons/common';
 import styled from '@emotion/styled';
 import { spacing } from '@ndla/core';
+import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
+import { InformationOutline } from '@ndla/icons/common';
+import { css } from '@emotion/react';
 
+import UrlAllowList from './UrlAllowList';
 import { fetchExternalOembed } from '../../util/apiHelpers';
 import {
   isValidURL,
@@ -226,6 +230,30 @@ class VisualElementUrlPreview extends Component {
             onClick={() => this.handleSaveUrl(url)}>
             {isChangedUrl ? t('form.content.link.insert') : t('form.content.link.update')}
           </Button>
+          <Modal
+            backgroundColor="white"
+            activateButton={
+              <Button>
+                <InformationOutline
+                  css={css`
+                    margin-right: 5px;
+                  `}
+                />
+                {t('form.content.link.validDomains')}
+              </Button>
+            }>
+            {onClose => (
+              <>
+                <ModalHeader>
+                  <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
+                </ModalHeader>
+                <ModalBody>
+                  <h1>{t('form.content.link.validDomains')}</h1>
+                  <UrlAllowList allowList={EXTERNAL_WHITELIST_PROVIDERS} />
+                </ModalBody>
+              </>
+            )}
+          </Modal>
         </StyledButtonWrapper>
         {showPreview && (
           <StyledPreviewWrapper>

--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -60,7 +60,7 @@ const StyledPreviewItem = styled('div')`
   width: 50%;
 `;
 
-const transformableDomains = [
+export const transformableDomains = [
   {
     domains: ['nrk.no', 'www.nrk.no'],
     shouldTransform: (url, domains) => {

--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -197,9 +197,11 @@ class VisualElementUrlPreview extends Component {
           <Modal
             backgroundColor="white"
             activateButton={
-              <Tooltip tooltip={t('form.content.link.validDomains')}>
-                <HelpIcon css={normalPaddingCSS} />
-              </Tooltip>
+              <div>
+                <Tooltip tooltip={t('form.content.link.validDomains')}>
+                  <HelpIcon css={normalPaddingCSS} />
+                </Tooltip>
+              </div>
             }>
             {onClose => (
               <>

--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -16,8 +16,7 @@ import { Link as LinkIcon } from '@ndla/icons/common';
 import styled from '@emotion/styled';
 import { spacing } from '@ndla/core';
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
-import { InformationOutline } from '@ndla/icons/common';
-import { css } from '@emotion/react';
+import Tooltip from '@ndla/tooltip';
 
 import UrlAllowList from './UrlAllowList';
 import { fetchExternalOembed } from '../../util/apiHelpers';
@@ -29,6 +28,7 @@ import {
 } from '../../util/htmlHelpers';
 import { EXTERNAL_WHITELIST_PROVIDERS } from '../../constants';
 import { fetchNrkMedia } from './visualElementApi';
+import { HelpIcon, normalPaddingCSS } from '../../components/HowTo';
 
 const filterWhiteListedURL = url => {
   const domain = urlDomain(url);
@@ -193,8 +193,29 @@ class VisualElementUrlPreview extends Component {
               ? t('form.content.link.newUrlResource')
               : t('form.content.link.changeUrlResource', { type })
           }
-          subTitle={this.getSubTitle()}
-        />
+          subTitle={this.getSubTitle()}>
+          <Modal
+            backgroundColor="white"
+            activateButton={
+              <Tooltip tooltip={t('form.content.link.validDomains')}>
+                <HelpIcon css={normalPaddingCSS} />
+              </Tooltip>
+            }>
+            {onClose => (
+              <>
+                <ModalHeader>
+                  <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
+                </ModalHeader>
+                <ModalBody>
+                  <h1>{t('form.content.link.validDomains')}</h1>
+                  <center>
+                    <UrlAllowList allowList={EXTERNAL_WHITELIST_PROVIDERS} />
+                  </center>
+                </ModalBody>
+              </>
+            )}
+          </Modal>
+        </FieldHeader>
         <FieldSection>
           <div>
             <FieldSplitter>
@@ -230,30 +251,6 @@ class VisualElementUrlPreview extends Component {
             onClick={() => this.handleSaveUrl(url)}>
             {isChangedUrl ? t('form.content.link.insert') : t('form.content.link.update')}
           </Button>
-          <Modal
-            backgroundColor="white"
-            activateButton={
-              <Button>
-                <InformationOutline
-                  css={css`
-                    margin-right: 5px;
-                  `}
-                />
-                {t('form.content.link.validDomains')}
-              </Button>
-            }>
-            {onClose => (
-              <>
-                <ModalHeader>
-                  <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
-                </ModalHeader>
-                <ModalBody>
-                  <h1>{t('form.content.link.validDomains')}</h1>
-                  <UrlAllowList allowList={EXTERNAL_WHITELIST_PROVIDERS} />
-                </ModalBody>
-              </>
-            )}
-          </Modal>
         </StyledButtonWrapper>
         {showPreview && (
           <StyledPreviewWrapper>

--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
@@ -5,7 +5,16 @@
  */
 
 import nock from 'nock';
-import { transformUrlIfNeeded } from '../VisualElementUrlPreview';
+import { transformableDomains } from '../VisualElementUrlPreview';
+
+const transformUrlIfNeeded = async url => {
+  for (const rule of transformableDomains) {
+    if (rule.shouldTransform(url, rule.domains)) {
+      return await rule.transform(url);
+    }
+  }
+  return url;
+};
 
 test('transformUrlIfNeeded returns static nrk url if correct nrk url is used', async () => {
   nock('http://nrk-api')

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -765,6 +765,9 @@ const phrases = {
         choose: 'Choose concept',
       },
       link: {
+        name: 'Name',
+        domains: 'Url',
+        validDomains: 'Valid domains',
         goTo: 'Go to',
         insert: 'Insert link',
         update: 'Update link',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -779,6 +779,9 @@ const phrases = {
         choose: 'Velg forklaring',
       },
       link: {
+        name: 'Navn',
+        domains: 'Url',
+        validDomains: 'Gyldige domener',
         goTo: 'Gå til',
         insert: 'Sett inn lenke',
         update: 'Oppdater lenke',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -788,6 +788,9 @@ const phrases = {
         choose: 'Velg forklaring',
       },
       link: {
+        name: 'Navn',
+        domains: 'Url',
+        validDomains: 'Gyldige domener',
         goTo: 'Gå til',
         insert: 'Sett inn lenke',
         update: 'Oppdater lenke',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -788,7 +788,7 @@ const phrases = {
         choose: 'Velg forklaring',
       },
       link: {
-        name: 'Navn',
+        name: 'Namn',
         domains: 'Url',
         validDomains: 'Gyldige domener',
         goTo: 'Gå til',


### PR DESCRIPTION
Fixes NDLANO/Issues#2707

Har lagt til en modal som viser en tabell over gyldige url-er. Denne finner man ved å redigere artikkel og legge til "Ressurs fra lenke" via legg-til-knappen.

Hvordan teste:
1. Åpne PR-instans
2. Åpne/lag artikkel
3. Legg til ressurs fra lenke
4. Det skal vises en ny knapp med tekst "gyldige domener".
5. Ting å sjekke
    - Modalen fungerer som forventet
    - Tabellen som vises
    - Translations
    - Styling