### PR TITLE
Concept visual element will be centered when not full width

### DIFF
--- a/src/components/PreviewConcept/PreviewConcept.tsx
+++ b/src/components/PreviewConcept/PreviewConcept.tsx
@@ -58,8 +58,9 @@ const TagWrapper = styled.div`
 `;
 
 const VisualElementWrapper = styled.div`
-  margin-left: auto;
-  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 interface Props {


### PR DESCRIPTION
En liten fiks på styling relatert til svg-er i visuelt element som blir rendret i størrelse 0*0px.

Forhåndsvisning av https://editorial-frontend-pr-1202.ndla.sh/concept/1197/edit/nn skal nå vise bilde i full bredde.