### PR TITLE
Bruker korrekt id for redigeringslenke

### DIFF
--- a/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
@@ -126,7 +126,7 @@ const EditSlateConcept = (props: Props) => {
           subTitle={t('conceptform.title')}
           content={
             concept && (
-              <SlateConceptPreview concept={concept} handleRemove={handleRemove} id={uuid} />
+              <SlateConceptPreview concept={concept} handleRemove={handleRemove} id={concept.id} />
             )
           }
           ariaLabel={t('notions.edit')}>


### PR DESCRIPTION
Lenke til redigering av forklaring er feil. Det brukes et løpenummer for forklaringene i artikkelen, og det har sneket seg inn i lenka. Ser ingen umiddelbare problemer med dette, men @haattis har vel hatt en grunn for å gjøre det slik? 