### PR TITLE
Add disable option in jump to resources button. Fixed structure resource fetching bug.

### DIFF
--- a/src/containers/StructurePage/StructureContainer.tsx
+++ b/src/containers/StructurePage/StructureContainer.tsx
@@ -70,6 +70,7 @@ export const StructureContainer = ({ match, location, history }: Props) => {
   const [resourcesUpdated, setResourcesUpdated] = useState(false);
   const [showFavorites, setShowFavorites] = useState(false);
   const [favoriteSubjects, setFavoriteSubjects] = useState<string[]>([]);
+  const [resourcesLoading, setResourcesLoading] = useState(false);
   const resourceSection = useRef<HTMLDivElement>(null);
   const prevRouteParams = useRef<RouteProps | undefined>(undefined);
 
@@ -89,7 +90,7 @@ export const StructureContainer = ({ match, location, history }: Props) => {
       if (subject) {
         getSubjectTopics(subject, locale);
       }
-      fetchFavoriteSubjects();
+      await fetchFavoriteSubjects();
       const shouldShowFavorites = window.localStorage.getItem(REMEMBER_FAVOURITE_SUBJECTS);
       setShowFavorites(shouldShowFavorites === 'true');
     })();
@@ -306,6 +307,7 @@ export const StructureContainer = ({ match, location, history }: Props) => {
                   getAllSubjects={getAllSubjects}
                   refreshTopics={refreshTopics}
                   structure={subjects}
+                  resourcesLoading={resourcesLoading}
                   jumpToResources={() =>
                     resourceSection && resourceSection.current?.scrollIntoView()
                   }
@@ -321,6 +323,7 @@ export const StructureContainer = ({ match, location, history }: Props) => {
         </Accordion>
         {topicId && currentTopic && (
           <StructureResources
+            setResourcesLoading={setResourcesLoading}
             locale={locale}
             params={params}
             resourceRef={resourceSection}

--- a/src/containers/StructurePage/__tests__/__snapshots__/StructurePage-test.jsx.snap
+++ b/src/containers/StructurePage/__tests__/__snapshots__/StructurePage-test.jsx.snap
@@ -27,7 +27,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   border: none;
 }
 
-.emotion-165 {
+.emotion-167 {
   margin: 3px 6.5px 3px auto;
   font-size: 14;
   font-size: 0.7777777777777778rem;
@@ -211,7 +211,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   padding: 0;
 }
 
-.emotion-170 {
+.emotion-172 {
   -webkit-animation-duration: 200ms;
   animation-duration: 200ms;
   -webkit-animation-name: fadeInTop;
@@ -430,7 +430,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   background: #f1f5f8;
 }
 
-.emotion-173 {
+.emotion-175 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -442,7 +442,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   flex-direction: column;
 }
 
-.emotion-168 {
+.emotion-170 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -457,7 +457,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   background: #ceddea;
 }
 
-.emotion-168:hover {
+.emotion-170:hover {
   background: #ceddea;
 }
 
@@ -506,7 +506,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   color: #f8f8f8;
 }
 
-.emotion-166 {
+.emotion-168 {
   display: inline-block;
   color: #ffffff;
   background-color: #20588f;
@@ -536,50 +536,56 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
   box-shadow: none;
 }
 
-.emotion-166:hover,
-.emotion-166:focus {
+.emotion-168:hover,
+.emotion-168:focus {
   color: white;
   background-color: #184673;
   border: 2px solid #184673;
 }
 
-.emotion-166[disabled] {
+.emotion-168[disabled] {
   color: #777777;
   background-color: #e6e6e6;
   border-color: transparent;
   cursor: not-allowed;
 }
 
-.emotion-166:focus {
+.emotion-168:focus {
   box-shadow: 0 0 2px #20588f;
 }
 
-.emotion-166:hover,
-.emotion-166:focus {
+.emotion-168:hover,
+.emotion-168:focus {
   color: white;
   background-color: #20588f;
   border: 2px solid transparent;
 }
 
-.emotion-166:disabled {
+.emotion-168:disabled {
   color: #777777;
   border: 2px solid transparent;
   background-color: #e6e6e6;
   cursor: not-allowed;
 }
 
-.emotion-166:hover,
-.emotion-166:focus {
+.emotion-168:hover,
+.emotion-168:focus {
   color: white;
   background-color: #20588f;
   border: 2px solid transparent;
 }
 
-.emotion-166:disabled {
+.emotion-168:disabled {
   color: #777777;
   border: 2px solid transparent;
   background-color: #e6e6e6;
   cursor: not-allowed;
+}
+
+.emotion-165 {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 26px;
 }
 
 <div
@@ -662,7 +668,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
           class="emotion-11 emotion-12"
         >
           <div
-            class="emotion-170"
+            class="emotion-172"
           >
             <li
               class="emotion-13 emotion-14"
@@ -1312,7 +1318,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
                 class="emotion-11 emotion-12"
               >
                 <div
-                  class="emotion-170"
+                  class="emotion-172"
                 >
                   <li
                     class="emotion-13 emotion-14"
@@ -1402,7 +1408,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
                       class="emotion-11 emotion-12"
                     >
                       <div
-                        class="emotion-170"
+                        class="emotion-172"
                       >
                         <li
                           class="emotion-13 emotion-14"
@@ -1427,10 +1433,10 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
                           />
                         </li>
                         <li
-                          class="emotion-173 emotion-14"
+                          class="emotion-175 emotion-14"
                         >
                           <div
-                            class="emotion-168 emotion-10"
+                            class="emotion-170 emotion-10"
                           >
                             <button
                               class="emotion-121 emotion-8"
@@ -1482,10 +1488,15 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
                                 </button>
                               </div>
                               <button
-                                class="emotion-165 emotion-166 emotion-4"
+                                class="emotion-167 emotion-168 emotion-4"
                                 type="button"
                               >
-                                Hopp til ressurser
+                                <div
+                                  class="emotion-165 emotion-166"
+                                  spacing="normal"
+                                >
+                                  Hopp til ressurser
+                                </div>
                               </button>
                             </div>
                           </div>
@@ -1493,7 +1504,7 @@ exports[`fetches and renders a list of subjects and topics based on pathname 1`]
                             class="emotion-11 emotion-12"
                           >
                             <div
-                              class="emotion-170"
+                              class="emotion-172"
                             />
                           </ul>
                         </li>

--- a/src/containers/StructurePage/folderComponents/FolderItem.tsx
+++ b/src/containers/StructurePage/folderComponents/FolderItem.tsx
@@ -23,6 +23,8 @@ import {
   TaxonomyElement,
   TaxonomyMetadata,
 } from '../../../modules/taxonomy/taxonomyApiInterfaces';
+import Spinner from '../../../components/Spinner';
+import { Row } from '../../../components';
 
 export const classes = new BEMHelper({
   name: 'folder',
@@ -38,11 +40,12 @@ interface BaseProps {
   getAllSubjects: () => Promise<void>;
   refreshTopics: () => Promise<void>;
   structure: SubjectType[];
-  jumpToResources: () => void;
+  jumpToResources?: () => void;
   locale: string;
   name: string;
   pathToString: string;
   isMainActive?: boolean;
+  resourcesLoading?: boolean;
   id: string;
   userAccess?: string;
   metadata: TaxonomyMetadata;
@@ -67,6 +70,7 @@ const FolderItem = ({
   userAccess,
   metadata,
   locale,
+  resourcesLoading,
   getAllSubjects,
   refreshTopics,
   subjectId,
@@ -105,8 +109,16 @@ const FolderItem = ({
         />
       )}
       {showJumpToResources && (
-        <Button outline css={resourceButtonStyle} type="button" onClick={jumpToResources}>
-          {t('taxonomy.jumpToResources')}
+        <Button
+          outline
+          css={resourceButtonStyle}
+          type="button"
+          disabled={resourcesLoading}
+          onClick={jumpToResources}>
+          <Row>
+            {t('taxonomy.jumpToResources')}
+            {resourcesLoading && <Spinner appearance="small" />}
+          </Row>
         </Button>
       )}
       {

--- a/src/containers/StructurePage/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePage/resourceComponents/StructureResources.tsx
@@ -50,6 +50,7 @@ interface Props {
   currentTopic: SubjectTopic;
   refreshTopics: () => Promise<void>;
   resourceRef: RefObject<HTMLDivElement>;
+  setResourcesLoading: (loading: boolean) => void;
   resourcesUpdated: boolean;
   setResourcesUpdated: (updated: boolean) => void;
   saveSubjectTopicItems: (topicId: string, saveItems: { metadata: TaxonomyMetadata }) => void;
@@ -65,6 +66,7 @@ const StructureResources = ({
   resourcesUpdated,
   setResourcesUpdated,
   saveSubjectTopicItems,
+  setResourcesLoading,
   grouped,
 }: Props) => {
   const { t } = useTranslation();
@@ -121,6 +123,7 @@ const StructureResources = ({
 
   const getTopicResources = async () => {
     const { id: topicId } = currentTopic;
+    setResourcesLoading(true);
     setLoading(true);
     if (topicId) {
       try {
@@ -142,12 +145,14 @@ const StructureResources = ({
 
         setTopicResources(allTopicResources);
       } catch (error) {
+        setTopicResources([]);
         handleError(error);
       }
     } else {
       setTopicResources([]);
     }
     setLoading(false);
+    setResourcesLoading(false);
   };
 
   const getResourceStatusesAndGrepCodes = async (allTopicResources: TopicResource[]) => {


### PR DESCRIPTION
La til muligheten til å disable "hopp til ressurser"-knappen i struktur inntil ressurser har blitt hentet. 

Fikset også en bug som oppsto når henting av topic resources feilet. I nåværende tilstand vil ressursene til forrige topic fortsette å bli vist. Valgte istedenfor å nullstille ressursene i slike tilfeller.