### PR TITLE
Bugfix hide metaimage checkbox in ndla film

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -13,6 +13,10 @@ const SlateVisualElementPicker = ({
   onInsertBlock,
 }) => {
   const formikContext = useFormikContext();
+  const { values } = formikContext;
+
+  const showMetaImageCheckbox =
+    values.metaImageAlt !== undefined && values.metaImageId !== undefined;
 
   const onVisualElementAdd = (visualElement, type = 'embed') => {
     if (type === 'embed') {
@@ -36,7 +40,7 @@ const SlateVisualElementPicker = ({
           handleVisualElementChange={onVisualElementAdd}
           closeModal={onVisualElementClose}
           setH5pFetchFail={setH5pFetchFail}
-          showMetaImageCheckbox={true}
+          showMetaImageCheckbox={showMetaImageCheckbox}
           onSaveAsMetaImage={image => onSaveAsMetaImage(image, formikContext)}
         />
       )}

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -13,6 +13,7 @@ const SlateVisualElementPicker = ({
   onInsertBlock,
 }) => {
   const formikContext = useFormikContext();
+
   const { values } = formikContext;
 
   const showMetaImageCheckbox =

--- a/src/containers/ConceptPage/conceptUtil.ts
+++ b/src/containers/ConceptPage/conceptUtil.ts
@@ -41,7 +41,7 @@ export const transformApiConceptToFormValues = (
     processors: concept.copyright?.processors || [],
     source: concept && concept.source ? concept.source : '',
     license: concept.copyright?.license?.license || '',
-    metaImageId: concept.metaImageId,
+    metaImageId: concept.metaImageId || '',
     metaImageAlt: concept.metaImage?.alt || '',
     tags: concept.tags || [],
     articles: concept.articles || [],

--- a/src/containers/VisualElement/VisualElementSelectField.jsx
+++ b/src/containers/VisualElement/VisualElementSelectField.jsx
@@ -33,6 +33,11 @@ const VisualElementSelectField = ({
 }) => {
   const formikContext = useFormikContext();
 
+  const { values } = formikContext;
+
+  const showMetaImageCheckbox =
+    values.metaImageAlt !== undefined && values.metaImageId !== undefined;
+
   const onImageLightboxClose = () => {
     resetSelectedResource();
   };
@@ -60,7 +65,7 @@ const VisualElementSelectField = ({
           videoTypes={videoTypes}
           articleLanguage={articleLanguage}
           setH5pFetchFail={setH5pFetchFail}
-          showMetaImageCheckbox={true}
+          showMetaImageCheckbox={showMetaImageCheckbox}
           onSaveAsMetaImage={image => onSaveAsMetaImage(image, formikContext)}
         />
       )}

--- a/src/containers/VisualElement/VisualElementSelectField.jsx
+++ b/src/containers/VisualElement/VisualElementSelectField.jsx
@@ -17,7 +17,7 @@ export const onSaveAsMetaImage = (image, formikContext) => {
 
   if (setFieldValue && image) {
     setTimeout(() => {
-      setFieldValue('metaImageId', parseInt(image.id));
+      setFieldValue('metaImageId', image.id || '');
       setFieldValue('metaImageAlt', image.alttext?.alttext || '');
     }, 0);
   }


### PR DESCRIPTION
Oppdaget en feil da jeg arbeidet med slate-oppgradering.

Boksen for å huke av om man vil sette et bilde som metabilde er synlig ved valg av visuelt element i ndla film. Denne PRen fikser dette.

Hvordan teste:
1. Bekreft at metabilde kan settes med checkbox ved innsetting av bilde i læringsressurs.
2. Bekreft at metabilde kan settes med checkbox ved valg av visuelt element i forklaring og emne.
3. Bekreft at metabilde ikke kan settes ved valg av visuelt element i ndla film.