### PR TITLE
Slate: Remove filelist on deletion of last file, without crashing

### DIFF
--- a/src/components/SlateEditor/plugins/file/Filelist.jsx
+++ b/src/components/SlateEditor/plugins/file/Filelist.jsx
@@ -138,7 +138,6 @@ class Filelist extends React.Component {
     const files = this.state.files;
     if (files.length === 1) {
       editor.removeNodeByKey(node.key);
-      this.setState({ files: [] }, this.updateFilesToEditor);
     } else {
       this.setState(prevState => {
         const newNodes = prevState.files.filter((_, i) => i !== indexToDelete);


### PR DESCRIPTION
Fixes NDLANO/Issues#2811

Fil-liste i slate krasjet ved sletting av den siste filen. Listen blir slettet når siste element fjernes, men det ble forsøkt gjort en ekstra oppdatering i etterkant som ikke burde være der.

Hvordan teste:
- Åpne en artikkel, legg til en fil-liste og fjern deretter filen. Lista skal bli borte uten at nettsiden krasjer.