### PR TITLE
Visual element without size and alt text no longer crashes on click

### DIFF
--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -76,8 +76,8 @@ interface Props {
           'lower-right-x'?: string;
           'lower-right-y'?: string;
         };
-        align: string;
-        size: string;
+        align?: string;
+        size?: string;
       }
     | undefined;
 }
@@ -184,12 +184,12 @@ const ImageEditor = ({ embed, onUpdatedImageSettings, imageUpdates }: Props) => 
           ) : (
             ''
           )}
-          {imageUpdates?.size.startsWith('full') || imageUpdates?.size.startsWith('medium') ? (
+          {imageUpdates?.size?.startsWith('full') || imageUpdates?.size?.startsWith('medium') ? (
             <StyledImageEditorMenu>
               {bylineOptions.map(option => (
                 <ShowBylineButton
                   show={option === 'show'}
-                  currentSize={imageUpdates?.size}
+                  currentSize={imageUpdates.size ?? ''}
                   onFieldChange={onFieldChange}
                 />
               ))}

--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -189,7 +189,7 @@ const ImageEditor = ({ embed, onUpdatedImageSettings, imageUpdates }: Props) => 
               {bylineOptions.map(option => (
                 <ShowBylineButton
                   show={option === 'show'}
-                  currentSize={imageUpdates.size ?? ''}
+                  currentSize={imageUpdates.size}
                   onFieldChange={onFieldChange}
                 />
               ))}

--- a/src/containers/ImageEditor/ImageSizeButton.tsx
+++ b/src/containers/ImageEditor/ImageSizeButton.tsx
@@ -21,7 +21,7 @@ const icon: Record<string, JSX.Element> = {
 interface Props {
   size: string;
   onFieldChange: (evt: MouseEvent, field: string, value: string) => void;
-  currentSize: string;
+  currentSize?: string;
 }
 
 const ImageSizeButton = ({ currentSize = 'fullwidth', size, onFieldChange }: Props) => {

--- a/src/containers/ImageEditor/ShowBylineButton.tsx
+++ b/src/containers/ImageEditor/ShowBylineButton.tsx
@@ -17,7 +17,7 @@ const icon = {
 };
 
 interface Props {
-  currentSize: string;
+  currentSize?: string;
   onFieldChange: (evt: MouseEvent, field: string, value: string) => void;
   show: boolean;
 }
@@ -25,7 +25,7 @@ interface Props {
 const ShowBylineButton = ({ currentSize, onFieldChange, show }: Props) => {
   const { t } = useTranslation();
   const bylineTag = '-hide-byline';
-  const hideByline = currentSize.endsWith(bylineTag);
+  const hideByline = currentSize?.endsWith(bylineTag);
 
   const isActive = (show && !hideByline) || (!show && hideByline);
 
@@ -34,7 +34,7 @@ const ShowBylineButton = ({ currentSize, onFieldChange, show }: Props) => {
       onFieldChange(
         evt,
         'size',
-        show ? currentSize.replace(bylineTag, '') : currentSize + bylineTag,
+        show && currentSize ? currentSize?.replace(bylineTag, '') : currentSize + bylineTag,
       );
     }
   };


### PR DESCRIPTION
Fixes NDLANO/Issues#2851

Fikser en feil der nettsiden krasjet ved forsøk på å redigere visuelt element. Dette gjaldt spesielt denne:
https://ed.test.ndla.no/subjectpage/urn:subject:1:8bfd0a97-d456-448d-8b5f-3bc49e445b37/78/edit/nn.


Hvordan teste:
1. https://editorial-frontend-pr-1264.ndla.sh
2. Åpne forklaring/emne/ndla-film eller emnet nevnt over.
3. Trykk visuelt element for å redigere (dersom det er et bilde)
4. Sjekk at siden ikke krasjer og at bilde kan redigeres og lagres som før.