### PR TITLE
2736 no multiple save search

### DIFF
--- a/src/containers/App/SearchPage.tsx
+++ b/src/containers/App/SearchPage.tsx
@@ -46,7 +46,16 @@ const SearchPage = ({ match }: Props) => {
     {
       title: t('subNavigation.searchContent'),
       type: 'content',
-      url: toSearch({ page: '1', sort: '-lastUpdated', 'page-size': 10 }, 'content'),
+      url: toSearch(
+        {
+          page: '1',
+          sort: '-lastUpdated',
+          'page-size': 10,
+          fallback: false,
+          'include-other-statuses': false,
+        },
+        'content',
+      ),
       icon: <SearchContent className="c-icon--large" />,
       path: `${match.url}/content`,
       searchFunction: searchContent,

--- a/src/containers/FormikForm/formikDraftHooks.ts
+++ b/src/containers/FormikForm/formikDraftHooks.ts
@@ -98,7 +98,7 @@ export function useFetchArticleData(articleId: string | undefined, locale: Local
   const updateUserData = async (articleId: number) => {
     const stringId = articleId.toString();
     const result = await draftApi.fetchUserData();
-    const latestEditedArticles = result.latestEditedArticles || [];
+    const latestEditedArticles = Array.from(new Set(result.latestEditedArticles || []));
     let userUpdatedMetadata;
 
     if (!latestEditedArticles.includes(stringId)) {
@@ -113,7 +113,7 @@ export function useFetchArticleData(articleId: string | undefined, locale: Local
       const latestEditedFiltered = latestEditedArticles.filter(id => {
         return id !== stringId;
       });
-      latestEditedFiltered.splice(0, 0, stringId);
+      latestEditedFiltered.unshift(stringId);
       userUpdatedMetadata = {
         latestEditedArticles: latestEditedFiltered,
       };

--- a/src/containers/Masthead/MastheadSearch.jsx
+++ b/src/containers/Masthead/MastheadSearch.jsx
@@ -51,7 +51,7 @@ class MastheadSearch extends Component {
 
     const newParams = {
       ...oldParams,
-      query: searchQuery,
+      query: searchQuery || undefined,
       page: 1,
       sort: searchQuery.sort || '-lastUpdated',
       'page-size': searchQuery['page-size'] || 10,

--- a/src/containers/Masthead/MastheadSearch.jsx
+++ b/src/containers/Masthead/MastheadSearch.jsx
@@ -15,6 +15,7 @@ import { toSearch } from '../../util/routeHelpers';
 import { HistoryShape, LocationShape } from '../../shapes';
 import { LocaleContext } from '../App/App';
 import { SearchTypeValues } from '../../constants';
+import { parseSearchParams } from '../SearchPage/components/form/SearchForm';
 
 class MastheadSearch extends Component {
   static getDerivedStateFromProps(props, state) {
@@ -41,17 +42,22 @@ class MastheadSearch extends Component {
       location.pathname.split('/').find(pathValue => SearchTypeValues.includes(pathValue)) ||
       'content';
 
-    history.push(
-      toSearch(
-        {
-          query: searchQuery,
-          page: 1,
-          sort: '-lastUpdated',
-          'page-size': 10,
-        },
-        type,
-      ),
-    );
+    let oldParams;
+    if (type === 'content') {
+      oldParams = parseSearchParams(location.search);
+    } else {
+      oldParams = queryString.parse(location.search);
+    }
+
+    const newParams = {
+      ...oldParams,
+      query: searchQuery,
+      page: 1,
+      sort: searchQuery.sort || '-lastUpdated',
+      'page-size': searchQuery['page-size'] || 10,
+    };
+
+    history.push(toSearch(newParams, type));
 
     close();
   };

--- a/src/containers/SearchPage/SearchSaveButton.tsx
+++ b/src/containers/SearchPage/SearchSaveButton.tsx
@@ -110,7 +110,7 @@ const SearchSaveButton = () => {
       <SaveButton
         isSaving={loading}
         showSaved={success}
-        defaultText={isSaved ? 'saved' : 'saveSearch'}
+        defaultText={isSaved ? 'alreadySaved' : 'saveSearch'}
         onClick={saveSearch}
         disabled={isSaved || success}
       />

--- a/src/containers/SearchPage/SearchSaveButton.tsx
+++ b/src/containers/SearchPage/SearchSaveButton.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
@@ -19,7 +19,7 @@ import {
 } from '../WelcomePage/components/SaveSearchUrl';
 import SaveButton from '../../components/SaveButton';
 
-type Error = 'alreadyExist' | 'other' | '';
+type Error = 'alreadyExist' | 'other' | 'fetchFailed' | '';
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -39,6 +39,7 @@ const SearchSaveButton = () => {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<Error>('');
   const [loading, setLoading] = useState(false);
+  const [savedSearches, setSavedSearches] = useState<string[] | undefined>(undefined);
 
   const fetchSavedSearch = async () => {
     const token = getAccessToken();
@@ -46,16 +47,27 @@ const SearchSaveButton = () => {
 
     if (isValid(token) && isAccessTokenPersonal) {
       const result = await fetchUserData();
-      return result.savedSearches || [];
+      return result.savedSearches;
     }
-    throw Error();
   };
 
-  const handleSuccess = () => {
+  useEffect(() => {
+    fetchSavedSearch().then(res => {
+      setSavedSearches(res);
+    });
+  }, []);
+
+  useEffect(() => {
+    setError('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [window.location.search]);
+
+  const handleSuccess = (newSearchList: string[]) => {
     setSuccess(true);
     setLoading(false);
     setTimeout(() => {
       setSuccess(false);
+      setSavedSearches(newSearchList);
     }, 2500);
   };
 
@@ -66,14 +78,21 @@ const SearchSaveButton = () => {
   };
 
   const saveSearch = async () => {
+    setError('');
     setLoading(true);
     const oldSearchList = await fetchSavedSearch();
     const newSearch = window.location.pathname + window.location.search;
 
+    if (!oldSearchList) {
+      handleFailure('fetchFailed');
+      return;
+    }
+
+    const newSearchList = [...oldSearchList, getSavedSearchRelativeUrl(newSearch)];
     if (!oldSearchList.find(s => s === getSavedSearchRelativeUrl(newSearch))) {
-      updateUserMetadata([...oldSearchList, getSavedSearchRelativeUrl(newSearch)])
+      updateUserMetadata(newSearchList)
         .then(() => {
-          handleSuccess();
+          handleSuccess(newSearchList);
         })
         .catch(() => {
           handleFailure('other');
@@ -83,13 +102,17 @@ const SearchSaveButton = () => {
     }
   };
 
+  const currentSearch = window.location.pathname + window.location.search;
+  const isSaved = savedSearches?.includes(getSavedSearchRelativeUrl(currentSearch));
+
   return (
     <StyledWrapper>
       <SaveButton
         isSaving={loading}
         showSaved={success}
-        defaultText={'saveSearch'}
+        defaultText={isSaved ? 'saved' : 'saveSearch'}
         onClick={saveSearch}
+        disabled={isSaved || success}
       />
       {error && (
         <WarningText>

--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -98,6 +98,17 @@ class SearchContentForm extends Component<Props & WithTranslation, State> {
     this.getExternalData();
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.searchObject.query !== this.props.searchObject.query) {
+      this.setState({
+        search: {
+          ...this.state.search,
+          query: this.props.searchObject.query || '',
+        },
+      });
+    }
+  }
+
   onFieldChange(evt: FormEvent<HTMLInputElement> | FormEvent<HTMLSelectElement>) {
     const { name, value } = evt.currentTarget;
     this.setState(prevState => {

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -144,6 +144,7 @@ const phrases = {
     },
     save: {
       alreadyExist: 'Search has already been saved.',
+      fetchFailed: 'Could not get load saved searches.',
       other: 'Save failed.',
     },
   },
@@ -515,7 +516,7 @@ const phrases = {
     saveDraft: 'Save draft',
     saveTax: 'Save taxonomy',
     saving: 'Saving...',
-    saveSearch: 'Lagre søk',
+    saveSearch: 'Save search',
     choose: 'Choose',
     saved: 'Saved ',
     feil: 'There are still errors.',

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -517,6 +517,7 @@ const phrases = {
     saveTax: 'Save taxonomy',
     saving: 'Saving...',
     saveSearch: 'Save search',
+    alreadySaved: 'Saved',
     choose: 'Choose',
     saved: 'Saved ',
     feil: 'There are still errors.',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -536,6 +536,7 @@ const phrases = {
     choose: 'Velg',
     saving: 'Lagrer...',
     saveSearch: 'Lagre søk',
+    alreadySaved: 'Lagret',
     saved: 'Lagret ',
     feil: 'Det er fortsatt flere feil i skjemaet',
     copy: 'kopi',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -145,6 +145,7 @@ const phrases = {
     },
     save: {
       alreadyExist: 'Søket er allerede lagret.',
+      fetchFailed: 'Kunne ikke laste lagrede søk.',
       other: 'Søk feilet.',
     },
   },

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -541,6 +541,7 @@ const phrases = {
     choose: 'Velg',
     saving: 'Lagrer...',
     saveSearch: 'Lagre søk',
+    alreadySaved: 'Lagra',
     saved: 'Lagra ',
     feil: 'Det er fortsatt flere feil i skjemaet',
     copy: 'kopi',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -145,6 +145,7 @@ const phrases = {
     },
     save: {
       alreadyExist: 'Søket er allereie lagra.',
+      fetchFailed: 'Kunne ikkje laste lagra søk.',
       other: 'Lagring feila.',
     },
   },


### PR DESCRIPTION
Fixes NDLANO/Issues#2736

Ting som er gjort:
- Lagring av søk på søkesiden lar deg nå ikke lagre det samme søket flere ganger. Dersom det skjer viser den også en feilmelding. Knappen indikerer nå også dersom søket allerede er lagret.
- Fikset litt uoverensstemmelser mellom søk i masthead og søkesiden:
   - Dersom man allerede er på søkesiden og søker via masthead, så vil søket og søkeskjemaet nå oppdatere seg. Det er kun query-feltet som skal endres, ingen andre parametre i url skal endres/fjernes/legges til.
   - Ved bytte til innholds-søk fra en av de andre søketypene legges nå `fallback=false&include-other-statuses=false` til i url. Dette er default for innholdssøk når man går dit via masthead.

Hvordan teste lagring av søk:
- Prøv ulike søk.
- Se at lagret søk vises på forsiden og at eksisterende søk ikke forsvinner.
- Se at eventuelle feilmeldinger vises og fjernes ved ny handling (disse er vanskelige å framprovosere nå fordi knappen disables). Dersom feilmeldinger vises skal disse forsvinne ved å gjøre et nytt søk.

Hvordan teste søkesiden:
- Bytt mellom ulike søk og sjekk at url, søkefelt og søkeresultat oppdateres som ønsket. Søk også via masthead