### PR TITLE
2730 Fixed infinite loading and image upload failure for learning resources

### DIFF
--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -36,6 +36,7 @@ interface Props {
   fetchImage: (id: number) => Promise<ImageApiType>;
   image?: ImageType;
   updateImage: (imageMetadata: UpdatedImageMetadata, image: string | Blob) => void;
+  inModal?: boolean;
 }
 
 const ImageSearchAndUploader = ({
@@ -47,6 +48,7 @@ const ImageSearchAndUploader = ({
   fetchImage,
   searchImages,
   onError,
+  inModal = false,
 }: Props) => {
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -96,7 +98,7 @@ const ImageSearchAndUploader = ({
           title: t('form.visualElement.imageUpload'),
           content: licenses ? (
             <ImageForm
-              isLoading={image === undefined}
+              inModal={inModal}
               image={image || { language: locale }}
               onUpdate={updateImage}
               closeModal={closeModal}

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -123,6 +123,7 @@ const MetaImageSearch = ({
             </ModalHeader>
             <ModalBody>
               <ImageSearchAndUploader
+                inModal={true}
                 onImageSelect={onImageSet}
                 locale={locale}
                 closeModal={onImageSelectClose}

--- a/src/containers/ImageUploader/EditImage.tsx
+++ b/src/containers/ImageUploader/EditImage.tsx
@@ -106,7 +106,7 @@ class EditImage extends Component<Props> {
       <LocaleContext.Consumer>
         {locale => (
           <ImageForm
-            isLoading={imageData === undefined}
+            isLoading={false}
             image={imageData || { language: locale }}
             onUpdate={(image: UpdatedImageMetadata, file: string | Blob) => {
               updateImage({ image, file, history, editingArticle });

--- a/src/containers/ImageUploader/components/ImageForm.tsx
+++ b/src/containers/ImageUploader/components/ImageForm.tsx
@@ -94,7 +94,7 @@ export const getInitialValues = (image: ImagePropType = {}): ImageFormikType => 
     rightsholders: parseCopyrightContributors(image, 'rightsholders'),
     origin: image?.copyright?.origin || '',
     license: image?.copyright?.license?.license,
-    modelReleased: image?.modelRelease,
+    modelReleased: image?.modelRelease ?? 'not-set',
   };
 };
 

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -83,6 +83,7 @@ class VisualElementSearch extends Component {
       case 'image':
         return (
           <ImageSearchAndUploader
+            inModal={true}
             handleVisualElementChange={handleVisualElementChange}
             locale={locale}
             isSavingImage={isSavingImage}


### PR DESCRIPTION
Opplastning av bilde feilet fordi `modelRelease`-verdien var undefined by default og fordi `inModal` alltid var false, selv om den skal være true. Satt `modelRelease` til å være `not-set` by default. 

Den evige innlastingen kom av en endring som tok til høyde for innlasting av bilder når man skulle redigere et eksisterende bilde. Har fjernet sjekken inntil videre, uten noen synlige bivirkninger.