### PR TITLE
Slate: Place side aligned image above paragraphs to allow clicking it

### DIFF
--- a/src/components/SlateEditor/plugins/embed/SlateImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.tsx
@@ -8,6 +8,7 @@
 
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
+import styled from '@emotion/styled';
 import React, { ReactNode, useState } from 'react';
 import { RenderElementProps } from 'slate-react';
 import Button from '@ndla/button';
@@ -40,6 +41,11 @@ interface Props {
   visualElement: boolean;
   children: ReactNode;
 }
+
+const StyledDiv = styled.div<{ embed: ImageEmbed }>`
+  ${props => (!props.embed.alt ? 'border: 2px solid rgba(209,55,46,0.3);' : '')}
+  z-index: 1;
+`;
 
 const SlateImage = ({
   active,
@@ -77,11 +83,11 @@ const SlateImage = ({
   };
 
   return (
-    <div
+    <StyledDiv
       {...attributes}
       draggable={!visualElement && !editMode}
       className={constructFigureClassName()}
-      css={!embed.alt && { border: '2px solid rgba(209,55,46,0.3);' }}>
+      embed={embed}>
       <FigureButtons
         tooltip={t('form.image.removeImage')}
         onRemoveClick={onRemoveClick}
@@ -123,7 +129,7 @@ const SlateImage = ({
         </Button>
       )}
       {children}
-    </div>
+    </StyledDiv>
   );
 };
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2869

Paragrafer i Slate skal ikke lenger dekke for hitboxen til bilder. Feilen kan sees her: https://ed.test.ndla.no/subject-matter/learning-resource/31293/edit/nb. Der er ikke hele bildet som er plassert ved siden av tekst klikkbart.

Hvordan teste:
1. Åpne den samme artikkelen i PR-instans.
2. Sjekk at hele bildet er klikkbart og åpner redigering ved klikk.