### PR TITLE
2805 delete link with backspace

### DIFF
--- a/cypress/integration/Editor/toolbar_spec.js
+++ b/cypress/integration/Editor/toolbar_spec.js
@@ -35,7 +35,9 @@ describe('Selecting text and using the toolbar', () => {
     cy.get('[data-cy=slate-editor] [data-slate-editor=true]')
       .last()
       .then($el => {
-        cy.wrap($el).type('last line{selectall}');
+        cy.get($el)
+          .focus()
+          .type('{selectall}last line{selectall}');
         cy.get('[data-testid=toolbar-button-bold]').click();
         cy.get('[data-testid=toolbar-button-italic]').click();
         cy.get('[data-testid=toolbar-button-code]').click();

--- a/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
+++ b/src/components/SlateEditor/plugins/embed/AudioPlayerMounter.tsx
@@ -51,6 +51,9 @@ const AudioPlayerMounter = ({ audio, locale, speech }: Props) => {
         p {
           margin: 0 !important;
         }
+        ul {
+          margin-top: 0;
+        }
       `}>
       <AudioPlayer
         src={audio.audioFile.url}
@@ -61,15 +64,13 @@ const AudioPlayerMounter = ({ audio, locale, speech }: Props) => {
         textVersion={audio?.manuscript}
       />
       {!speech && (
-        <>
-          <FigureCaption
-            id={figureLicenseDialogId}
-            figureId={`figure-${audio.id}`}
-            caption={audio.caption}
-            reuseLabel=""
-            licenseRights={license.rights}
-            authors={copyright.creators}
-          />
+        <FigureCaption
+          id={figureLicenseDialogId}
+          figureId={`figure-${audio.id}`}
+          caption={audio.caption}
+          reuseLabel={t('audio.reuse')}
+          licenseRights={license.rights}
+          authors={copyright.creators}>
           <FigureLicenseDialog
             id={figureLicenseDialogId}
             title={audio.title}
@@ -79,7 +80,7 @@ const AudioPlayerMounter = ({ audio, locale, speech }: Props) => {
             messages={messages}
             locale={locale}
           />
-        </>
+        </FigureCaption>
       )}
     </div>
   );

--- a/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
@@ -118,4 +118,57 @@ describe('link normalizer tests', () => {
     Editor.normalize(editor, { force: true });
     expect(editor.children).toEqual(expectedValue);
   });
+
+  test('Remove empty links', () => {
+    const editorValue: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [
+              { text: '' },
+              {
+                type: TYPE_LINK,
+                href: 'test-url',
+                children: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+              { text: '' },
+              {
+                type: TYPE_CONTENT_LINK,
+                'content-type': 'test',
+                'content-id': '123',
+                'open-in': 'test',
+                children: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+              { text: '' },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [{ text: '' }],
+          },
+        ],
+      },
+    ];
+    editor.children = editorValue;
+    Editor.normalize(editor, { force: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
 });

--- a/src/components/SlateEditor/plugins/link/index.tsx
+++ b/src/components/SlateEditor/plugins/link/index.tsx
@@ -26,7 +26,6 @@ export interface LinkElement {
   children: Descendant[];
 }
 
-// TODO: change to data: {content-type, content-id, open-in}
 export interface ContentLinkElement {
   type: 'content-link';
   'content-type': string;
@@ -134,9 +133,11 @@ export const linkPlugin = (language: string) => (editor: Editor) => {
       if (node.type === 'content-link' || node.type === 'link') {
         for (const [index, child] of node.children.entries()) {
           if (!Text.isText(child)) {
-            Transforms.unwrapNodes(editor, { at: [...path, index] });
-            return;
+            return Transforms.unwrapNodes(editor, { at: [...path, index] });
           }
+        }
+        if (Node.string(node) === '') {
+          return Transforms.removeNodes(editor, { at: path });
         }
       }
       if (node.type === 'content-link') {


### PR DESCRIPTION
Fixes NDLANO/Issues#2805

Avventer https://github.com/NDLANO/editorial-frontend/pull/1217

Når man trykker backspace i en lenke skal den nå forsvinne når den er tom. Tidligere dukket den opp igjen etter lagring.