### PR TITLE
Prevent async dropdown from crashing on esc-click

### DIFF
--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -137,8 +137,11 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
     setPage(page.page);
   };
 
-  const handleChange = (selectedItem: ItemValues<ApiType>) => {
+  const handleChange = (selectedItem: ItemValues<ApiType> | null) => {
     setSelectedItem(selectedItem);
+    if (!selectedItem) {
+      return;
+    }
     setInputValue(labelField ? itemToString(selectedItem, labelField) : selectedItem.title);
     onChange(selectedItem.originalItem);
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2841

Retter en feil der asyncdropdown krasjer ved trykk på esc etter valg av element.

Hvordan teste:
1. Åpne PR-instans.
2. Åpne tilfeldig artikkel
3. Åpne seksjonen "Relatert innhold"
4. Skriv i "Forklaringer"-feltet og trykk på en vilkårlig forklaring.
5. Trykk på escape. I test vil dette krasje. I PR-instans skal dette gå fint.