### PR TITLE
Slate: Set focus correctly after closing code block editor

### DIFF
--- a/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
@@ -54,7 +54,6 @@ const getInfoFromNode = (element: CodeblockElement) => {
 const CodeBlock = ({ attributes, editor, element, children }: Props) => {
   const { model } = getInfoFromNode(element);
   const [editMode, setEditMode] = useState<boolean>(!model.code && !model.title);
-  const [firstEdit, setFirstEdit] = useState<boolean>(element.isFirstEdit);
 
   const toggleEditMode = () => {
     setEditMode(!editMode);
@@ -69,13 +68,14 @@ const CodeBlock = ({ attributes, editor, element, children }: Props) => {
       },
       isFirstEdit: false,
     };
-
+    ReactEditor.focus(editor);
     setEditMode(false);
-    setFirstEdit(false);
     const path = ReactEditor.findPath(editor, element);
     Transforms.setNodes(editor, properties, { at: path });
     if (Editor.hasPath(editor, Path.next(path))) {
-      Transforms.select(editor, Path.next(path));
+      setTimeout(() => {
+        Transforms.select(editor, Path.next(path));
+      }, 0);
     }
   };
 
@@ -88,13 +88,16 @@ const CodeBlock = ({ attributes, editor, element, children }: Props) => {
   };
 
   const onExit = () => {
+    ReactEditor.focus(editor);
     setEditMode(false);
-    if (firstEdit) {
+    if (element.isFirstEdit) {
       handleUndo();
     }
     const path = ReactEditor.findPath(editor, element);
     if (Editor.hasPath(editor, Path.next(path))) {
-      Transforms.select(editor, Path.next(path));
+      setTimeout(() => {
+        Transforms.select(editor, Path.next(path));
+      }, 0);
     }
   };
 


### PR DESCRIPTION
Fikser en feil som ble oppdaget i beta. Ved lukking av kodeblokk ble fokus ofte satt i starten av editor.

Dette er løst ved å sette fokus i editor og plassere selection etterpå med en timeout.

Hvordan teste:
- Åpne / lag artikkel
- Sett inn kodevisning og forsøk alle metoder for å lukke modalen. Fokus skal alltid settes etter kodevisningen.