### PR TITLE
Add h5p resizer to preview page

### DIFF
--- a/src/components/PreviewDraft/PreviewDraft.tsx
+++ b/src/components/PreviewDraft/PreviewDraft.tsx
@@ -15,6 +15,7 @@ import { Article } from '@ndla/ui';
 import { ArticleType, LocaleType } from '../../interfaces';
 //@ts-ignore
 import { transformArticle } from '../../util/articleUtil';
+import '../DisplayEmbed/helpers/h5pResizer';
 
 interface Props {
   article: ArticleType;


### PR DESCRIPTION
Legger til h5p-resizer til forhåndsvisning av artikkel.

H5p i artikler som vises i ed blir ikkje resiza korrekt i forhåndsvisning. Fikser det ved å importere helperfil i previewdraft.

Test:
* Artikkel med høg h5p skal vises med h5p ekspandert til å ikkje ha scrollbars. Både i slate og i forhåndsvisning.