### PR TITLE
Setter samme utseende på matte som i frontend.

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -50,9 +50,13 @@
 
 /* Should be moved to Article component in @ndla/ui */
 /* stylelint-disable-next-line */
-mjx-container[jax='CHTML'][display='true'] {
-  margin: 0;
-  display: inline-block !important;
+mjx-container.MathJax[jax='CHTML'][display='true'] {
+  display: inline-flex !important;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 1px 0;
+  margin: 5px 0;
+  max-width: -webkit-stretch;
 }
 
 /* Override @ndla/ui styles */


### PR DESCRIPTION
Plusser på 1px padding for å unngå at formler barberes i topp og bunn.

Matte som forhåndsvises i ed blir litt anderledes enn i frontend. Dette gjør at ting blir likere.

Test:
* Åpne artikkel med matte som også er publisert.
* Klikk på grønt ikon i toppen for å sjå artikkel på test.ndla.no
* Klikk på forhåndsvisning og sammenlig utseende på artikkelen i dei to fanene.

Artikkel 31308 kan brukes til test.