### PR TITLE
Added a reuse label to Audio FigureCaptions.

### DIFF
--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -66,7 +66,7 @@ const AudioPlayerMounter = ({ audio, locale, speech }: Props) => {
             id={figureLicenseDialogId}
             figureId={`figure-${audio.id}`}
             caption={audio.caption}
-            reuseLabel=""
+            reuseLabel={t('audio.reuse')}
             licenseRights={license.rights}
             authors={copyright.creators}
           />


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2782

Knappen gjør ingenting i editoren, men det er mer innlysende enn å kun ha en tom knapp. Alternativt kan vi endre `LicenseByLine` i frontend-packages slik at man kan omitte knappen.