### PR TITLE
2724 deletion of audio files

### DIFF
--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -81,7 +81,7 @@ const AudioContent = ({ formik }: Props) => {
       <FormikField noBorder name="audioFile" label={t('form.audio.file')}>
         {() => (
           <>
-            <FieldHeader title={t('form.audio.file')}>
+            <FieldHeader title={t('form.audio.sound')}>
               <AudioFileInfoModal />
             </FieldHeader>
             {playerObject ? (

--- a/src/containers/AudioUploader/components/AudioFileInfoModal.tsx
+++ b/src/containers/AudioUploader/components/AudioFileInfoModal.tsx
@@ -37,6 +37,7 @@ const AudioFileInfoModal = () => {
               <li>{t('form.audio.info.multipleFiles')}</li>
               <li>{t('form.audio.info.changeFile')}</li>
               <li>{t('form.audio.info.newLanguage')}</li>
+              <li>{t('form.audio.info.deleteFiles')}</li>
             </ul>
           </ModalBody>
         </>

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -979,6 +979,7 @@ const phrases = {
         changeFile: 'Changes made to a language will not alter the other languages.',
         newLanguage:
           'When adding a new language, an audio file from an existing language will be suggested.',
+        deleteFiles: 'Audio files will only be deleted when not used in any language.',
       },
       modal: {
         header: 'Audio files',

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -975,11 +975,10 @@ const phrases = {
       copiedFrom:
         'Audio file will be copied from {{language}}. Click the delete icon to remove it and upload a new file.',
       info: {
-        multipleFiles: 'You can upload different audio files for each language version.',
-        changeFile:
-          'Changes made to a language version will not alter the other language versions.',
+        multipleFiles: 'You can upload different audio files for each language.',
+        changeFile: 'Changes made to a language will not alter the other languages.',
         newLanguage:
-          'When creating a new language version, an audio file from an existing language will be suggested.',
+          'When adding a new language, an audio file from an existing language will be suggested.',
       },
       modal: {
         header: 'Audio files',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -989,6 +989,7 @@ const phrases = {
         changeFile: 'Fjerning og endring av et språk vil ikke påvirke de andre språkene.',
         newLanguage:
           'Ved oppretting av nytt språk vil en lydfil fra et eksisterende språk foreslås.',
+        deleteFiles: 'En lydfil slettes kun når den ikke lenger er brukt i et språk.',
       },
       modal: {
         header: 'Lydfiler',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -983,17 +983,16 @@ const phrases = {
         ariaLabel: 'Dra og slipp eller trykk for å laste opp lydfil',
       },
       copiedFrom:
-        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten ved siden av lydfilen for å fjerne den og laste opp en ny fil.',
+        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten for å fjerne den og laste opp en ny fil.',
       info: {
-        multipleFiles: 'Du kan laste opp forskjellige lydfiler for hver språkversjon.',
-        changeFile:
-          'Fjerning og endring av en språkversjon vil ikke påvirke de andre språkversjonene.',
+        multipleFiles: 'Du kan laste opp forskjellig lydfiler for hvert språk.',
+        changeFile: 'Fjerning og endring av et språk vil ikke påvirke de andre språkene.',
         newLanguage:
-          'Ved oppretting av ny språkversjon vil en lydfil fra en eksisterende språkversjon foreslås.',
+          'Ved oppretting av nytt språk vil en lydfil fra et eksisterende språk foreslås.',
       },
       modal: {
         header: 'Lydfiler',
-        label: 'Informasjon om lydfiler',
+        label: 'Informasjon om lyd',
       },
     },
     podcast: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -992,13 +992,12 @@ const phrases = {
         ariaLabel: 'Dra og slipp eller trykk for å laste opp lydfil',
       },
       copiedFrom:
-        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten ved sida av lydfila for å fjerne den og laste opp ei ny fil.',
+        'Lydfil kopieres fra {{language}}. Trykk på søppelbøtten for å fjerne den og laste opp ei ny fil.',
       info: {
-        multipleFiles: 'Du kan laste opp forskjellige lydfilar for kvar språkversjon.',
-        changeFile:
-          'Fjerning og endring av ein språkversjon vil ikkje påverke dei andre språkversjonane.',
+        multipleFiles: 'Du kan laste opp forskjellige lydfilar for kvart språk.',
+        changeFile: 'Fjerning og endring av eit språk vil ikkje påverke dei andre språka.',
         newLanguage:
-          'Ved oppretting av ny språkversjon vil ei lydfil fra ein eksisterande språkversjon foreslås.',
+          'Ved oppretting av eit nytt språk vil ei lydfil fra eit eksisterande språk foreslås.',
       },
       modal: {
         header: 'Lydfiler',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -998,6 +998,7 @@ const phrases = {
         changeFile: 'Fjerning og endring av eit språk vil ikkje påverke dei andre språka.',
         newLanguage:
           'Ved oppretting av eit nytt språk vil ei lydfil fra eit eksisterande språk foreslås.',
+        deleteFiles: 'Ei lydfil slettes bare når den ikkje lenger brukes i eit språk.',
       },
       modal: {
         header: 'Lydfiler',


### PR DESCRIPTION
NDLANO/Issues#2724

Har lagt til en linje om sletting av filer i informasjons-modalen i audio form. Oversettelser er også omformulert.

Hvordan teste:
- Åpne eller lag lydfil og sjekk at oversettelser vises riktig. Det skal nå være fire punkter.
- Se over phrases.