### PR TITLE
Preserve search object on updating sort options

### DIFF
--- a/src/containers/SearchPage/SearchContainer.tsx
+++ b/src/containers/SearchPage/SearchContainer.tsx
@@ -84,7 +84,7 @@ const SearchContainer = ({ searchHook, type, location, history }: Props) => {
   const onQueryPush = useMemo(() => debounce(_onQueryPush, 400), []);
 
   const onSortOrderChange = (sort: string): void => {
-    onQueryPush({ sort, page: 1 });
+    onQueryPush({ ...searchObject, sort, page: 1 });
   };
 
   const lastPage = results?.totalCount


### PR DESCRIPTION
Fixes NDLANO/Issues#2879

Ved endring av sortering på søkeside ble alle andre parametre tilbakestilt. Denne PRen sørger for at parametrene ikke blir tilbakestilt lenger.

Hvordan teste:
- Åpne søkeside
- Gjør et søk med noe tekst og parametre
- Endre sortering og bekreft at antallet resultater er likt og at parametre ikke blir tilbakestilt.