### PR TITLE
Make save as new work again

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -204,7 +204,6 @@ const LearningResourceForm = ({
     savedToServer,
     formikRef,
     initialValues,
-    setSaveAsNewVersion,
     handleSubmit,
     fetchStatusStateMachine,
     validateDraft,
@@ -217,7 +216,6 @@ const LearningResourceForm = ({
     updateArticle,
     updateArticleAndStatus,
     getArticleFromSlate,
-    isNewlyCreated,
   });
 
   const [translateOnContinue, setTranslateOnContinue] = useState(false);
@@ -268,8 +266,7 @@ const LearningResourceForm = ({
           savedToServer={savedToServer}
           getEntity={getArticle}
           onSaveClick={(saveAsNewVersion?: boolean) => {
-            setSaveAsNewVersion(saveAsNewVersion ?? false);
-            handleSubmit(values, formik);
+            handleSubmit(values, formik, saveAsNewVersion || false);
           }}
           entityStatus={article.status}
           fetchStatusStateMachine={fetchStatusStateMachine}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -192,7 +192,6 @@ const TopicArticleForm = (props: Props) => {
     savedToServer,
     formikRef,
     initialValues,
-    setSaveAsNewVersion,
     handleSubmit,
     fetchStatusStateMachine,
     validateDraft,
@@ -206,7 +205,6 @@ const TopicArticleForm = (props: Props) => {
     updateArticleAndStatus,
     licenses,
     getArticleFromSlate,
-    isNewlyCreated,
   });
 
   const [translateOnContinue, setTranslateOnContinue] = useState(false);
@@ -258,8 +256,7 @@ const TopicArticleForm = (props: Props) => {
           savedToServer={savedToServer}
           getEntity={getArticle}
           onSaveClick={saveAsNewVersion => {
-            setSaveAsNewVersion(saveAsNewVersion ?? false);
-            handleSubmit(values, formik);
+            handleSubmit(values, formik, saveAsNewVersion ?? false);
           }}
           entityStatus={article.status}
           fetchStatusStateMachine={fetchStatusStateMachine}

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -107,7 +107,6 @@ type HooksInputObject<T> = {
     initialValues: T;
     preview: boolean;
   }) => UpdatedDraftApiType;
-  isNewlyCreated: boolean;
 };
 
 export function useArticleFormHooks<
@@ -120,13 +119,11 @@ export function useArticleFormHooks<
   updateArticle,
   updateArticleAndStatus,
   getArticleFromSlate,
-  isNewlyCreated = false,
 }: HooksInputObject<T>) {
   const { id, revision, language } = article;
   const formikRef: any = useRef<any>(null); // TODO: Formik bruker any for denne ref'en men kanskje vi skulle gjort noe kulere?
   const { createMessage, applicationError } = useMessages();
   const [savedToServer, setSavedToServer] = useState(false);
-  const [saveAsNewVersion, setSaveAsNewVersion] = useState(isNewlyCreated);
   const initialValues = getInitialValues(article);
 
   useEffect(() => {
@@ -138,7 +135,11 @@ export function useArticleFormHooks<
     }
   }, [language, id]);
 
-  const handleSubmit = async (values: T, formikHelpers: FormikHelpers<T>): Promise<void> => {
+  const handleSubmit = async (
+    values: T,
+    formikHelpers: FormikHelpers<T>,
+    saveAsNew = false,
+  ): Promise<void> => {
     formikHelpers.setSubmitting(true);
     const initialStatus = articleStatus ? articleStatus.current : undefined;
     const newStatus = values.status?.current;
@@ -149,9 +150,7 @@ export function useArticleFormHooks<
       preview: false,
     });
 
-    const newArticle = saveAsNewVersion
-      ? { ...slateArticle, createNewVersion: true }
-      : slateArticle;
+    const newArticle = saveAsNew ? { ...slateArticle, createNewVersion: true } : slateArticle;
 
     let savedArticle: ConvertedDraftType;
     try {
@@ -210,7 +209,6 @@ export function useArticleFormHooks<
     savedToServer,
     formikRef,
     initialValues,
-    setSaveAsNewVersion,
     handleSubmit,
     fetchStatusStateMachine,
     validateDraft,

--- a/src/containers/GrepCodes/GrepCodesForm.tsx
+++ b/src/containers/GrepCodes/GrepCodesForm.tsx
@@ -82,7 +82,6 @@ const GrepCodesForm = ({
     updateArticle,
     updateArticleAndStatus,
     getArticleFromSlate: getArticle,
-    isNewlyCreated: false,
   });
 
   return (


### PR DESCRIPTION
Fixes NDLANO/Issues#2885

Bruk av state setter oppdaterer ikkje verdien før etter render, så det som sendes inn tas ikkje hensyn til. Gjorde det enkelt og sender inn en verdi som defaulter til false.

Dagens oppførsel er at dersom du bruker lagre som ny så lagres det vanlig, men neste lagring vil uansett lagre som ny fordi flagget er satt og ikkje tilbakestillt.

Test:
* Valget lagre som ny skal fungere som det skal.