### PR TITLE
Removed all calls to initAudioPlayers

### DIFF
--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import css from '@emotion/css';
-import { AudioPlayer, initAudioPlayers } from '@ndla/ui';
+import { AudioPlayer } from '@ndla/ui';
 // @ts-ignore
 import { FigureCaption, FigureLicenseDialog } from '@ndla/ui';
 import { getLicenseByAbbreviation } from '@ndla/licenses';
@@ -24,10 +24,6 @@ interface Props {
 const AudioPlayerMounter = ({ audio, locale, speech }: Props) => {
   const { t } = useTranslation();
   const { copyright, podcastMeta } = audio;
-
-  useEffect(() => {
-    initAudioPlayers(locale);
-  }, [locale]);
 
   const license = getLicenseByAbbreviation(copyright.license?.license || '', locale);
   const figureLicenseDialogId = `edit-audio-${audio.id}`;

--- a/src/components/SlateEditor/plugins/embed/EditAudio.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditAudio.tsx
@@ -10,13 +10,13 @@ import { css } from '@emotion/core';
 import React, { useEffect, Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@ndla/forms';
-import { AudioPlayer, initAudioPlayers } from '@ndla/ui';
+import { AudioPlayer } from '@ndla/ui';
 import ObjectSelector from '../../../ObjectSelector';
 import Overlay from '../../../Overlay';
 import { Portal } from '../../../Portal';
 import { useSlateContext } from '../../SlateContext';
 import FigureButtons from './FigureButtons';
-import { SlateAudio, Embed, LocaleType } from '../../../../interfaces';
+import { SlateAudio, Embed } from '../../../../interfaces';
 
 const placeholderStyle = css`
   position: relative;
@@ -28,7 +28,6 @@ interface Props {
   changes: { [x: string]: string };
   embed: Embed;
   language: string;
-  locale: LocaleType;
   onAudioFigureInputChange: (event: React.FormEvent<HTMLSelectElement>) => void;
   onChange: (event: React.FormEvent<HTMLSelectElement>) => void;
   onExit: (event: React.MouseEvent) => void;
@@ -45,7 +44,6 @@ const EditAudio = ({
   onRemoveClick,
   type,
   language,
-  locale,
   speech,
   audio,
   changes,
@@ -66,8 +64,7 @@ const EditAudio = ({
     embedElement.style.top = `${placeholderRect.top - bodyRect.top}px`;
     embedElement.style.left = `${placeholderRect.left}px`;
     embedElement.style.width = `${placeholderRect.width}px`;
-    initAudioPlayers(locale);
-  }, [embedElement, locale, placeholderElement]);
+  }, [embedElement, placeholderElement]);
 
   return (
     <Fragment>

--- a/src/components/SlateEditor/plugins/embed/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateAudio.tsx
@@ -85,7 +85,6 @@ const SlateAudio = ({
             changes={changes}
             embed={embed}
             language={language}
-            locale={locale}
             onExit={toggleEdit}
             onChange={onFigureInputChange}
             onAudioFigureInputChange={onAudioFigureInputChange}


### PR DESCRIPTION
Fikser delvis https://github.com/NDLANO/Issues/issues/2783
Fikser fullstendig sammen med https://github.com/NDLANO/frontend-packages/pull/889

Kallene til i18next i ed er unødvendige. Dette kallet trenger kun å brukes dersom man mottar en artikkel fra article-converter. Der den ble brukt i ED var innholdet allerede dynamisk.