### PR TITLE
2716 kahoot url transform

### DIFF
--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -9,7 +9,6 @@
 import React, { Fragment, Component } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
-import queryString from 'query-string';
 import Button from '@ndla/button';
 import { FieldHeader, FieldSection, Input, FieldSplitter, FieldRemoveButton } from '@ndla/forms';
 import { Link as LinkIcon } from '@ndla/icons/common';
@@ -20,15 +19,10 @@ import Tooltip from '@ndla/tooltip';
 
 import UrlAllowList from './UrlAllowList';
 import { fetchExternalOembed } from '../../util/apiHelpers';
-import {
-  isValidURL,
-  urlDomain,
-  urlAsATag,
-  getIframeSrcFromHtmlString,
-} from '../../util/htmlHelpers';
+import { isValidURL, urlDomain, getIframeSrcFromHtmlString } from '../../util/htmlHelpers';
 import { EXTERNAL_WHITELIST_PROVIDERS } from '../../constants';
-import { fetchNrkMedia } from './visualElementApi';
 import { HelpIcon, normalPaddingCSS } from '../../components/HowTo';
+import { urlTransformers } from './urlTransformers';
 
 const filterWhiteListedURL = url => {
   const domain = urlDomain(url);
@@ -59,62 +53,6 @@ const StyledPreviewWrapper = styled('div')`
 const StyledPreviewItem = styled('div')`
   width: 50%;
 `;
-
-export const transformableDomains = [
-  {
-    domains: ['nrk.no', 'www.nrk.no'],
-    shouldTransform: (url, domains) => {
-      const aTag = urlAsATag(url);
-
-      if (!domains.includes(aTag.hostname)) {
-        return false;
-      }
-      const mediaId = queryString.parse(aTag.search).mediaId;
-      if (mediaId) {
-        return true;
-      }
-      return false;
-    },
-    transform: async url => {
-      const aTag = urlAsATag(url);
-      const mediaId = queryString.parse(aTag.search).mediaId;
-      if (!mediaId) {
-        return url;
-      }
-      try {
-        const nrkMedia = await fetchNrkMedia(mediaId);
-        if (nrkMedia.psId) {
-          return `https://static.nrk.no/ludo/latest/video-embed.html#id=${nrkMedia.psId}`;
-        }
-        return url;
-      } catch {
-        return url;
-      }
-    },
-  },
-  {
-    domains: ['create.kahoot.it'],
-    shouldTransform: (url, domains) => {
-      const aTag = urlAsATag(url);
-
-      if (!domains.includes(aTag.hostname)) {
-        return false;
-      }
-      const kahootID = url.split('/').pop();
-      if (kahootID.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
-        return true;
-      }
-      return false;
-    },
-    transform: async url => {
-      const kahootID = url.split('/').pop();
-      if (kahootID.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
-        return `https://embed.kahoot.it/${kahootID}`;
-      }
-      return url;
-    },
-  },
-];
 
 class VisualElementUrlPreview extends Component {
   constructor(props) {
@@ -194,7 +132,7 @@ class VisualElementUrlPreview extends Component {
 
   async handleChange(evt) {
     let url = evt.target.value;
-    for (const rule of transformableDomains) {
+    for (const rule of urlTransformers) {
       if (rule.shouldTransform(url, rule.domains)) {
         url = await rule.transform(url);
         break;

--- a/src/containers/VisualElement/VisualElementUrlPreview.jsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.jsx
@@ -66,8 +66,8 @@ export const transformableDomains = [
     shouldTransform: (url, domains) => {
       const aTag = urlAsATag(url);
 
-      if (domains.includes(aTag.hostname)) {
-        return true;
+      if (!domains.includes(aTag.hostname)) {
+        return false;
       }
       const mediaId = queryString.parse(aTag.search).mediaId;
       if (mediaId) {
@@ -90,6 +90,28 @@ export const transformableDomains = [
       } catch {
         return url;
       }
+    },
+  },
+  {
+    domains: ['create.kahoot.it'],
+    shouldTransform: (url, domains) => {
+      const aTag = urlAsATag(url);
+
+      if (!domains.includes(aTag.hostname)) {
+        return false;
+      }
+      const kahootID = url.split('/').pop();
+      if (kahootID.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
+        return true;
+      }
+      return false;
+    },
+    transform: async url => {
+      const kahootID = url.split('/').pop();
+      if (kahootID.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
+        return `https://embed.kahoot.it/${kahootID}`;
+      }
+      return url;
     },
   },
 ];

--- a/src/containers/VisualElement/__tests__/__snapshots__/transformUrlIfNeeded-test.js.snap
+++ b/src/containers/VisualElement/__tests__/__snapshots__/transformUrlIfNeeded-test.js.snap
@@ -4,6 +4,8 @@ exports[`transformUrlIfNeeded does not crash without url 1`] = `undefined`;
 
 exports[`transformUrlIfNeeded returns kahoot embed url if correct kahoot url is used 1`] = `"https://embed.kahoot.it/ab095e8e-1234-1234-1234-a0386f1811b5"`;
 
+exports[`transformUrlIfNeeded returns original if kahoot profile url is used 1`] = `"https://create.kahoot.it/profiles/random/ab095e8e-1234-1234-1234-a0386f1811b5"`;
+
 exports[`transformUrlIfNeeded returns original if wrong kahoot url is used 1`] = `"https://create.kahoot.it/share/random/ab095e8e-1234-1234-1234-a0386f1811b5/test"`;
 
 exports[`transformUrlIfNeeded returns original if wrong kahoot url is used 2`] = `"https://create.kahoot.it/share/random/ab09e8e-1234-1234-1234-a0386f1811b"`;

--- a/src/containers/VisualElement/__tests__/__snapshots__/transformUrlIfNeeded-test.js.snap
+++ b/src/containers/VisualElement/__tests__/__snapshots__/transformUrlIfNeeded-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`transformUrlIfNeeded does not crash without url 1`] = `undefined`;
 
+exports[`transformUrlIfNeeded returns kahoot embed url if correct kahoot url is used 1`] = `"https://embed.kahoot.it/ab095e8e-1234-1234-1234-a0386f1811b5"`;
+
+exports[`transformUrlIfNeeded returns original if wrong kahoot url is used 1`] = `"https://create.kahoot.it/share/random/ab095e8e-1234-1234-1234-a0386f1811b5/test"`;
+
+exports[`transformUrlIfNeeded returns original if wrong kahoot url is used 2`] = `"https://create.kahoot.it/share/random/ab09e8e-1234-1234-1234-a0386f1811b"`;
+
 exports[`transformUrlIfNeeded returns same url if not from nrk 1`] = `"https://somerandomurl.com"`;
 
 exports[`transformUrlIfNeeded returns static nrk url if correct nrk url is used 1`] = `"https://static.nrk.no/ludo/latest/video-embed.html#id=33"`;

--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
@@ -5,10 +5,10 @@
  */
 
 import nock from 'nock';
-import { transformableDomains } from '../VisualElementUrlPreview';
+import { urlTransformers } from '../urlTransformers';
 
 const transformUrlIfNeeded = async url => {
-  for (const rule of transformableDomains) {
+  for (const rule of urlTransformers) {
     if (rule.shouldTransform(url, rule.domains)) {
       return await rule.transform(url);
     }

--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
@@ -74,3 +74,11 @@ test('transformUrlIfNeeded returns original if wrong kahoot url is used', async 
   expect(url1).toMatchSnapshot();
   expect(url2).toMatchSnapshot();
 });
+
+test('transformUrlIfNeeded returns original if kahoot profile url is used', async () => {
+  const url1 = await transformUrlIfNeeded(
+    'https://create.kahoot.it/profiles/random/ab095e8e-1234-1234-1234-a0386f1811b5',
+  );
+
+  expect(url1).toMatchSnapshot();
+});

--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
@@ -54,3 +54,23 @@ test('transformUrlIfNeeded does not crash without url', async () => {
 
   expect(url).toMatchSnapshot();
 });
+
+test('transformUrlIfNeeded returns kahoot embed url if correct kahoot url is used', async () => {
+  const url = await transformUrlIfNeeded(
+    'https://create.kahoot.it/share/random/ab095e8e-1234-1234-1234-a0386f1811b5',
+  );
+
+  expect(url).toMatchSnapshot();
+});
+
+test('transformUrlIfNeeded returns original if wrong kahoot url is used', async () => {
+  const url1 = await transformUrlIfNeeded(
+    'https://create.kahoot.it/share/random/ab095e8e-1234-1234-1234-a0386f1811b5/test',
+  );
+  const url2 = await transformUrlIfNeeded(
+    'https://create.kahoot.it/share/random/ab09e8e-1234-1234-1234-a0386f1811b',
+  );
+
+  expect(url1).toMatchSnapshot();
+  expect(url2).toMatchSnapshot();
+});

--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -48,6 +48,9 @@ const kahootTransformer: UrlTransformer = {
     if (!domains.includes(aTag.hostname)) {
       return false;
     }
+    if (!aTag.href.includes(domains[0] + '/share/')) {
+      return false;
+    }
     const kahootID = url.split('/').pop();
     if (kahootID?.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
       return true;

--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -1,0 +1,66 @@
+import queryString from 'query-string';
+import { fetchNrkMedia } from './visualElementApi';
+import { urlAsATag } from '../../util/htmlHelpers';
+
+export interface UrlTransformer {
+  domains: string[];
+  shouldTransform: (url: string, domains: string[]) => boolean;
+  transform: (url: string) => Promise<string>;
+}
+
+const nrkTransformer: UrlTransformer = {
+  domains: ['nrk.no', 'www.nrk.no'],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    const mediaId = queryString.parse(aTag.search).mediaId;
+    if (mediaId) {
+      return true;
+    }
+    return false;
+  },
+  transform: async url => {
+    const aTag = urlAsATag(url);
+    const mediaId = queryString.parse(aTag.search).mediaId;
+    if (!mediaId) {
+      return url;
+    }
+    try {
+      const nrkMedia = await fetchNrkMedia(mediaId);
+      if (nrkMedia.psId) {
+        return `https://static.nrk.no/ludo/latest/video-embed.html#id=${nrkMedia.psId}`;
+      }
+      return url;
+    } catch {
+      return url;
+    }
+  },
+};
+
+const kahootTransformer: UrlTransformer = {
+  domains: ['create.kahoot.it'],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    const kahootID = url.split('/').pop();
+    if (kahootID?.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
+      return true;
+    }
+    return false;
+  },
+  transform: async url => {
+    const kahootID = url.split('/').pop();
+    if (kahootID?.match(/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/)) {
+      return `https://embed.kahoot.it/${kahootID}`;
+    }
+    return url;
+  },
+};
+
+export const urlTransformers: UrlTransformer[] = [nrkTransformer, kahootTransformer];


### PR DESCRIPTION
Fixes NDLANO/Issues#2716

Avhengig av https://github.com/NDLANO/editorial-frontend/pull/1146

Legger til oversetting av kahoot-lenker.

Hvordan teste:
1. Åpne artikkel
2. Legg til ressurs fra lenke via +-knapp.
3. Lim inn en lenke på formatet `create.kahoot.it/<valgfritt>/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
4. Denne skal transformeres til `embed.kahoot.it/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
5. Forhåndsvisning skal fungere