### PR TITLE
Fixed faulty type guard for EditorFooter

### DIFF
--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -108,8 +108,7 @@ function EditorFooter<T extends FormValues>({
   };
 
   const isDraftApiType = (t: UpdatedDraftApiType | ConceptType): t is UpdatedDraftApiType => {
-    const casted = t as ConceptType;
-    return casted.parsedVisualElement !== undefined;
+    return (t as UpdatedDraftApiType).revision !== undefined;
   };
 
   const onValidateClick = async () => {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2748.

Det hadde å gjøre med en type guard som var feildefinert, slik at valideringsfunksjonen returnerte tidlig.