### PR TITLE
ignorere ny path når man oppdaterer h5p

### DIFF
--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -52,9 +52,11 @@ export class DisplayExternal extends Component {
     if (properties.url !== embed.url || properties.path !== embed.path) {
       editor.setNodeByKey(node.key, {
         data: {
+          ...embed,
           ...properties,
         },
       });
+      this.iframe.src = embed.url;
       this.closeEditEmbed();
     }
   }

--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -49,16 +49,23 @@ export class DisplayExternal extends Component {
   onEditEmbed(properties) {
     const { editor, node, embed } = this.props;
 
-    if (properties.url !== embed.url || properties.path !== embed.path) {
+    if (embed.url) {
       editor.setNodeByKey(node.key, {
         data: {
-          ...embed,
           ...properties,
+          url: embed.url,
+          path: embed.path,
         },
       });
       this.iframe.src = embed.url;
-      this.closeEditEmbed();
+    } else {
+      editor.setNodeByKey(node.key, {
+        data: {
+          ...properties,
+        },
+      });
     }
+    this.closeEditEmbed();
   }
 
   async getPropsFromEmbed() {

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -161,7 +161,6 @@ class VisualElementSearch extends Component {
             onSelect={h5p =>
               handleVisualElementChange({
                 resource: 'h5p',
-                path: h5p.path,
                 title: h5p.title,
                 metaData: {},
               })

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -161,6 +161,7 @@ class VisualElementSearch extends Component {
             onSelect={h5p =>
               handleVisualElementChange({
                 resource: 'h5p',
+                path: h5p.path,
                 title: h5p.title,
                 metaData: {},
               })


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2690
onEditEmbed hadde en bug som gjorde at if setningen alltid var true fordi den sjekket
properties.url !== embed.url, men properties.url er alltid undefined
Dette førte også til at url ble satt til undefined, er ikke helt sikker på hva den originale ideen var