### PR TITLE
Using correct prop

### DIFF
--- a/src/containers/FormikForm/components/ElementList.jsx
+++ b/src/containers/FormikForm/components/ElementList.jsx
@@ -159,7 +159,7 @@ class ElementList extends Component {
                     deleteIndex={deleteIndex}
                     messages={messages}
                     index={index}
-                    locale={this.props.i18n.locale}
+                    locale={this.props.i18n.language}
                     executeDeleteFile={this.executeDeleteFile}
                     showDragTooltip={elements.length > 1 && draggingIndex === -1}
                     onDragEnd={this.onDragEnd}
@@ -177,7 +177,7 @@ class ElementList extends Component {
                     deleteIndex={deleteIndex}
                     messages={messages}
                     index={index}
-                    locale={this.props.i18n.locale}
+                    locale={this.props.i18n.language}
                     executeDeleteFile={this.executeDeleteFile}
                     showDragTooltip={elements.length > 1 && draggingIndex === -1}
                     onDragEnd={this.onDragEnd}
@@ -203,7 +203,7 @@ ElementList.propTypes = {
   }),
   onUpdateElements: PropTypes.func,
   i18n: PropTypes.shape({
-    locale: LocaleShape.isRequired,
+    language: LocaleShape.isRequired,
   }).isRequired,
 };
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2853

Viser korrekt språk i lenke til læringssti.

Test:
* Åpne artikkel 5148 i pr-installasjon og i test. 
* Klikk på ikon for bruk i læringssti.
* I test er det undefined i urlen, men i pr-installasjon er det locale fra i18n.