### PR TITLE
Viser ikon for bruk av innhold kun dersom dersom bruk.

### DIFF
--- a/src/components/HeaderWithLanguage/EmbedInformation/EmbedConnection.tsx
+++ b/src/components/HeaderWithLanguage/EmbedInformation/EmbedConnection.tsx
@@ -77,14 +77,7 @@ const EmbedConnection = ({ id, type, articles, setArticles, concepts, setConcept
   }, [id, type, setArticles, setConcepts]);
 
   if (!articles?.length && !concepts?.length) {
-    return (
-      <Tooltip
-        tooltip={t('form.embedConnections.notInUse', {
-          resource: t(`form.embedConnections.type.${type}`),
-        })}>
-        <SubjectMaterial css={normalPaddingCSS} />
-      </Tooltip>
-    );
+    return null;
   }
 
   return (

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -167,13 +167,10 @@ const HeaderStatusInformation = ({
         {articleConnections}
         {conceptConnecions}
         {learningpathConnections}
-      </Splitter>
-      <Splitter disableSplitter={indentLeft}>
         {published &&
           (taxonomyPaths && taxonomyPaths?.length > 0 ? publishedIconLink : publishedIcon)}
         {multipleTaxonomyIcon}
       </Splitter>
-      {imageConnections}
     </>
   );
 

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1069,7 +1069,6 @@ const phrases = {
         concept: 'Uses of the concept in articles',
         article: 'Uses of the article in other articles',
       },
-      notInUse: 'No uses of the {{resource}} in articles and/or concepts were found',
       articles: '1 article',
       articles_plural: '{{count}} articles',
       concepts: '1 concept',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1070,7 +1070,6 @@ const phrases = {
         concept: 'Bruk av forklaringen i artikler',
         article: 'Bruk av artikkelen i andre artikler',
       },
-      notInUse: 'Fant ingen artikler eller forklaringer som bruker {{resource}}',
       articles: '{{count}} artikkel',
       articles_plural: '{{count}} artikler',
       concepts: '1 forklaring',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1070,7 +1070,6 @@ const phrases = {
         concept: 'Bruk av forklaringa i artikler',
         article: 'Bruk av artikkelen i andre artiklar',
       },
-      notInUse: 'Fant ingen artikler eller forklaringar som bruker {{resource}}',
       articles: '1 artikkel',
       articles_plural: '{{count}} artikler',
       concepts: '1 forklaring',


### PR DESCRIPTION
NDLA ønsker at ikon kun skal vises dersom det faktisk er bruk av innholdet.

Test:
* Ikon for at artikkel/bilde/lyd er brukt av andre skal kun vises dersom det faktisk er i bruk.