### PR TITLE
#2719: Adds options for handling not-set value for modelReleased images

### DIFF
--- a/src/containers/ImageUploader/components/ImageMetaData.tsx
+++ b/src/containers/ImageUploader/components/ImageMetaData.tsx
@@ -52,25 +52,29 @@ const ImageMetaData = ({ imageTags, licenses, imageLanguage }: Props) => {
       <FormikField label={t('form.origin.label')} name="origin" />
       <ContributorsField contributorTypes={contributorTypes} />
 
-      <FormikField name="modelReleased" label={t('form.modelReleased.label')}>
+      <FormikField
+        name="modelReleased"
+        label={t('form.modelReleased.label')}
+        description={t('form.modelReleased.description')}>
         {({ field }: { field: FieldInputProps<string> }) => {
-          const options = ['yes', 'not-applicable', 'no'];
-          const defaultValue = 'no';
+          const options = ['yes', 'not-applicable', 'no', 'not-set'];
+          const defaultValue = 'not-set';
           return (
-            <RadioButtonGroup
-              label={t('form.modelReleased.description')}
-              selected={field.value ?? defaultValue}
-              uniqeIds
-              options={options.map(value => ({ title: t(`form.modelReleased.${value}`), value }))}
-              onChange={(value: string) =>
-                field.onChange({
-                  target: {
-                    name: field.name,
-                    value: value,
-                  },
-                })
-              }
-            />
+            <>
+              <RadioButtonGroup
+                selected={field.value ?? defaultValue}
+                uniqeIds
+                options={options.map(value => ({ title: t(`form.modelReleased.${value}`), value }))}
+                onChange={(value: string) =>
+                  field.onChange({
+                    target: {
+                      name: field.name,
+                      value: value,
+                    },
+                  })
+                }
+              />
+            </>
           );
         }}
       </FormikField>

--- a/src/containers/SearchPage/components/form/SearchImageForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchImageForm.tsx
@@ -48,6 +48,7 @@ const getModelReleasedValues = (t: WithTranslation['t']) => [
   { id: 'yes', name: t('imageSearch.modelReleased.yes') },
   { id: 'not-applicable', name: t('imageSearch.modelReleased.not-applicable') },
   { id: 'no', name: t('imageSearch.modelReleased.no') },
+  { id: 'not-set', name: t('imageSearch.modelReleased.not-set') },
 ];
 
 class SearchImageForm extends Component<Props & WithTranslation, State> {

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -273,6 +273,7 @@ const phrases = {
       yes: 'Model released',
       no: 'Not model released',
       'not-applicable': 'Not applicable',
+      'not-set': 'Not set',
     },
     placeholder: 'Search images',
     buttonTitle: 'Search',
@@ -651,6 +652,7 @@ const phrases = {
       yes: 'Yes',
       no: 'No',
       'not-applicable': 'Not applicable',
+      'not-set': 'Not set',
       description: 'Whether the image is model released or not:',
     },
     markdown: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -275,6 +275,7 @@ const phrases = {
       yes: 'Modelklarert',
       no: 'Ikke modelklarert',
       'not-applicable': 'Gjelder ikke',
+      'not-set': 'Ikke valgt',
     },
     placeholder: 'Søk i bilder',
     buttonTitle: 'Søk',
@@ -674,6 +675,7 @@ const phrases = {
       yes: 'Ja',
       no: 'Nei',
       'not-applicable': 'Gjelder ikke',
+      'not-set': 'Ikke valgt',
       description: 'Om bildet er modelklarert eller ikke:',
     },
     markdown: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -282,6 +282,7 @@ const phrases = {
       yes: 'Modelklarert',
       no: 'Ikkje modelklarert',
       'not-applicable': 'Gjeld ikkje',
+      'not-set': 'Ikkje valgt',
     },
   },
   videoSearch: {
@@ -674,6 +675,7 @@ const phrases = {
       yes: 'Ja',
       no: 'Nei',
       'not-applicable': 'Gjeld ikkje',
+      'not-set': 'Ikkje valgt',
       description: 'Om bildet er modelklarert eller ikkje:',
     },
     markdown: {


### PR DESCRIPTION
Fixes NDLANO/Issues#2719

Kan testes ved å lage/oppdatere bilder og sjekke at modellklarering funker som det skal.

NB: Denne er branchet fra versjonen som kjører i staging (`1c9fa85`)