### PR TITLE
Viser meir korrekte overskrifter på sammenligning av versjoner.

### DIFF
--- a/src/components/PreviewDraft/PreviewProduction.tsx
+++ b/src/components/PreviewDraft/PreviewProduction.tsx
@@ -31,7 +31,7 @@ const PreviewProduction = ({
     <>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
-          {t('form.previewProductionArticle.draft')}
+          {t('form.previewProductionArticle.current')}
         </h2>
         <PreviewDraft
           article={firstEntity}
@@ -42,7 +42,7 @@ const PreviewProduction = ({
       </StyledPreviewTwoArticles>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
-          {t('form.previewProductionArticle.article')}
+          {t('form.previewProductionArticle.version', { revision: secondEntity.revision })}
         </h2>
         <PreviewDraft
           article={secondEntity}

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -584,9 +584,9 @@ const phrases = {
       coverPhotoId: 'Meta image',
     },
     previewProductionArticle: {
-      button: 'Compare draft and article',
-      article: 'Published version',
-      draft: 'Draft',
+      button: 'Compare current version with old version',
+      version: 'Version {{revision}}',
+      current: 'Current version',
     },
     previewLanguageArticle: {
       button: 'Compare language versions',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -586,9 +586,9 @@ const phrases = {
       coverPhotoId: 'Metabilde',
     },
     previewProductionArticle: {
-      button: 'Sammenlign utkast og artikkel',
-      article: 'Publisert versjon',
-      draft: 'Utkast',
+      button: 'Sammenlign gjeldende versjon med gammel versjon',
+      version: 'Versjon {{revision}}',
+      current: 'Gjeldende versjon',
     },
     previewLanguageArticle: {
       button: 'Sammenlign språkversjoner',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -585,9 +585,9 @@ const phrases = {
       coverPhotoId: 'Metabilde',
     },
     previewProductionArticle: {
-      button: 'Samanlikn utkast og artikkel',
-      article: 'Publisert versjon',
-      draft: 'Utkast',
+      button: 'Samanlikn gjeldande versjon med gamal versjon',
+      version: 'Versjon {{revision}}',
+      current: 'Gjeldende versjon',
     },
     previewLanguageArticle: {
       button: 'Samanlikn språkversjonar',


### PR DESCRIPTION
Viser andre headers for versjoner.

Test:
Om du sammenligner med gamle versjoner skal det no stå revisjonsnummeret i header.