### PR TITLE
Adding relevanceId as param to create topic-resource

### DIFF
--- a/src/modules/taxonomy/topicresouces/index.ts
+++ b/src/modules/taxonomy/topicresouces/index.ts
@@ -80,6 +80,7 @@ async function createDeleteUpdateTopicResources(
         createTopicResource({
           topicid: item.id,
           primary: item.primary,
+          relevanceId: item.relevanceId,
           resourceId, // Not consistent!
         }),
       ),


### PR DESCRIPTION
Fixes NDLANO/Issues#2873

Legger på ekstra parameter for å ta vare på relevance.

Test:
* Åpne en ressurs-artikkel og legg den under et emne i taksonomi.
* Velg at ressursen skal være tilleggstoff og klikk "Lagre taksonomi"
* Lukk og åpne taksonomiblokk og sjekk at ressursen er tilleggstoff.