### PR TITLE
Cypress should now wait for allMovies to be returned before clicking an element

### DIFF
--- a/cypress/integration/Film/film_spec.js
+++ b/cypress/integration/Film/film_spec.js
@@ -22,9 +22,8 @@ describe('Film editing', () => {
     cy.get(`input[placeholder="Legg til film i slideshow"]`)
       .click()
       .type('Page One');
-    cy.contains('Page One: A Year Inside the New York Times')
-      .click()
-      .wait('@allMovies');
+    cy.wait('@allMovies');
+    cy.contains('Page One: A Year Inside the New York Times').click();
   });
 
   it('Can remove movie from slideshow', () => {


### PR DESCRIPTION
Har et lite håp om at dette gjør testen mindre flaky. 

Før forsøkte den å klikke på et søkeelement før man ventet på søkeresultatet. Nå venter man på søkeresultatet, for deretter å klikke på et element. Aner ikke om det funker, men har et håp.