### PR TITLE
Save using ctrl+s now works in articles

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -10,7 +10,7 @@ import React, { Component, Fragment } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { FormikContextType, FormikHelpers } from 'formik';
+import { FormikContextType } from 'formik';
 import { FieldHeader } from '@ndla/forms';
 import Tooltip from '@ndla/tooltip';
 import { Eye } from '@ndla/icons/editor';
@@ -95,10 +95,7 @@ type Props = {
   userAccess?: string;
   handleBlur: (evt: { target: { name: string } }) => void;
   values: ArticleFormikType;
-  handleSubmit: (
-    values: ArticleFormikType,
-    formikHelpers: FormikHelpers<ArticleFormikType>,
-  ) => Promise<void>;
+  handleSubmit: () => Promise<void>;
 } & WithTranslation & { formik: FormikContextType<ArticleFormikType> };
 
 interface State {
@@ -184,7 +181,7 @@ class LearningResourceContent extends Component<Props, State> {
     return (
       <Fragment>
         <TitleField
-          handleSubmit={() => handleSubmit(this.props.values, this.props.formik)}
+          handleSubmit={handleSubmit}
           onBlur={(event, editor, next) => {
             next();
             // this is a hack since formik onBlur-handler interferes with slates

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -62,7 +62,7 @@ const LearningResourcePanels = ({
         <LearningResourceContent
           formik={formikContext}
           userAccess={userAccess}
-          handleSubmit={handleSubmit}
+          handleSubmit={() => handleSubmit(values, formikContext)}
           handleBlur={handleBlur}
           values={values}
           article={article}

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -139,11 +139,6 @@ export function useArticleFormHooks({
     values: ArticleFormikType,
     formikHelpers: FormikHelpers<ArticleFormikType>,
   ): Promise<void> => {
-    if (revision === undefined) {
-      formikHelpers.setSubmitting(false);
-      return;
-    }
-
     formikHelpers.setSubmitting(true);
     const initialStatus = articleStatus ? articleStatus.current : undefined;
     const newStatus = values.status?.current;
@@ -172,7 +167,7 @@ export function useArticleFormHooks({
         savedArticle = await updateArticleAndStatus({
           updatedArticle: {
             ...newArticle,
-            revision,
+            revision: revision || newArticle.revision,
           },
           newStatus,
           dirty: !skipSaving,
@@ -180,7 +175,7 @@ export function useArticleFormHooks({
       } else {
         savedArticle = await updateArticle({
           ...newArticle,
-          revision,
+          revision: revision || newArticle.revision,
         });
       }
 


### PR DESCRIPTION
Feil som dukket opp som følge av at RichBlockTextEditor er javascript og ikke ga feilmelding på at type til handleSubmit ble endret. Reverserer derfor så vi går tilbake til slik strukturen var før.

Hvordan teste:
- Åpne artikkel og test at lagring med knapp / ctrl+s fungerer i alle felter.
- ~Sjekk også at liste over sist redigerte artikler på forsiden ikke inneholder duplikater~. Løses i https://github.com/NDLANO/editorial-frontend/pull/1167