### PR TITLE
Update slate content on reverting article version

### DIFF
--- a/src/components/SlateEditor/PlainTextEditor.tsx
+++ b/src/components/SlateEditor/PlainTextEditor.tsx
@@ -39,8 +39,7 @@ const PlainTextEditor = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const editor = useMemo(() => withHistory(withReact(withPlugins(createEditor(), plugins))), []);
 
-  const formikContext = useFormikContext<LearningResourceFormikType>();
-  const { status, setStatus } = formikContext;
+  const { status, setStatus } = useFormikContext<LearningResourceFormikType>();
 
   useEffect(() => {
     if (status === 'revertVersion') {

--- a/src/components/SlateEditor/PlainTextEditor.tsx
+++ b/src/components/SlateEditor/PlainTextEditor.tsx
@@ -6,13 +6,14 @@
  *
  */
 
-import { useMemo, FocusEvent } from 'react';
+import { useMemo, FocusEvent, useEffect } from 'react';
 import { createEditor, Descendant } from 'slate';
 import { Slate, Editable, ReactEditor, withReact } from 'slate-react';
 import { withHistory } from 'slate-history';
-import { FormikHandlers } from 'formik';
+import { FormikHandlers, useFormikContext } from 'formik';
 import { SlatePlugin } from './interfaces';
 import withPlugins from './utils/withPlugins';
+import { LearningResourceFormikType } from '../../containers/FormikForm/articleFormHooks';
 
 interface Props {
   id: string;
@@ -37,6 +38,18 @@ const PlainTextEditor = ({
 }: Props) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const editor = useMemo(() => withHistory(withReact(withPlugins(createEditor(), plugins))), []);
+
+  const formikContext = useFormikContext<LearningResourceFormikType>();
+  const { status, setStatus } = formikContext;
+
+  useEffect(() => {
+    if (status === 'revertVersion') {
+      ReactEditor.deselect(editor);
+      editor.children = value;
+      setStatus(undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
 
   return (
     <Slate

--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -36,7 +36,6 @@ const slateEditorDivStyle = css`
 `;
 
 interface Props {
-  // value: Descendant[];
   initialValue: Descendant[];
   onChange: (descendant: Descendant[]) => void;
   className?: string;

--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -55,8 +55,7 @@ const RichTextEditor = ({ className, placeholder, plugins, value, onChange, subm
   const [isFirstNormalize, setIsFirstNormalize] = useState(true);
   const prevSubmitted = useRef(submitted);
 
-  const formikContext = useFormikContext<LearningResourceFormikType>();
-  const { status, setStatus } = formikContext;
+  const { status, setStatus } = useFormikContext<LearningResourceFormikType>();
 
   useEffect(() => {
     Editor.normalize(editor, { force: true });

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -56,7 +56,7 @@ import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
 import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
 import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
 import { ConvertedDraftType, LocaleType } from '../../../../interfaces';
-import { ArticleFormikType } from '../../../FormikForm/articleFormHooks';
+import { LearningResourceFormikType } from '../../../FormikForm/articleFormHooks';
 import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
@@ -140,11 +140,11 @@ type Props = {
   locale: LocaleType;
   article: Partial<ConvertedDraftType>;
   handleBlur: (evt: { target: { name: string } }) => void;
-  values: ArticleFormikType;
+  values: LearningResourceFormikType;
   handleSubmit: () => Promise<void>;
   initialContent: Descendant[];
 } & CustomWithTranslation & {
-    formik: FormikContextType<ArticleFormikType>;
+    formik: FormikContextType<LearningResourceFormikType>;
   } & SessionProps;
 
 const LearningResourceContent = ({

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -56,7 +56,7 @@ import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
 import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
 import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
 import { ConvertedDraftType, LocaleType } from '../../../../interfaces';
-import { LearningResourceFormikType } from '../../../FormikForm/articleFormHooks';
+import { ArticleFormikType } from '../../../FormikForm/articleFormHooks';
 import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
@@ -140,10 +140,11 @@ type Props = {
   locale: LocaleType;
   article: Partial<ConvertedDraftType>;
   handleBlur: (evt: { target: { name: string } }) => void;
-  values: LearningResourceFormikType;
+  values: ArticleFormikType;
   handleSubmit: () => Promise<void>;
+  initialContent: Descendant[];
 } & CustomWithTranslation & {
-    formik: FormikContextType<LearningResourceFormikType>;
+    formik: FormikContextType<ArticleFormikType>;
   } & SessionProps;
 
 const LearningResourceContent = ({
@@ -153,6 +154,7 @@ const LearningResourceContent = ({
   values: { id, language, creators, published },
   handleSubmit,
   locale,
+  initialContent,
 }: Props) => {
   const handleSubmitRef = useRef(handleSubmit);
 
@@ -206,7 +208,7 @@ const LearningResourceContent = ({
             </FieldHeader>
             <RichTextEditor
               placeholder={t('form.content.placeholder')}
-              value={value}
+              initialValue={initialContent}
               submitted={isSubmitting}
               plugins={plugins(articleLanguage ?? '', locale, handleSubmitRef)}
               data-cy="learning-resource-content"

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -40,7 +40,6 @@ import { conceptPlugin } from '../../../../components/SlateEditor/plugins/concep
 import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
 import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
 import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
-// import pasteHandler from '../../../../components/SlateEditor/plugins/pastehandler';
 import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
 
 import { tablePlugin } from '../../../../components/SlateEditor/plugins/table';
@@ -142,7 +141,6 @@ type Props = {
   handleBlur: (evt: { target: { name: string } }) => void;
   values: LearningResourceFormikType;
   handleSubmit: () => Promise<void>;
-  initialContent: Descendant[];
 } & CustomWithTranslation & {
     formik: FormikContextType<LearningResourceFormikType>;
   } & SessionProps;
@@ -154,7 +152,6 @@ const LearningResourceContent = ({
   values: { id, language, creators, published },
   handleSubmit,
   locale,
-  initialContent,
 }: Props) => {
   const handleSubmitRef = useRef(handleSubmit);
 
@@ -208,7 +205,7 @@ const LearningResourceContent = ({
             </FieldHeader>
             <RichTextEditor
               placeholder={t('form.content.placeholder')}
-              initialValue={initialContent}
+              value={value}
               submitted={isSubmitting}
               plugins={plugins(articleLanguage ?? '', locale, handleSubmitRef)}
               data-cy="learning-resource-content"

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { FormikHelpers, useFormikContext } from 'formik';
@@ -40,8 +39,7 @@ const LearningResourcePanels = ({
   const { userAccess } = useSession();
   const locale = i18n.language;
   const formikContext = useFormikContext<LearningResourceFormikType>();
-  const { values, setValues, errors, handleBlur } = formikContext;
-  const [initialContent, setInitialContent] = useState(values.content);
+  const { values, setValues, errors, handleBlur, setStatus } = formikContext;
 
   const showTaxonomySection = !!values.id && !!userAccess?.includes(TAXONOMY_WRITE_SCOPE);
 
@@ -60,7 +58,6 @@ const LearningResourcePanels = ({
           values={values}
           article={article}
           locale={locale}
-          initialContent={initialContent}
         />
       </AccordionSection>
       {showTaxonomySection && (
@@ -115,7 +112,7 @@ const LearningResourcePanels = ({
             getArticle={getArticle}
             getInitialValues={getInitialValues}
             setValues={setValues}
-            setContent={setInitialContent}
+            setStatus={setStatus}
           />
         </AccordionSection>
       )}

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { FormikHelpers, useFormikContext } from 'formik';
@@ -9,19 +10,19 @@ import GrepCodesField from '../../../FormikForm/GrepCodesField';
 import LearningResourceTaxonomy from './LearningResourceTaxonomy';
 import LearningResourceContent from './LearningResourceContent';
 import { ConvertedDraftType, SearchResult } from '../../../../interfaces';
-import { LearningResourceFormikType } from '../../../FormikForm/articleFormHooks';
 import { UpdatedDraftApiType } from '../../../../modules/draft/draftApiInterfaces';
 import { useSession } from '../../../Session/SessionProvider';
+import { ArticleFormikType } from '../../../FormikForm/articleFormHooks';
 
 interface Props {
   fetchSearchTags: (input: string, language: string) => Promise<SearchResult>;
   handleSubmit: (
-    values: LearningResourceFormikType,
-    formikHelpers: FormikHelpers<LearningResourceFormikType>,
+    values: ArticleFormikType,
+    formikHelpers: FormikHelpers<ArticleFormikType>,
   ) => Promise<void>;
   article: Partial<ConvertedDraftType>;
   formIsDirty: boolean;
-  getInitialValues: (article: Partial<ConvertedDraftType>) => LearningResourceFormikType;
+  getInitialValues: (article: Partial<ConvertedDraftType>) => ArticleFormikType;
   updateNotes: (art: UpdatedDraftApiType) => Promise<ConvertedDraftType>;
   getArticle: (preview: boolean) => UpdatedDraftApiType;
 }
@@ -38,8 +39,9 @@ const LearningResourcePanels = ({
   const { t, i18n } = useTranslation();
   const { userAccess } = useSession();
   const locale = i18n.language;
-  const formikContext = useFormikContext<LearningResourceFormikType>();
+  const formikContext = useFormikContext<ArticleFormikType>();
   const { values, setValues, errors, handleBlur } = formikContext;
+  const [initialContent, setInitialContent] = useState(values.content);
 
   const showTaxonomySection = !!values.id && !!userAccess?.includes(TAXONOMY_WRITE_SCOPE);
 
@@ -58,6 +60,7 @@ const LearningResourcePanels = ({
           values={values}
           article={article}
           locale={locale}
+          initialContent={initialContent}
         />
       </AccordionSection>
       {showTaxonomySection && (
@@ -112,6 +115,7 @@ const LearningResourcePanels = ({
             getArticle={getArticle}
             getInitialValues={getInitialValues}
             setValues={setValues}
+            setContent={setInitialContent}
           />
         </AccordionSection>
       )}

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -12,17 +12,17 @@ import LearningResourceContent from './LearningResourceContent';
 import { ConvertedDraftType, SearchResult } from '../../../../interfaces';
 import { UpdatedDraftApiType } from '../../../../modules/draft/draftApiInterfaces';
 import { useSession } from '../../../Session/SessionProvider';
-import { ArticleFormikType } from '../../../FormikForm/articleFormHooks';
+import { LearningResourceFormikType } from '../../../FormikForm/articleFormHooks';
 
 interface Props {
   fetchSearchTags: (input: string, language: string) => Promise<SearchResult>;
   handleSubmit: (
-    values: ArticleFormikType,
-    formikHelpers: FormikHelpers<ArticleFormikType>,
+    values: LearningResourceFormikType,
+    formikHelpers: FormikHelpers<LearningResourceFormikType>,
   ) => Promise<void>;
   article: Partial<ConvertedDraftType>;
   formIsDirty: boolean;
-  getInitialValues: (article: Partial<ConvertedDraftType>) => ArticleFormikType;
+  getInitialValues: (article: Partial<ConvertedDraftType>) => LearningResourceFormikType;
   updateNotes: (art: UpdatedDraftApiType) => Promise<ConvertedDraftType>;
   getArticle: (preview: boolean) => UpdatedDraftApiType;
 }
@@ -39,7 +39,7 @@ const LearningResourcePanels = ({
   const { t, i18n } = useTranslation();
   const { userAccess } = useSession();
   const locale = i18n.language;
-  const formikContext = useFormikContext<ArticleFormikType>();
+  const formikContext = useFormikContext<LearningResourceFormikType>();
   const { values, setValues, errors, handleBlur } = formikContext;
   const [initialContent, setInitialContent] = useState(values.content);
 

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { useFormikContext } from 'formik';
@@ -37,6 +38,8 @@ const TopicArticleAccordionPanels = ({
   const { userAccess } = useSession();
   const formikContext = useFormikContext<TopicArticleFormikType>();
   const { values, handleBlur, errors, setValues } = formikContext;
+  const [initialContent, setInitialContent] = useState(values.content);
+
   return (
     <Accordions>
       <AccordionSection
@@ -45,7 +48,12 @@ const TopicArticleAccordionPanels = ({
         className={'u-4/6@desktop u-push-1/6@desktop'}
         hasError={!!(errors.title || errors.introduction || errors.content || errors.visualElement)}
         startOpen>
-        <TopicArticleContent handleSubmit={handleSubmit} handleBlur={handleBlur} values={values} />
+        <TopicArticleContent
+          handleSubmit={handleSubmit}
+          handleBlur={handleBlur}
+          values={values}
+          initialContent={initialContent}
+        />
       </AccordionSection>
       {values.id && !!userAccess?.includes(TAXONOMY_WRITE_SCOPE) && (
         <AccordionSection
@@ -99,6 +107,7 @@ const TopicArticleAccordionPanels = ({
             getArticle={getArticle}
             getInitialValues={getInitialValues}
             setValues={setValues}
+            setContent={setInitialContent}
           />
         </AccordionSection>
       )}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { useFormikContext } from 'formik';
@@ -37,8 +36,7 @@ const TopicArticleAccordionPanels = ({
   const locale = i18n.language;
   const { userAccess } = useSession();
   const formikContext = useFormikContext<TopicArticleFormikType>();
-  const { values, handleBlur, errors, setValues } = formikContext;
-  const [initialContent, setInitialContent] = useState(values.content);
+  const { values, handleBlur, errors, setValues, setStatus } = formikContext;
 
   return (
     <Accordions>
@@ -48,12 +46,7 @@ const TopicArticleAccordionPanels = ({
         className={'u-4/6@desktop u-push-1/6@desktop'}
         hasError={!!(errors.title || errors.introduction || errors.content || errors.visualElement)}
         startOpen>
-        <TopicArticleContent
-          handleSubmit={handleSubmit}
-          handleBlur={handleBlur}
-          values={values}
-          initialContent={initialContent}
-        />
+        <TopicArticleContent handleSubmit={handleSubmit} handleBlur={handleBlur} values={values} />
       </AccordionSection>
       {values.id && !!userAccess?.includes(TAXONOMY_WRITE_SCOPE) && (
         <AccordionSection
@@ -107,7 +100,7 @@ const TopicArticleAccordionPanels = ({
             getArticle={getArticle}
             getInitialValues={getInitialValues}
             setValues={setValues}
-            setContent={setInitialContent}
+            setStatus={setStatus}
           />
         </AccordionSection>
       )}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -10,6 +10,7 @@ import { useRef, useEffect, RefObject, useMemo, useState } from 'react';
 import { FieldHeader } from '@ndla/forms';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'formik';
+import { Descendant } from 'slate';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Tooltip from '@ndla/tooltip';
@@ -40,11 +41,11 @@ import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
 import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
 import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
 import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
-import { TopicArticleFormikType } from '../../../FormikForm/articleFormHooks';
 import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { useSession } from '../../../Session/SessionProvider';
+import { TopicArticleFormikType } from '../../../FormikForm/articleFormHooks';
 
 const byLineStyle = css`
   display: flex;
@@ -101,6 +102,7 @@ interface Props {
   values: TopicArticleFormikType;
   handleBlur: (evt: { target: { name: string } }) => void;
   handleSubmit: () => Promise<void>;
+  initialContent: Descendant[];
 }
 
 const TopicArticleContent = (props: Props) => {
@@ -159,7 +161,7 @@ const TopicArticleContent = (props: Props) => {
             </FieldHeader>
             <RichTextEditor
               placeholder={t('form.content.placeholder')}
-              value={value}
+              initialValue={props.initialContent}
               submitted={isSubmitting}
               plugins={plugins}
               onChange={value => {

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -10,7 +10,6 @@ import { useRef, useEffect, RefObject, useMemo, useState } from 'react';
 import { FieldHeader } from '@ndla/forms';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'formik';
-import { Descendant } from 'slate';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Tooltip from '@ndla/tooltip';
@@ -102,7 +101,6 @@ interface Props {
   values: TopicArticleFormikType;
   handleBlur: (evt: { target: { name: string } }) => void;
   handleSubmit: () => Promise<void>;
-  initialContent: Descendant[];
 }
 
 const TopicArticleContent = (props: Props) => {
@@ -161,7 +159,7 @@ const TopicArticleContent = (props: Props) => {
             </FieldHeader>
             <RichTextEditor
               placeholder={t('form.content.placeholder')}
-              initialValue={props.initialContent}
+              value={value}
               submitted={isSubmitting}
               plugins={plugins}
               onChange={value => {

--- a/src/containers/FormikForm/VersionAndNotesPanel.tsx
+++ b/src/containers/FormikForm/VersionAndNotesPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState, Fragment } from 'react';
 import { spacing, colors } from '@ndla/core';
 import { css } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
+import { Descendant } from 'slate';
 import Accordion, {
   AccordionWrapper,
   AccordionPanel,
@@ -49,6 +50,7 @@ interface Props {
   getInitialValues: (article: Partial<ConvertedDraftType>) => ArticleFormikType;
   setValues(values: ArticleFormikType, shouldValidate?: boolean): void;
   getArticle: (preview: boolean) => UpdatedDraftApiType;
+  setContent: (content: Descendant[]) => void;
 }
 
 const VersionAndNotesPanel = ({
@@ -57,6 +59,7 @@ const VersionAndNotesPanel = ({
   getInitialValues,
   setValues,
   getArticle,
+  setContent,
 }: Props) => {
   const { t } = useTranslation();
   const [versions, setVersions] = useState<DraftApiType[]>([]);
@@ -116,6 +119,7 @@ const VersionAndNotesPanel = ({
         await transformArticleFromApiVersion({ ...newArticle, status: version.status }, language),
       );
 
+      setContent(newValues.content);
       setValues(newValues);
       createMessage({
         message: t('form.resetToProd.success'),

--- a/src/containers/FormikForm/VersionAndNotesPanel.tsx
+++ b/src/containers/FormikForm/VersionAndNotesPanel.tsx
@@ -10,7 +10,6 @@ import { useEffect, useState, Fragment } from 'react';
 import { spacing, colors } from '@ndla/core';
 import { css } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
-import { Descendant } from 'slate';
 import Accordion, {
   AccordionWrapper,
   AccordionPanel,
@@ -55,7 +54,7 @@ interface Props {
     shouldValidate?: boolean,
   ): void;
   getArticle: (preview: boolean) => UpdatedDraftApiType;
-  setContent: (content: Descendant[]) => void;
+  setStatus: (status?: any) => void;
 }
 
 const VersionAndNotesPanel = ({
@@ -64,7 +63,7 @@ const VersionAndNotesPanel = ({
   getInitialValues,
   setValues,
   getArticle,
-  setContent,
+  setStatus,
 }: Props) => {
   const { t } = useTranslation();
   const [versions, setVersions] = useState<DraftApiType[]>([]);
@@ -124,8 +123,8 @@ const VersionAndNotesPanel = ({
         await transformArticleFromApiVersion({ ...newArticle, status: version.status }, language),
       );
 
-      setContent(newValues.content);
       setValues(newValues);
+      setStatus('revertVersion');
       createMessage({
         message: t('form.resetToProd.success'),
         severity: 'success',

--- a/src/containers/FormikForm/VersionAndNotesPanel.tsx
+++ b/src/containers/FormikForm/VersionAndNotesPanel.tsx
@@ -31,7 +31,7 @@ import * as articleApi from '../../modules/article/articleApi';
 import Spinner from '../../components/Spinner';
 import { ConvertedDraftType, Note } from '../../interfaces';
 import { DraftApiType, UpdatedDraftApiType } from '../../modules/draft/draftApiInterfaces';
-import { ArticleFormikType } from './articleFormHooks';
+import { LearningResourceFormikType, TopicArticleFormikType } from './articleFormHooks';
 import { useMessages } from '../Messages/MessagesProvider';
 
 const paddingPanelStyleInside = css`
@@ -47,8 +47,13 @@ const getUser = (userId: string, allUsers: SimpleUserType[]) => {
 interface Props {
   articleId: number;
   article: Partial<ConvertedDraftType>;
-  getInitialValues: (article: Partial<ConvertedDraftType>) => ArticleFormikType;
-  setValues(values: ArticleFormikType, shouldValidate?: boolean): void;
+  getInitialValues: (
+    article: Partial<ConvertedDraftType>,
+  ) => LearningResourceFormikType | TopicArticleFormikType;
+  setValues(
+    values: LearningResourceFormikType | TopicArticleFormikType,
+    shouldValidate?: boolean,
+  ): void;
   getArticle: (preview: boolean) => UpdatedDraftApiType;
   setContent: (content: Descendant[]) => void;
 }

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -57,6 +57,7 @@ export interface ArticleFormikType {
   title?: Descendant[];
   introduction?: Descendant[];
   metaDescription?: Descendant[];
+  content: Descendant[];
   agreementId?: number;
   articleType: string;
   status?: DraftStatus;
@@ -82,14 +83,6 @@ export interface ArticleFormikType {
   relatedContent: (DraftApiType | RelatedContent)[];
 }
 
-export interface LearningResourceFormikType extends ArticleFormikType {
-  content: Descendant[];
-}
-
-export interface TopicArticleFormikType extends ArticleFormikType {
-  content: Descendant[];
-}
-
 type HooksInputObject<T> = {
   getInitialValues: (article: Partial<ConvertedDraftType>) => T;
   article: Partial<ConvertedDraftType>;
@@ -110,9 +103,7 @@ type HooksInputObject<T> = {
   isNewlyCreated: boolean;
 };
 
-export function useArticleFormHooks<
-  T extends LearningResourceFormikType | TopicArticleFormikType | ArticleFormikType
->({
+export function useArticleFormHooks<T extends ArticleFormikType>({
   getInitialValues,
   article,
   t,

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -57,7 +57,6 @@ export interface ArticleFormikType {
   title?: Descendant[];
   introduction?: Descendant[];
   metaDescription?: Descendant[];
-  content: Descendant[];
   agreementId?: number;
   articleType: string;
   status?: DraftStatus;
@@ -83,6 +82,14 @@ export interface ArticleFormikType {
   relatedContent: (DraftApiType | RelatedContent)[];
 }
 
+export interface LearningResourceFormikType extends ArticleFormikType {
+  content: Descendant[];
+}
+
+export interface TopicArticleFormikType extends ArticleFormikType {
+  content: Descendant[];
+}
+
 type HooksInputObject<T> = {
   getInitialValues: (article: Partial<ConvertedDraftType>) => T;
   article: Partial<ConvertedDraftType>;
@@ -103,7 +110,9 @@ type HooksInputObject<T> = {
   isNewlyCreated: boolean;
 };
 
-export function useArticleFormHooks<T extends ArticleFormikType>({
+export function useArticleFormHooks<
+  T extends LearningResourceFormikType | TopicArticleFormikType | ArticleFormikType
+>({
   getInitialValues,
   article,
   t,


### PR DESCRIPTION
Fixes NDLANO/Issues#2892

Slate editors vil nå endre seg ved tilbakestilling til en eldre versjon i læringsressurs. Da vil alle slate-felter oppdatere seg med verdiene fra den gamle versjonen.

Hvordan teste:
1. Åpne en læringsressurs.
2. Tilbakestill til en eldre versjon i versjonsloggen.
3. Alle felter i formen skal oppdateres til verdiene som er i den tilbakestilte versjonen.