### PR TITLE
Fixed updating subject pages

### DIFF
--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -151,8 +151,8 @@ const SubjectpageForm = ({
   const { t } = useTranslation();
   const { savedToServer, handleSubmit, initialValues } = useSubjectpageFormHooks(
     getSubjectpageFromSlate,
-    updateSubjectpage,
     t,
+    updateSubjectpage,
     subjectpage,
     getInitialValues,
     selectedLanguage,

--- a/src/containers/FormikForm/subjectpageFormHooks.ts
+++ b/src/containers/FormikForm/subjectpageFormHooks.ts
@@ -37,7 +37,7 @@ export function useSubjectpageFormHooks(
       await updateSubjectpage(newSubjectpage);
 
       Object.keys(formik.values).map(fieldName => formik.setFieldTouched(fieldName, true, true));
-      formik.resetForm({ values: initialValues });
+      formik.resetForm();
       setSavedToServer(true);
     } catch (err) {
       if (err?.status === 409) {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2787

Feilen kom av at `TFunction` ble passert inn istedenfor oppdateringsfunksjonen. Hvordan det ikke ble plukket opp av TypeScript er jeg litt usikker på.

Hvordan teste:
1. Gå til en subjectpage som allerede finnes.
2. Endre metabeskrivelse.
3. Trykk lagre.
4. Refresh siden og sjekk at metabeskrivelsen er oppdatert.