### PR TITLE
#2786: Allows mp4 extensions when uploading files

### DIFF
--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -102,6 +102,7 @@ const allowedFiles = [
   '.xlsx',
   '.xml',
   '.f3d',
+  '.mp4',
 ];
 
 export default FileUploader;


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2786
Depends on https://github.com/NDLANO/draft-api/pull/282

Kan testes ved  å sjekke at filopplasting av mp4 filer funker i artikler :smile: