### PR TITLE
Add option to ignore scheduled renewal of auth token

### DIFF
--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -148,7 +148,7 @@ class App extends React.Component<ActualProps, InternalState> {
 
 const AuthInitializer = ({ children }: { children: React.ReactElement }) => {
   const { createMessage } = useMessages();
-  scheduleRenewal(createMessage);
+  scheduleRenewal(createMessage, true);
   return children;
 };
 

--- a/src/util/authHelpers.ts
+++ b/src/util/authHelpers.ts
@@ -159,9 +159,15 @@ export const renewAuth = async () => {
 
 let tokenRenewalTimeout: ReturnType<typeof setTimeout>;
 
-export const scheduleRenewal = async (createMessage?: (newMessage: NewMessageType) => void) => {
+export const scheduleRenewal = async (
+  createMessage?: (newMessage: NewMessageType) => void,
+  ignoreRenew = false,
+) => {
   if (!createMessageRef && createMessage) {
     createMessageRef = createMessage;
+  }
+  if (ignoreRenew) {
+    return;
   }
   if (localStorage.getItem('access_token_personal') !== 'true') {
     return null;


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2872
Feilen kom av at AuthInitializer ble kjørt flere ganger. Fikset det ved å legge inn et flagg som sørget for at createMessage kunne bli satt, men at renewal ikke ble gjort. Dette reduserer auth0-kallene fra uendelig til 2-3 kall hver gang man fokuserer en fane.