### PR TITLE
Changed isArticleArrayGuard

### DIFF
--- a/src/components/PreviewDraft/PreviewLightboxContent.tsx
+++ b/src/components/PreviewDraft/PreviewLightboxContent.tsx
@@ -44,7 +44,7 @@ interface Props {
   ) => React.ReactNode;
 }
 
-const isArticleArray = createArrayGuard<ArticleConverterApiType>('agreementId');
+const isArticleArray = createArrayGuard<ArticleConverterApiType>('availability');
 
 const PreviewLightboxContent = ({
   firstEntity,


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2831.

Guarden som bestemte om en entitet var av typen ArticleConverterApiType tok i bruk en supertype-property som ikke eksisterte på selve `ArticleConverterType`. 

Kunne det vært en tanke å legge på et readonly `_typename`-felt når man henter noe fra et API? På den måten har vi "tryggere" type guards, og vi vil slippe å være avhengige av type-guards der man prøver å finne noe unikt mellom mulighetene. 