### PR TITLE
Trigger Mathjax script when preview content changes

### DIFF
--- a/src/components/PreviewDraft/PreviewDraft.tsx
+++ b/src/components/PreviewDraft/PreviewDraft.tsx
@@ -26,7 +26,17 @@ interface Props {
 
 class PreviewDraft extends Component<Props, {}> {
   componentDidMount() {
-    if (window.MathJax) window.MathJax.typesetPromise();
+    if (window.MathJax) {
+      window.MathJax.typesetPromise();
+    }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.article.content !== this.props.article.content) {
+      if (window.MathJax) {
+        window.MathJax.typesetPromise();
+      }
+    }
   }
 
   render() {


### PR DESCRIPTION
Fixes NDLANO/Issues#2791

Ved bytting av språkversjon i sammenlikning eller forhåndsvisning av språkversjon i ed vil Mathjax ikke rendres lenger dersom det finnes i innholdet.

Hvordan teste:
1. https://ed.test.ndla.no/subject-matter/learning-resource/31044/edit/nb. Bytting mellom språk ved forhåndsvisning/sammenlikning vil få mathjax til å slutte å vises riktig.
2. Gjør det samme i PR-instans, men nå skal mathjax vises riktig selv etter bytting.