### PR TITLE
2903 bugfix deletion of mathml in table cells

### DIFF
--- a/src/components/SlateEditor/plugins/paragraph/utils.ts
+++ b/src/components/SlateEditor/plugins/paragraph/utils.ts
@@ -8,11 +8,12 @@
 
 import { Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
+import { ParagraphElement } from '.';
 
 export const TYPE_PARAGRAPH = 'paragraph';
 
 export const defaultParagraphBlock = () =>
-  slatejsx('element', { type: TYPE_PARAGRAPH }, { text: '' });
+  slatejsx('element', { type: TYPE_PARAGRAPH }, { text: '' }) as ParagraphElement;
 
 export const getCurrentParagraph = (editor: Editor) => {
   if (!editor.selection?.anchor) return null;

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -248,10 +248,15 @@ export const tablePlugin = (editor: Editor) => {
     if (isTableCell(node)) {
       // Cells should only contain elements. If not, wrap content in paragraph
       if (!Element.isElementList(node.children)) {
-        return Transforms.wrapNodes(editor, defaultParagraphBlock(), {
-          at: path,
-          match: node => !Element.isElement(node),
-        });
+        return Transforms.wrapNodes(
+          editor,
+          { ...defaultParagraphBlock(), serializeAsText: true },
+          {
+            at: path,
+            match: n => n !== node,
+            mode: 'highest',
+          },
+        );
       }
     }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2903

Fikser en feil der mathml som ligger direkte i `<td>` blir fjernet i normalisering.

Hvordan teste:
1. Åpne /subject-matter/learning-resource/31330/edit/nb i PR-instans. Alle matteformler skal vises.
   - Lagreknappen blir aktivert, men det er fordi det mangler en celle i andre rad som automatisk blir lagt til.