### PR TITLE
Changed the variable used to render markdown when slate video is not currently being edited

### DIFF
--- a/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
@@ -164,7 +164,7 @@ const SlateVideo = ({
                     margin: 0;
                   }
                 `}>
-                {parseMarkdown(tEmbed.caption)}
+                {parseMarkdown(caption)}
               </div>
             </figcaption>
           </Button>


### PR DESCRIPTION
Tok bare i bruk feil variabel. 

Kan testes ut ved å redigere en video-caption i en artikkel. Se at endringene kommer opp i artikkelen med en gang du har klikket på "lagre video".

