### PR TITLE
2723 audiofile info

### DIFF
--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -13,15 +13,14 @@ import BEMHelper from 'react-bem-helper';
 import { UploadDropZone, FieldHeader } from '@ndla/forms';
 import styled from '@emotion/styled';
 import Tooltip from '@ndla/tooltip';
-import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { DeleteForever } from '@ndla/icons/editor';
 import IconButton from '../../../components/IconButton';
 import AudioPlayer from './AudioPlayer';
 import FormikField from '../../../components/FormikField';
 import { AudioFormikType } from './AudioForm';
 import { TitleField } from '../../FormikForm';
-import AudioFormInfo from './AudioFormInfo';
-import { HelpIcon, normalPaddingCSS } from '../../../components/HowTo';
+import AudioCopyInfo from './AudioCopyInfo';
+import AudioFileInfoModal from './AudioFileInfoModal';
 
 interface BaseProps {
   classes: BEMHelper<BEMHelper.ReturnObject>;
@@ -83,31 +82,7 @@ const AudioContent = ({ formik }: Props) => {
         {() => (
           <>
             <FieldHeader title={t('form.audio.file')}>
-              <Modal
-                backgroundColor="white"
-                activateButton={
-                  <div>
-                    <Tooltip tooltip={t('form.audio.modal.label')}>
-                      <HelpIcon css={normalPaddingCSS} />
-                    </Tooltip>
-                  </div>
-                }>
-                {(onClose: () => void) => (
-                  <>
-                    <ModalHeader>
-                      <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
-                    </ModalHeader>
-                    <ModalBody>
-                      <h1>{t('form.audio.modal.header')}</h1>
-                      <ul>
-                        <li>{t('form.audio.info.multipleFiles')}</li>
-                        <li>{t('form.audio.info.changeFile')}</li>
-                        <li>{t('form.audio.info.newLanguage')}</li>
-                      </ul>
-                    </ModalBody>
-                  </>
-                )}
-              </Modal>
+              <AudioFileInfoModal />
             </FieldHeader>
             {playerObject ? (
               <PlayerWrapper>
@@ -142,7 +117,7 @@ const AudioContent = ({ formik }: Props) => {
           </>
         )}
       </FormikField>
-      {playerObject && <AudioFormInfo values={values} />}
+      <AudioCopyInfo values={values} />
     </Fragment>
   );
 };

--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -10,9 +10,10 @@ import React, { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect, FormikContextType } from 'formik';
 import BEMHelper from 'react-bem-helper';
-import { UploadDropZone } from '@ndla/forms';
+import { UploadDropZone, FieldHeader } from '@ndla/forms';
 import styled from '@emotion/styled';
 import Tooltip from '@ndla/tooltip';
+import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { DeleteForever } from '@ndla/icons/editor';
 import IconButton from '../../../components/IconButton';
 import AudioPlayer from './AudioPlayer';
@@ -20,6 +21,7 @@ import FormikField from '../../../components/FormikField';
 import { AudioFormikType } from './AudioForm';
 import { TitleField } from '../../FormikForm';
 import AudioFormInfo from './AudioFormInfo';
+import { HelpIcon, normalPaddingCSS } from '../../../components/HowTo';
 
 interface BaseProps {
   classes: BEMHelper<BEMHelper.ReturnObject>;
@@ -78,9 +80,36 @@ const AudioContent = ({ formik }: Props) => {
       />
 
       <FormikField noBorder name="audioFile" label={t('form.audio.file')}>
-        {() =>
-          playerObject ? (
-            <>
+        {() => (
+          <>
+            <FieldHeader title={t('form.audio.file')}>
+              <Modal
+                backgroundColor="white"
+                activateButton={
+                  <div>
+                    <Tooltip tooltip={t('form.audio.modal.label')}>
+                      <HelpIcon css={normalPaddingCSS} />
+                    </Tooltip>
+                  </div>
+                }>
+                {(onClose: () => void) => (
+                  <>
+                    <ModalHeader>
+                      <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
+                    </ModalHeader>
+                    <ModalBody>
+                      <h1>{t('form.audio.modal.header')}</h1>
+                      <ul>
+                        <li>{t('form.audio.info.multipleFiles')}</li>
+                        <li>{t('form.audio.info.changeFile')}</li>
+                        <li>{t('form.audio.info.newLanguage')}</li>
+                      </ul>
+                    </ModalBody>
+                  </>
+                )}
+              </Modal>
+            </FieldHeader>
+            {playerObject ? (
               <PlayerWrapper>
                 <AudioPlayer audio={playerObject} />
                 <StyledDeleteButtonContainer>
@@ -95,23 +124,23 @@ const AudioContent = ({ formik }: Props) => {
                   </Tooltip>
                 </StyledDeleteButtonContainer>
               </PlayerWrapper>
-            </>
-          ) : (
-            <UploadDropZone
-              name="audioFile"
-              allowedFiles={['audio/mp3', 'audio/mpeg']}
-              onAddedFiles={(files: FileList, evt: React.FormEvent<HTMLInputElement>) => {
-                const file = evt.currentTarget.files?.[0];
-                const filepath = file ? URL.createObjectURL(file) : undefined;
-                const newFile = file && filepath ? { file, filepath } : undefined;
-                setFieldValue('audioFile', { newFile });
-              }}
-              ariaLabel={t('form.audio.dragdrop.ariaLabel')}>
-              <strong>{t('form.audio.dragdrop.main')}</strong>
-              {t('form.audio.dragdrop.sub')}
-            </UploadDropZone>
-          )
-        }
+            ) : (
+              <UploadDropZone
+                name="audioFile"
+                allowedFiles={['audio/mp3', 'audio/mpeg']}
+                onAddedFiles={(files: FileList, evt: React.FormEvent<HTMLInputElement>) => {
+                  const file = evt.currentTarget.files?.[0];
+                  const filepath = file ? URL.createObjectURL(file) : undefined;
+                  const newFile = file && filepath ? { file, filepath } : undefined;
+                  setFieldValue('audioFile', { newFile });
+                }}
+                ariaLabel={t('form.audio.dragdrop.ariaLabel')}>
+                <strong>{t('form.audio.dragdrop.main')}</strong>
+                {t('form.audio.dragdrop.sub')}
+              </UploadDropZone>
+            )}
+          </>
+        )}
       </FormikField>
       {playerObject && <AudioFormInfo values={values} />}
     </Fragment>

--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -19,6 +19,7 @@ import AudioPlayer from './AudioPlayer';
 import FormikField from '../../../components/FormikField';
 import { AudioFormikType } from './AudioForm';
 import { TitleField } from '../../FormikForm';
+import AudioFormInfo from './AudioFormInfo';
 
 interface BaseProps {
   classes: BEMHelper<BEMHelper.ReturnObject>;
@@ -112,6 +113,7 @@ const AudioContent = ({ formik }: Props) => {
           )
         }
       </FormikField>
+      {playerObject && <AudioFormInfo values={values} />}
     </Fragment>
   );
 };

--- a/src/containers/AudioUploader/components/AudioCopyInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioCopyInfo.tsx
@@ -32,27 +32,30 @@ const IconWrapper = styled.div`
 
 const AudioFormInfo = ({ values }: Props) => {
   const {
-    audioFile: { storedFile: { language: fileLanguage } = {} },
+    audioFile: { storedFile: { language: copiedLanguage } = {} },
     language,
   } = values;
 
   const { t, i18n } = useTranslation();
 
-  if (!fileLanguage) {
+  if (!copiedLanguage) {
     return null;
   }
+
+  const tCopiedLanguage =
+    i18n.language === 'en'
+      ? t('language.' + copiedLanguage)
+      : t('language.' + copiedLanguage).toLowerCase();
+
   return (
     <div>
-      {language !== fileLanguage && (
+      {language !== copiedLanguage && (
         <InfoWrapper>
           <IconWrapper>
             <InformationOutline />
           </IconWrapper>
           {t('form.audio.copiedFrom', {
-            language:
-              i18n.language === 'en'
-                ? t('language.' + fileLanguage)
-                : t('language.' + fileLanguage).toLowerCase(),
+            language: tCopiedLanguage,
           })}
         </InfoWrapper>
       )}

--- a/src/containers/AudioUploader/components/AudioCopyInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioCopyInfo.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import styled from '@emotion/styled';
 import { InformationOutline } from '@ndla/icons/common';
 import React from 'react';

--- a/src/containers/AudioUploader/components/AudioCopyInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioCopyInfo.tsx
@@ -30,9 +30,12 @@ const AudioFormInfo = ({ values }: Props) => {
 
   const { t, i18n } = useTranslation();
 
+  if (!fileLanguage) {
+    return null;
+  }
   return (
     <div>
-      {fileLanguage && language !== fileLanguage && (
+      {language !== fileLanguage && (
         <InfoWrapper>
           <IconWrapper>
             <InformationOutline />

--- a/src/containers/AudioUploader/components/AudioFileInfoModal.tsx
+++ b/src/containers/AudioUploader/components/AudioFileInfoModal.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
+import Tooltip from '@ndla/tooltip';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { HelpIcon, normalPaddingCSS } from '../../../components/HowTo';
+
+const AudioFileInfoModal = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      backgroundColor="white"
+      activateButton={
+        <div>
+          <Tooltip tooltip={t('form.audio.modal.label')}>
+            <HelpIcon css={normalPaddingCSS} />
+          </Tooltip>
+        </div>
+      }>
+      {(onClose: () => void) => (
+        <>
+          <ModalHeader>
+            <ModalCloseButton title={t('dialog.close')} onClick={onClose} />
+          </ModalHeader>
+          <ModalBody>
+            <h1>{t('form.audio.modal.header')}</h1>
+            <ul>
+              <li>{t('form.audio.info.multipleFiles')}</li>
+              <li>{t('form.audio.info.changeFile')}</li>
+              <li>{t('form.audio.info.newLanguage')}</li>
+            </ul>
+          </ModalBody>
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default AudioFileInfoModal;

--- a/src/containers/AudioUploader/components/AudioForm.tsx
+++ b/src/containers/AudioUploader/components/AudioForm.tsx
@@ -263,7 +263,6 @@ class AudioForm extends Component<Props, State> {
                   </AccordionSection>
                 </Accordions>
               )}
-
               <Field right>
                 <AbortButton outline disabled={isSubmitting}>
                   {t('form.abort')}

--- a/src/containers/AudioUploader/components/AudioFormInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioFormInfo.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import { InformationOutline } from '@ndla/icons/common';
+import { breakpoints } from '@ndla/util';
+import React from 'react';
+import { spacing, colors, fonts } from '@ndla/core';
+import { useTranslation } from 'react-i18next';
+import { AudioFormikType } from './AudioForm';
+
+interface Props {
+  values: AudioFormikType;
+}
+
+const InfoWrapper = styled.div`
+  margin: 0 auto;
+  padding: 10px;
+  display: flex;
+  font-size: ${fonts.sizes(14, 1.2)};
+`;
+
+const IconWrapper = styled.div`
+  padding-right: ${spacing.xsmall};
+  display: flex;
+  align-items: center;
+`;
+
+const AudioFormInfo = ({ values }: Props) => {
+  const {
+    audioFile: { storedFile: { language: fileLanguage } = {} },
+    language,
+  } = values;
+
+  const { t, i18n } = useTranslation();
+
+  return (
+    <div>
+      {fileLanguage && language !== fileLanguage ? (
+        <InfoWrapper>
+          <IconWrapper>
+            <InformationOutline />
+          </IconWrapper>
+          {t('form.audio.copiedFrom', {
+            language:
+              i18n.language === 'en'
+                ? t('language.' + fileLanguage)
+                : t('language.' + fileLanguage).toLowerCase(),
+          })}
+        </InfoWrapper>
+      ) : (
+        <InfoWrapper>
+          <IconWrapper>
+            <InformationOutline />
+          </IconWrapper>
+          {t('form.audio.fileInfo')}
+        </InfoWrapper>
+      )}
+    </div>
+  );
+};
+
+export default AudioFormInfo;

--- a/src/containers/AudioUploader/components/AudioFormInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioFormInfo.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 import { InformationOutline } from '@ndla/icons/common';
-import { breakpoints } from '@ndla/util';
 import React from 'react';
-import { spacing, colors, fonts } from '@ndla/core';
+import { spacing, fonts } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { AudioFormikType } from './AudioForm';
 

--- a/src/containers/AudioUploader/components/AudioFormInfo.tsx
+++ b/src/containers/AudioUploader/components/AudioFormInfo.tsx
@@ -33,7 +33,7 @@ const AudioFormInfo = ({ values }: Props) => {
 
   return (
     <div>
-      {fileLanguage && language !== fileLanguage ? (
+      {fileLanguage && language !== fileLanguage && (
         <InfoWrapper>
           <IconWrapper>
             <InformationOutline />
@@ -44,13 +44,6 @@ const AudioFormInfo = ({ values }: Props) => {
                 ? t('language.' + fileLanguage)
                 : t('language.' + fileLanguage).toLowerCase(),
           })}
-        </InfoWrapper>
-      ) : (
-        <InfoWrapper>
-          <IconWrapper>
-            <InformationOutline />
-          </IconWrapper>
-          {t('form.audio.fileInfo')}
         </InfoWrapper>
       )}
     </div>

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -965,7 +965,7 @@ const phrases = {
         ariaLabel: 'Drag and drop or click to upload image',
       },
       copiedFrom:
-        'Audio file will be copied from {{language}}. Click the bucket icon to remove it and upload a new file.',
+        'Audio file will be copied from {{language}}. Click the delete icon to remove it and upload a new file.',
       info: {
         multipleFiles: 'You can upload different audio files for each language version.',
         changeFile:

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -964,6 +964,19 @@ const phrases = {
         sub: 'or click to upload image',
         ariaLabel: 'Drag and drop or click to upload image',
       },
+      copiedFrom:
+        'Audio file will be copied from {{language}}. Click the bucket icon to remove it and upload a new file.',
+      info: {
+        multipleFiles: 'You can upload different audio files for each language version.',
+        changeFile:
+          'Changes made to a language version will not alter the other language versions.',
+        newLanguage:
+          'When creating a new language version, an audio file from an existing language will be suggested.',
+      },
+      modal: {
+        header: 'Audio files',
+        label: 'Audio file information',
+      },
     },
     podcast: {
       remove: 'Remove podcast',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -974,6 +974,8 @@ const phrases = {
         sub: 'eller trykk for å laste opp lydfil',
         ariaLabel: 'Dra og slipp eller trykk for å laste opp lydfil',
       },
+      copiedFrom: 'Lydfil er kopiert fra {{language}}.',
+      fileInfo: 'Du kan laste opp forskjellige filer for hver språkversjon.',
     },
     podcast: {
       remove: 'Ta bort podkast',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -974,8 +974,19 @@ const phrases = {
         sub: 'eller trykk for å laste opp lydfil',
         ariaLabel: 'Dra og slipp eller trykk for å laste opp lydfil',
       },
-      copiedFrom: 'Lydfil er kopiert fra {{language}}.',
-      fileInfo: 'Du kan laste opp forskjellige filer for hver språkversjon.',
+      copiedFrom:
+        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten ved siden av lydfilen for å fjerne den og laste opp en ny fil.',
+      info: {
+        multipleFiles: 'Du kan laste opp forskjellige lydfiler for hver språkversjon.',
+        changeFile:
+          'Fjerning og endring av en språkversjon vil ikke påvirke de andre språkversjonene.',
+        newLanguage:
+          'Ved oppretting av ny språkversjon vil en lydfil fra en eksisterende språkversjon foreslås.',
+      },
+      modal: {
+        header: 'Lydfiler',
+        label: 'Informasjon om lydfiler',
+      },
     },
     podcast: {
       remove: 'Ta bort podkast',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -983,6 +983,19 @@ const phrases = {
         sub: 'eller trykk for å laste opp lydfil',
         ariaLabel: 'Dra og slipp eller trykk for å laste opp lydfil',
       },
+      copiedFrom:
+        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten ved sida av lydfila for å fjerne den og laste opp ei ny fil.',
+      info: {
+        multipleFiles: 'Du kan laste opp forskjellige lydfilar for kvar språkversjon.',
+        changeFile:
+          'Fjerning og endring av ein språkversjon vil ikkje påverke dei andre språkversjonane.',
+        newLanguage:
+          'Ved oppretting av ny språkversjon vil ei lydfil fra ein eksisterande språkversjon foreslås.',
+      },
+      modal: {
+        header: 'Lydfiler',
+        label: 'Informasjon om lydfiler',
+      },
     },
     podcast: {
       remove: 'Ta bort podkast',


### PR DESCRIPTION
Fixes NDLANO/Issues#2723

Har lagt til informasjon to steder i AudioForm.
1. Header-felt over lydfil med klikkbart ikon som åpner modal.
2. Ved opprettelse av ny språkversjon legges det informasjon under lydfilen om hvor den er hentet fra.

Hvordan teste:
- Åpne PR-instans
- Åpne lydfil
- Forsøk å lage ny språkversjon og se om (2) fungerer. Dette skal kun dukke opp i dette tilfellet.
- Sjekk at modal fungerer som forventet.
- Se gjennom styling, oversettinger og innhold.