### PR TITLE
2779 fix blank topic connections

### DIFF
--- a/src/components/Taxonomy/ActiveTopicConnection.tsx
+++ b/src/components/Taxonomy/ActiveTopicConnection.tsx
@@ -63,10 +63,7 @@ const ActiveTopicConnection = ({
         <StyledConnections>
           <Breadcrumb breadcrumb={topic.breadcrumb} type={type} />
         </StyledConnections>
-        <SharedTopicConnections
-          topic={topic}
-          type={type}
-        />
+        <SharedTopicConnections topic={topic} type={type} />
       </>
     );
   }

--- a/src/components/Taxonomy/ActiveTopicConnection.tsx
+++ b/src/components/Taxonomy/ActiveTopicConnection.tsx
@@ -20,11 +20,9 @@ import SharedTopicConnections from './SharedTopicConnections';
 import Breadcrumb from './Breadcrumb';
 import RelevanceOption from '../../containers/StructurePage/folderComponents/menuOptions/RelevanceOption';
 import RemoveButton from '../RemoveButton';
-import { PathArray } from '../../util/retrieveBreadCrumbs';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
 
 interface Props {
-  retrieveBreadCrumbs: (path: string) => PathArray;
   removeConnection?: (id: string) => void;
   setPrimaryConnection?: (id: string) => void;
   topic: StagedTopic;
@@ -38,7 +36,6 @@ const StyledFlexWrapper = styled.div`
 `;
 
 const ActiveTopicConnection = ({
-  retrieveBreadCrumbs,
   removeConnection,
   setPrimaryConnection,
   setRelevance,
@@ -46,8 +43,7 @@ const ActiveTopicConnection = ({
   topic,
 }: Props) => {
   const { t } = useTranslation();
-  const breadcrumb = retrieveBreadCrumbs(topic.path);
-  if (!breadcrumb) {
+  if (!topic.breadcrumb) {
     return (
       <StyledConnections error>
         <StyledErrorLabel>{t('taxonomy.topics.disconnectedTaxonomyWarning')}</StyledErrorLabel>
@@ -65,11 +61,10 @@ const ActiveTopicConnection = ({
     return (
       <>
         <StyledConnections>
-          <Breadcrumb breadcrumb={breadcrumb} type={type} />
+          <Breadcrumb breadcrumb={topic.breadcrumb} type={type} />
         </StyledConnections>
         <SharedTopicConnections
           topic={topic}
-          retrieveBreadCrumbs={retrieveBreadCrumbs}
           type={type}
         />
       </>
@@ -85,7 +80,7 @@ const ActiveTopicConnection = ({
             onClick={() => setPrimaryConnection && setPrimaryConnection(topic.id)}>
             {t('form.topics.primaryTopic')}
           </StyledPrimaryConnectionButton>
-          <Breadcrumb breadcrumb={breadcrumb} />
+          <Breadcrumb breadcrumb={topic.breadcrumb} />
         </StyledFlexWrapper>
         <StyledFlexWrapper>
           <RelevanceOption
@@ -95,7 +90,7 @@ const ActiveTopicConnection = ({
           <RemoveButton onClick={() => removeConnection && removeConnection(topic.id)} />
         </StyledFlexWrapper>
       </StyledConnections>
-      <SharedTopicConnections topic={topic} retrieveBreadCrumbs={retrieveBreadCrumbs} />
+      <SharedTopicConnections topic={topic} />
     </>
   );
 };

--- a/src/components/Taxonomy/ActiveTopicConnections.tsx
+++ b/src/components/Taxonomy/ActiveTopicConnections.tsx
@@ -9,11 +9,9 @@
 import React from 'react';
 import { StyledConnectionsWrapper } from '../../style/LearningResourceTaxonomyStyles';
 import ActiveTopicConnection from './ActiveTopicConnection';
-import { PathArray } from '../../util/retrieveBreadCrumbs';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
 
 interface Props {
-  retrieveBreadCrumbs: (path: string) => PathArray;
   removeConnection?: (id: string) => void;
   setPrimaryConnection?: (id: string) => void;
   activeTopics: StagedTopic[];

--- a/src/components/Taxonomy/SharedTopicConnections.tsx
+++ b/src/components/Taxonomy/SharedTopicConnections.tsx
@@ -13,16 +13,14 @@ import {
   StyledDuplicateConnectionLabel,
 } from '../../style/LearningResourceTaxonomyStyles';
 import Breadcrumb from './Breadcrumb';
-import { PathArray } from '../../util/retrieveBreadCrumbs';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
 
 interface Props {
   topic: StagedTopic;
   type?: string;
-  retrieveBreadCrumbs: (path: string) => PathArray;
 }
 
-export const SharedTopicConnections = ({ topic, retrieveBreadCrumbs, type }: Props) => {
+export const SharedTopicConnections = ({ topic, type }: Props) => {
   const { t } = useTranslation();
   if (!topic.paths || topic.paths.length === 0) {
     return null;
@@ -38,7 +36,7 @@ export const SharedTopicConnections = ({ topic, retrieveBreadCrumbs, type }: Pro
               <StyledDuplicateConnectionLabel>
                 {t('form.topics.sharedTopic')}
               </StyledDuplicateConnectionLabel>
-              <Breadcrumb breadcrumb={retrieveBreadCrumbs(path)} type={type} />
+              <Breadcrumb breadcrumb={topic.breadcrumb || []} type={type} />
             </StyledConnections>
           );
         })}

--- a/src/components/Taxonomy/TopicConnections.tsx
+++ b/src/components/Taxonomy/TopicConnections.tsx
@@ -23,7 +23,7 @@ import HowToHelper from '../HowTo/HowToHelper';
 import StructureButtons from '../../containers/ArticlePage/LearningResourcePage/components/taxonomy/StructureButtons';
 import { SubjectType } from '../../modules/taxonomy/taxonomyApiInterfaces';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
-import { getBreadcrumbFromPath } from '../../util/taxonomyHelpers';
+import { getBreadcrumbFromPath } from '../../util/taxonomyHelpers';
 
 const StyledTitleModal = styled('h1')`
   color: ${colors.text.primary};

--- a/src/components/Taxonomy/TopicConnections.tsx
+++ b/src/components/Taxonomy/TopicConnections.tsx
@@ -17,13 +17,13 @@ import Button from '@ndla/button';
 import { useTranslation } from 'react-i18next';
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { fetchUserData } from '../../modules/draft/draftApi';
-import { fetchTopicConnections } from '../../modules/taxonomy';
+import { fetchTopic, fetchTopicConnections } from '../../modules/taxonomy';
 import ActiveTopicConnections from './ActiveTopicConnections';
 import HowToHelper from '../HowTo/HowToHelper';
 import StructureButtons from '../../containers/ArticlePage/LearningResourcePage/components/taxonomy/StructureButtons';
 import { SubjectType } from '../../modules/taxonomy/taxonomyApiInterfaces';
-import { PathArray } from '../../util/retrieveBreadCrumbs';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
+import { getBreadcrumbFromPath } from '../../util/taxonomyHelpers';
 
 const StyledTitleModal = styled('h1')`
   color: ${colors.text.primary};
@@ -38,12 +38,6 @@ const ModalTitleRow = styled.div`
 interface Props {
   structure: SubjectType[];
   activeTopics: StagedTopic[];
-  allTopics: {
-    contentUri: string;
-    id: string;
-    name: string;
-    path: string;
-  }[];
   onChangeShowFavorites: () => void;
   // showFavorites: boolean;
   removeConnection: (id: string) => void;
@@ -52,13 +46,11 @@ interface Props {
   stageTaxonomyChanges: (properties: any) => void;
   getSubjectTopics: (subjectId: string) => Promise<void>;
   setRelevance: (topicId: string, relevanceId: string) => void;
-  retrieveBreadCrumbs: (topicPath: string) => PathArray;
 }
 
 const TopicConnections = ({
   structure,
   activeTopics,
-  allTopics,
   onChangeShowFavorites,
   // showFavorites,
   removeConnection,
@@ -67,7 +59,6 @@ const TopicConnections = ({
   stageTaxonomyChanges,
   getSubjectTopics,
   setRelevance,
-  retrieveBreadCrumbs,
 }: Props) => {
   const { t } = useTranslation();
   const [openedPaths, setOpenedPaths] = useState<string[]>([]);
@@ -115,20 +106,22 @@ const TopicConnections = ({
   };
 
   const addTopic = async (id: string | undefined, closeModal: () => void) => {
-    const topicToAdd = allTopics.find(taxonomyTopic => taxonomyTopic.id === id);
-
-    const topicConnections = await fetchTopicConnections(topicToAdd!.id);
-
-    stageTaxonomyChanges({
-      topics: [
-        ...activeTopics,
-        {
-          ...topicToAdd,
-          topicConnections,
-          primary: activeTopics.length === 0,
-        },
-      ],
-    });
+    if (id) {
+      const topicToAdd = await fetchTopic(id);
+      const topicConnections = await fetchTopicConnections(topicToAdd.id);
+      const breadcrumb = await getBreadcrumbFromPath(topicToAdd.path);
+      stageTaxonomyChanges({
+        topics: [
+          ...activeTopics,
+          {
+            ...topicToAdd,
+            breadcrumb,
+            topicConnections,
+            primary: activeTopics.length === 0,
+          },
+        ],
+      });
+    }
     closeModal();
   };
 
@@ -142,7 +135,6 @@ const TopicConnections = ({
         setRelevance={setRelevance}
         removeConnection={removeConnection}
         setPrimaryConnection={setPrimaryConnection}
-        retrieveBreadCrumbs={retrieveBreadCrumbs}
         type="topicarticle"
       />
       <Modal

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
@@ -13,7 +13,6 @@ import { ErrorMessage } from '@ndla/ui';
 import Field from '../../../../components/Field';
 import {
   fetchResourceTypes,
-  fetchTopics,
   fetchSubjects,
   fetchSubjectTopics,
   fetchTopicConnections,
@@ -23,9 +22,8 @@ import {
   createResource,
   getResourceId,
 } from '../../../../modules/taxonomy';
-import { sortByName, groupTopics } from '../../../../util/taxonomyHelpers';
+import { sortByName, groupTopics, getBreadcrumbFromPath } from '../../../../util/taxonomyHelpers';
 import handleError from '../../../../util/handleError';
-import retrieveBreadCrumbs from '../../../../util/retrieveBreadCrumbs';
 import TopicConnections from '../../../../components/Taxonomy/TopicConnections';
 import SaveButton from '../../../../components/SaveButton';
 import { ActionButton } from '../../../FormikForm';
@@ -39,7 +37,6 @@ import {
 import { FormikFieldHelp } from '../../../../components/FormikField';
 import {
   TaxonomyMetadata,
-  Topic,
   ResourceType,
   ResourceResourceType,
   SubjectType,
@@ -95,7 +92,6 @@ interface State {
   };
 
   taxonomyChoices: {
-    allTopics: Topic[];
     availableResourceTypes: ResourceType[];
   };
   showWarning: boolean;
@@ -116,7 +112,6 @@ class LearningResourceTaxonomy extends Component<Props, State> {
         ...emptyTaxonomy,
       },
       taxonomyChoices: {
-        allTopics: [],
         availableResourceTypes: [],
       },
       showWarning: false,
@@ -248,9 +243,8 @@ class LearningResourceTaxonomy extends Component<Props, State> {
     } = this.props;
     if (!language) return;
     try {
-      const [allResourceTypes, allTopics, subjects] = await Promise.all([
+      const [allResourceTypes, subjects] = await Promise.all([
         fetchResourceTypes(language),
-        fetchTopics(language),
         fetchSubjects(language),
       ]);
 
@@ -260,7 +254,6 @@ class LearningResourceTaxonomy extends Component<Props, State> {
         this.setState({
           taxonomyChoices: {
             availableResourceTypes: allResourceTypes.filter(resourceType => resourceType.name),
-            allTopics: allTopics.filter(topic => topic.name),
           },
           structure: sortedSubjects,
         });
@@ -349,20 +342,23 @@ class LearningResourceTaxonomy extends Component<Props, State> {
     const topicResources = await Promise.all(
       sortedParents.map(topic => fetchTopicResources(topic.id)),
     );
-    const topicsWithConnectionsAndRelevanceId = sortedParents.map((topic, index) => {
+    const topicsWithConnectionsAndRelevanceId = sortedParents.map(async (topic, index) => {
       const foundRelevanceId = topicResources[index]?.find(resource => resource.id === resourceId)
         ?.relevanceId;
+      const breadcrumb = await getBreadcrumbFromPath(topic.path);
       return {
         topicConnections: topicConnections[index],
         relevanceId: foundRelevanceId ?? RESOURCE_FILTER_CORE,
+        breadcrumb,
         ...topic,
       };
     });
+    const topics = await Promise.all(topicsWithConnectionsAndRelevanceId);
 
     return {
       name,
       resourceTypes,
-      topics: topicsWithConnectionsAndRelevanceId,
+      topics,
       metadata,
     };
   };
@@ -415,7 +411,7 @@ class LearningResourceTaxonomy extends Component<Props, State> {
 
   render() {
     const {
-      taxonomyChoices: { availableResourceTypes, allTopics },
+      taxonomyChoices: { availableResourceTypes },
       taxonomyChanges: { resourceTypes, topics, metadata },
       resourceId,
       resourceTaxonomy,
@@ -453,17 +449,6 @@ class LearningResourceTaxonomy extends Component<Props, State> {
       );
     }
 
-    const breadCrumbs = [];
-    topics.forEach(topic => {
-      if (topic.paths) {
-        topic.paths.forEach(path =>
-          breadCrumbs.push(retrieveBreadCrumbs({ topicPath: path, allTopics, structure })),
-        );
-      } else {
-        breadCrumbs.push(retrieveBreadCrumbs({ topicPath: topic.path, allTopics, structure }));
-      }
-    });
-
     return (
       <Fragment>
         {userAccess?.includes(TAXONOMY_ADMIN_SCOPE) && resourceId && (
@@ -483,11 +468,7 @@ class LearningResourceTaxonomy extends Component<Props, State> {
         />
         <TopicConnections
           structure={structure}
-          allTopics={allTopics}
           activeTopics={topics}
-          retrieveBreadCrumbs={topicPath =>
-            retrieveBreadCrumbs({ topicPath, allTopics, structure })
-          }
           removeConnection={this.removeConnection}
           setPrimaryConnection={this.setPrimaryConnection}
           setRelevance={this.setRelevance}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleConnections.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleConnections.tsx
@@ -20,7 +20,6 @@ import { fetchUserData } from '../../../../modules/draft/draftApi';
 import { HowToHelper } from '../../../../components/HowTo';
 import StructureFunctionButtons from './StructureFunctionButtons';
 import ActiveTopicConnections from '../../../../components/Taxonomy/ActiveTopicConnections';
-import { PathArray } from '../../../../util/retrieveBreadCrumbs';
 import { SubjectType } from '../../../../modules/taxonomy/taxonomyApiInterfaces';
 import { LocaleType } from '../../../../interfaces';
 import { StagedTopic } from './TopicArticleTaxonomy';
@@ -31,7 +30,6 @@ interface Props {
   allowMultipleSubjectsOpen?: boolean;
   stageTaxonomyChanges: ({ path }: { path: string }) => void;
   getSubjectTopics: (subjectId: string, locale: LocaleType) => Promise<void>;
-  retrieveBreadCrumbs: (path: string) => PathArray;
   locale: LocaleType;
 }
 
@@ -51,7 +49,6 @@ const TopicArticleConnections = ({
   allowMultipleSubjectsOpen,
   stageTaxonomyChanges,
   getSubjectTopics,
-  retrieveBreadCrumbs,
   locale,
 }: Props) => {
   const { t } = useTranslation();
@@ -113,11 +110,7 @@ const TopicArticleConnections = ({
         subTitle={t('taxonomy.topics.subTitleTopic')}>
         <HowToHelper pageId="TaxonomyTopicConnections" tooltip={t('taxonomy.topics.helpLabel')} />
       </FieldHeader>
-      <ActiveTopicConnections
-        activeTopics={activeTopics}
-        type="topic-article"
-        retrieveBreadCrumbs={retrieveBreadCrumbs}
-      />
+      <ActiveTopicConnections activeTopics={activeTopics} type="topic-article" />
       <Modal
         backgroundColor="white"
         animation="subtle"

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -12,7 +12,6 @@ import { Spinner } from '@ndla/editor';
 import { ErrorMessage } from '@ndla/ui';
 import Field from '../../../../components/Field';
 import {
-  fetchTopics,
   fetchSubjects,
   fetchSubjectTopics,
   queryTopics,
@@ -20,11 +19,14 @@ import {
   addTopicToTopic,
   addSubjectTopic,
   addTopic,
-  fetchResourceTypes,
 } from '../../../../modules/taxonomy';
-import { sortByName, groupTopics, pathToUrnArray } from '../../../../util/taxonomyHelpers';
+import {
+  sortByName,
+  groupTopics,
+  pathToUrnArray,
+  getBreadcrumbFromPath,
+} from '../../../../util/taxonomyHelpers';
 import handleError from '../../../../util/handleError';
-import retrieveBreadCrumbs from '../../../../util/retrieveBreadCrumbs';
 import SaveButton from '../../../../components/SaveButton';
 import { ActionButton } from '../../../FormikForm';
 import TopicArticleConnections from './TopicArticleConnections';
@@ -32,12 +34,10 @@ import TopicArticleConnections from './TopicArticleConnections';
 import { FormikFieldHelp } from '../../../../components/FormikField';
 import { ConvertedDraftType, LocaleType } from '../../../../interfaces';
 import {
-  ResourceType,
   SubjectTopic,
   SubjectType,
   TaxonomyElement,
   TaxonomyMetadata,
-  Topic,
   TopicConnections,
 } from '../../../../modules/taxonomy/taxonomyApiInterfaces';
 import { UpdatedDraftApiType } from '../../../../modules/draft/draftApiInterfaces';
@@ -73,10 +73,6 @@ interface State {
   status: string;
   isDirty: boolean;
   stagedTopicChanges: StagedTopic[];
-  taxonomyChoices: {
-    allTopics: SubjectTopic[] | Topic[];
-    availableResourceTypes?: ResourceType[];
-  };
   showWarning: boolean;
 }
 
@@ -88,9 +84,6 @@ class TopicArticleTaxonomy extends Component<Props, State> {
       status: 'loading',
       isDirty: false,
       stagedTopicChanges: [],
-      taxonomyChoices: {
-        allTopics: [],
-      },
       showWarning: false,
     };
   }
@@ -127,11 +120,9 @@ class TopicArticleTaxonomy extends Component<Props, State> {
     } = this.props;
     if (!language) return;
     try {
-      const [topics, allTopics, subjects, allResourceTypes] = await Promise.all([
+      const [topics, subjects] = await Promise.all([
         queryTopics(articleId.toString(), language),
-        fetchTopics(language),
         fetchSubjects(language),
-        fetchResourceTypes(language),
       ]);
 
       const sortedSubjects = subjects.filter(subject => subject.name).sort(sortByName);
@@ -142,19 +133,20 @@ class TopicArticleTaxonomy extends Component<Props, State> {
         sortedTopics.map(topic => fetchTopicConnections(topic.id)),
       );
 
-      const topicsWithConnections = sortedTopics.map((topic, index) => ({
-        topicConnections: topicConnections[index],
-        ...topic,
-      }));
+      const topicsWithConnections = sortedTopics.map(async (topic, index) => {
+        const breadcrumb = await getBreadcrumbFromPath(topic.path);
+        return {
+          topicConnections: topicConnections[index],
+          breadcrumb,
+          ...topic,
+        };
+      });
+      const stagedTopicChanges = await Promise.all(topicsWithConnections);
 
       this.setState({
         status: 'initial',
-        stagedTopicChanges: topicsWithConnections,
+        stagedTopicChanges,
         structure: sortedSubjects,
-        taxonomyChoices: {
-          availableResourceTypes: allResourceTypes.filter(resourceType => resourceType.name),
-          allTopics: allTopics.filter(topic => topic.name),
-        },
       });
     } catch (e) {
       handleError(e);
@@ -162,12 +154,14 @@ class TopicArticleTaxonomy extends Component<Props, State> {
     }
   };
 
-  stageTaxonomyChanges = ({ path }: { path: string }) => {
+  stageTaxonomyChanges = async ({ path }: { path: string }) => {
     if (path) {
+      const breadcrumb = await getBreadcrumbFromPath(path);
       const newTopic: StagedTopic = {
         id: 'staged',
         name: this.props.article.title ?? '',
         path: `${path}/staged`,
+        breadcrumb,
         metadata: {
           grepCodes: [],
           visible: true,
@@ -284,19 +278,8 @@ class TopicArticleTaxonomy extends Component<Props, State> {
   };
 
   render() {
-    const {
-      taxonomyChoices: { allTopics },
-      stagedTopicChanges,
-      structure,
-      status,
-      isDirty,
-      showWarning,
-    } = this.state;
-    const {
-      t,
-      article: { title },
-      locale,
-    } = this.props;
+    const { stagedTopicChanges, structure, status, isDirty, showWarning } = this.state;
+    const { t, locale } = this.props;
 
     if (status === 'loading') {
       return <Spinner />;
@@ -318,25 +301,11 @@ class TopicArticleTaxonomy extends Component<Props, State> {
       );
     }
 
-    const breadCrumbs = [];
-    stagedTopicChanges.forEach(topic => {
-      if (topic.paths) {
-        topic.paths.forEach(path =>
-          breadCrumbs.push(retrieveBreadCrumbs({ topicPath: path, allTopics, structure })),
-        );
-      } else {
-        breadCrumbs.push(retrieveBreadCrumbs({ topicPath: topic.path, allTopics, structure }));
-      }
-    });
-
     return (
       <Fragment>
         <TopicArticleConnections
           structure={structure}
-          activeTopics={this.state.stagedTopicChanges}
-          retrieveBreadCrumbs={topicPath =>
-            retrieveBreadCrumbs({ topicPath, allTopics, structure, title })
-          }
+          activeTopics={stagedTopicChanges}
           locale={locale}
           getSubjectTopics={this.getSubjectTopics}
           stageTaxonomyChanges={this.stageTaxonomyChanges}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -60,6 +60,7 @@ export interface StagedTopic extends TaxonomyElement {
   name: string;
   path: string;
   paths?: string[];
+  breadcrumb?: TaxonomyElement[];
   topicConnections?: TopicConnections[];
   primary?: boolean;
   relevanceId?: string;

--- a/src/modules/taxonomy/taxonomyApiInterfaces.ts
+++ b/src/modules/taxonomy/taxonomyApiInterfaces.ts
@@ -78,6 +78,7 @@ export interface ParentTopic extends TaxonomyElement {
 export type ParentTopicWithRelevanceAndConnections = ParentTopic & {
   topicConnections: TopicConnections[];
   relevanceId: string;
+  breadcrumb: TaxonomyElement[];
 };
 
 export interface ResourceTranslation {

--- a/src/util/taxonomyHelpers.ts
+++ b/src/util/taxonomyHelpers.ts
@@ -13,8 +13,13 @@ import {
   SubjectTopic,
   TaxonomyElement,
 } from '../modules/taxonomy/taxonomyApiInterfaces';
-import { updateTopicResource, updateTopicSubtopic, updateSubjectTopic } from '../modules/taxonomy';
-
+import {
+  updateTopicResource,
+  updateTopicSubtopic,
+  updateSubjectTopic,
+  fetchTopic,
+  fetchSubject,
+} from '../modules/taxonomy';
 import { getContentTypeFromResourceTypes } from './resourceHelpers';
 
 // Kan hende at id i contentUri fra taxonomy inneholder '#xxx' (revision)
@@ -234,6 +239,19 @@ const updateRelevanceId = (
   }
 };
 
+const getBreadcrumbFromPath = async (path: string): Promise<TaxonomyElement[]> => {
+  const [subjectPath, ...topicPaths] = pathToUrnArray(path);
+  const subjectAndTopics = await Promise.all([
+    fetchSubject(subjectPath),
+    ...topicPaths.map(id => fetchTopic(id)),
+  ]);
+  return subjectAndTopics.map(element => ({
+    id: element.id,
+    name: element.name,
+    metadata: element.metadata,
+  }));
+};
+
 export {
   flattenResourceTypesAndAddContextTypes,
   sortIntoCreateDeleteUpdate,
@@ -248,4 +266,5 @@ export {
   selectedResourceTypeValue,
   pathToUrnArray,
   updateRelevanceId,
+  getBreadcrumbFromPath,
 };


### PR DESCRIPTION
Fixes NDLANO/Issues#2779

Test:
* Gå inn på en læringsressurs
* Åpne taksonomitaben
* Breadcrumbs skal dukke opp med en gang (sammenlign med ed.test)

Tilsvarende test kan gjøres for emneplassering i emne artikkel. Her vistes spinneren helt til all data var hentet fra før, men dette skal nå gå raskere.

Koden for å legge til en emnetilknyttning er også endret på. Dette skal fungere som før.

