### PR TITLE
Reverter endring som forsvant i merge av slate.

### DIFF
--- a/src/components/DisplayEmbed/DisplayExternal.jsx
+++ b/src/components/DisplayEmbed/DisplayExternal.jsx
@@ -51,26 +51,11 @@ export class DisplayExternal extends Component {
     const { editor, element, embed } = this.props;
 
     if (properties.url !== embed.url || properties.path !== embed.path) {
-      if (properties.resource === 'h5p') {
-        Transforms.setNodes(
-          editor,
-          {
-            data: {
-              ...properties,
-              url: embed.url,
-              path: embed.path,
-            },
-          },
-          { at: ReactEditor.findPath(editor, element) },
-        );
-        this.iframe.src = embed.url;
-      } else {
-        Transforms.setNodes(
-          editor,
-          { data: { ...properties } },
-          { at: ReactEditor.findPath(editor, element) },
-        );
-      }
+      Transforms.setNodes(
+        editor,
+        { data: { ...properties } },
+        { at: ReactEditor.findPath(editor, element) },
+      );
       this.closeEditEmbed();
     }
   }


### PR DESCRIPTION
Redigerign av h5p skal oppdatere artikkelen slik som tidligere. Dette blei fiksa tidligere men forsvant i merge.

Test
* Rediger h5p i artikkel og sjekk at lagreknapp blir blå etter at du har lagra h5p.