### PR TITLE
2770 sync concept meta and visual

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ndla/forms": "1.0.29",
     "@ndla/howto": "1.1.14",
     "@ndla/icons": "1.3.1",
-    "@ndla/image-search": "1.1.24",
+    "@ndla/image-search": "1.1.30-alpha.5+059023e41",
     "@ndla/licenses": "1.0.7",
     "@ndla/listview": "1.0.29",
     "@ndla/modal": "1.1.10",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ndla/forms": "1.0.29",
     "@ndla/howto": "1.1.14",
     "@ndla/icons": "1.3.1",
-    "@ndla/image-search": "1.1.30-alpha.5+059023e41",
+    "@ndla/image-search": "2.0.0",
     "@ndla/licenses": "1.0.7",
     "@ndla/listview": "1.0.29",
     "@ndla/modal": "1.1.10",

--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -36,6 +36,8 @@ interface Props {
   image?: ImageApiType;
   updateImage: (imageMetadata: UpdatedImageMetadata, image: string | Blob) => void;
   inModal?: boolean;
+  showMetaImageCheckbox?: boolean;
+  onSaveAsMetaImage?: (image: ImageApiType) => void;
 }
 
 const ImageSearchAndUploader = ({
@@ -48,6 +50,8 @@ const ImageSearchAndUploader = ({
   searchImages,
   onError,
   inModal = false,
+  showMetaImageCheckbox,
+  onSaveAsMetaImage,
 }: Props) => {
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -71,6 +75,7 @@ const ImageSearchAndUploader = ({
               searchPlaceholder={t('imageSearch.placeholder')}
               searchButtonTitle={t('imageSearch.buttonTitle')}
               useImageTitle={t('imageSearch.useImage')}
+              metaImageCheckboxLabel={t('imageSearch.metaImageCheckboxLabel')}
               onImageSelect={onImageSelect}
               noResults={
                 <>
@@ -86,6 +91,8 @@ const ImageSearchAndUploader = ({
                 </>
               }
               onError={onError}
+              showMetaImageCheckbox={showMetaImageCheckbox}
+              onSaveAsMetaImage={onSaveAsMetaImage}
             />
           ),
         },

--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -36,8 +36,8 @@ interface Props {
   image?: ImageApiType;
   updateImage: (imageMetadata: UpdatedImageMetadata, image: string | Blob) => void;
   inModal?: boolean;
-  showMetaImageCheckbox?: boolean;
-  onSaveAsMetaImage?: (image: ImageApiType) => void;
+  showCheckbox?: boolean;
+  checkboxAction?: (image: ImageApiType) => void;
 }
 
 const ImageSearchAndUploader = ({
@@ -50,8 +50,8 @@ const ImageSearchAndUploader = ({
   searchImages,
   onError,
   inModal = false,
-  showMetaImageCheckbox,
-  onSaveAsMetaImage,
+  showCheckbox,
+  checkboxAction,
 }: Props) => {
   const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -75,7 +75,7 @@ const ImageSearchAndUploader = ({
               searchPlaceholder={t('imageSearch.placeholder')}
               searchButtonTitle={t('imageSearch.buttonTitle')}
               useImageTitle={t('imageSearch.useImage')}
-              metaImageCheckboxLabel={t('imageSearch.metaImageCheckboxLabel')}
+              checkboxLabel={t('imageSearch.visualElementCheckboxLabel')}
               onImageSelect={onImageSelect}
               noResults={
                 <>
@@ -91,8 +91,8 @@ const ImageSearchAndUploader = ({
                 </>
               }
               onError={onError}
-              showMetaImageCheckbox={showMetaImageCheckbox}
-              onSaveAsMetaImage={onSaveAsMetaImage}
+              showCheckbox={showCheckbox}
+              checkboxAction={checkboxAction}
             />
           ),
         },

--- a/src/components/ImageSearchAndUploader.tsx
+++ b/src/components/ImageSearchAndUploader.tsx
@@ -32,8 +32,8 @@ interface Props {
   onError: Function;
   searchImages: (query: ImageSearchQuery) => Promise<ImageSearchResult>;
   fetchImage: (id: string) => Promise<ImageApiType>;
-  showMetaImageCheckbox?: boolean;
-  onSaveAsMetaImage?: (image: ImageApiType) => void;
+  showCheckbox?: boolean;
+  checkboxAction?: (image: ImageApiType) => void;
 }
 
 const ImageSearchAndUploader = ({
@@ -44,8 +44,8 @@ const ImageSearchAndUploader = ({
   onError,
   searchImages,
   fetchImage,
-  showMetaImageCheckbox,
-  onSaveAsMetaImage,
+  showCheckbox,
+  checkboxAction,
 }: Props) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const { t } = useTranslation();
@@ -69,7 +69,7 @@ const ImageSearchAndUploader = ({
               searchPlaceholder={t('imageSearch.placeholder')}
               searchButtonTitle={t('imageSearch.buttonTitle')}
               useImageTitle={t('imageSearch.useImage')}
-              metaImageCheckboxLabel={t('imageSearch.metaImageCheckboxLabel')}
+              checkboxLabel={t('imageSearch.metaImageCheckboxLabel')}
               onImageSelect={onImageSelect}
               noResults={
                 <>
@@ -85,8 +85,8 @@ const ImageSearchAndUploader = ({
                 </>
               }
               onError={onError}
-              showMetaImageCheckbox={showMetaImageCheckbox}
-              onSaveAsMetaImage={onSaveAsMetaImage}
+              showCheckbox={showCheckbox}
+              checkboxAction={checkboxAction}
             />
           ),
         },

--- a/src/components/SlateEditor/VisualElementEditor.tsx
+++ b/src/components/SlateEditor/VisualElementEditor.tsx
@@ -6,8 +6,9 @@
  *
  */
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { FormikHandlers } from 'formik';
+import { isEqual } from 'lodash';
 import { Descendant, createEditor } from 'slate';
 import { Slate, Editable, withReact, RenderElementProps } from 'slate-react';
 import { withHistory } from 'slate-history';
@@ -43,6 +44,15 @@ const VisualElementEditor = ({ name, value, plugins, onChange, types, language }
     return <div {...attributes}>{children}</div>;
   };
 
+  useEffect(() => {
+    if (!isEqual(editor.children, value)) {
+      editor.children = value;
+      editor.history = { undos: [], redos: [] };
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
   return (
     <SlateProvider>
       <Slate
@@ -53,13 +63,12 @@ const VisualElementEditor = ({ name, value, plugins, onChange, types, language }
             target: {
               name,
               value: val,
-              type: 'SlateEditorValue',
             },
           });
         }}>
         <VisualElementPicker editor={editor} types={types} language={language} />
         <Editable
-          readOnly={true}
+          readOnly={false}
           renderElement={renderElement}
           onDragStart={e => {
             e.stopPropagation();

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.jsx
@@ -4,7 +4,7 @@ import VisualElementSearch from '../../../../containers/VisualElement/VisualElem
 import { defaultEmbedBlock } from '../embed/utils';
 import { defaultFileBlock } from '../file/utils';
 import VisualElementModalWrapper from '../../../../containers/VisualElement/VisualElementModalWrapper';
-import { onSaveAsMetaImage } from '../../../../containers/VisualElement/VisualElementSelectField';
+import { checkboxAction } from '../../../../containers/VisualElement/VisualElementSelectField';
 
 const SlateVisualElementPicker = ({
   articleLanguage,
@@ -15,8 +15,7 @@ const SlateVisualElementPicker = ({
   const formikContext = useFormikContext();
   const { values } = formikContext;
 
-  const showMetaImageCheckbox =
-    values.metaImageAlt !== undefined && values.metaImageId !== undefined;
+  const showCheckbox = values.metaImageAlt !== undefined && values.metaImageId !== undefined;
 
   const onVisualElementAdd = (visualElement, type = 'embed') => {
     if (type === 'embed') {
@@ -37,8 +36,8 @@ const SlateVisualElementPicker = ({
           handleVisualElementChange={onVisualElementAdd}
           closeModal={onVisualElementClose}
           setH5pFetchFail={setH5pFetchFail}
-          showMetaImageCheckbox={showMetaImageCheckbox}
-          onSaveAsMetaImage={image => onSaveAsMetaImage(image, formikContext)}
+          showCheckbox={showCheckbox}
+          checkboxAction={image => checkboxAction(image, formikContext)}
         />
       )}
     </VisualElementModalWrapper>

--- a/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
@@ -106,6 +106,7 @@ const ConceptModal = ({
       ? await updateConcept(upsertedConcept)
       : await createConcept(upsertedConcept);
     addConcept(savedConcept);
+    return savedConcept;
   };
 
   useEffect(() => {

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -12,6 +12,8 @@ import { TopicArticleFormikType } from '../../../FormikForm/articleFormHooks';
 import { ConvertedDraftType, SearchResult } from '../../../../interfaces';
 import { UpdatedDraftApiType } from '../../../../modules/draft/draftApiInterfaces';
 import { useSession } from '../../../Session/SessionProvider';
+import { ImageApiType } from '../../../../modules/image/imageApiInterfaces';
+import { onSaveAsVisualElement } from '../../../FormikForm/utils';
 
 interface Props {
   fetchSearchTags: (input: string, language: string) => Promise<SearchResult>;
@@ -70,7 +72,12 @@ const TopicArticleAccordionPanels = ({
         title={t('form.metadataSection')}
         className={'u-6/6'}
         hasError={!!(errors.metaDescription || errors.tags)}>
-        <MetaDataField article={article} fetchSearchTags={fetchSearchTags} />
+        <MetaDataField
+          article={article}
+          fetchSearchTags={fetchSearchTags}
+          showCheckbox={true}
+          checkboxAction={(image: ImageApiType) => onSaveAsVisualElement(image, formikContext)}
+        />
       </AccordionSection>
       <AccordionSection
         id={'topic-article-grepCodes'}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { useTranslation } from 'react-i18next';
 import { Accordions, AccordionSection } from '@ndla/accordion';
 import { useFormikContext } from 'formik';

--- a/src/containers/ConceptPage/CreateConcept.tsx
+++ b/src/containers/ConceptPage/CreateConcept.tsx
@@ -35,6 +35,7 @@ const CreateConcept = ({ locale, inModal = false, addConceptInModal }: Props) =>
     } else {
       navigate(toEditConcept(savedConcept.id, createdConcept.language));
     }
+    return savedConcept;
   };
 
   return (

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -60,7 +60,7 @@ const EditConcept = ({ isNewlyCreated }: Props) => {
         fetchConceptTags={fetchSearchTags}
         isNewlyCreated={isNewlyCreated}
         onUpdate={async concept => {
-          updateConcept(concept as ConceptPatchType);
+          return updateConcept(concept as ConceptPatchType);
         }}
         language={selectedLanguage!}
         subjects={subjects}

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { useFormikContext } from 'formik';
+import { FormikContextType, useFormikContext } from 'formik';
 import FormikField from '../../../components/FormikField';
 import AsyncSearchTags from '../../../components/Dropdown/asyncDropdown/AsyncSearchTags';
 import { MetaImageSearch } from '../../FormikForm';
@@ -16,6 +16,10 @@ import InlineImageSearch from './InlineImageSearch';
 import { SubjectType } from '../../../modules/taxonomy/taxonomyApiInterfaces';
 import MultiSelectDropdown from '../../../components/Dropdown/MultiSelectDropdown';
 import { ConceptTagsSearchResult } from '../../../modules/concept/conceptApiInterfaces';
+import { ImageApiType } from '../../../modules/image/imageApiInterfaces';
+import { convertFieldWithFallback } from '../../../util/convertFieldWithFallback';
+import { defaultEmbedBlock } from '../../../components/SlateEditor/plugins/embed/utils';
+import { ImageEmbed } from '../../../interfaces';
 
 interface Props {
   subjects: SubjectType[];
@@ -23,9 +27,31 @@ interface Props {
   inModal: boolean;
 }
 
+const onSaveAsVisualElement = (
+  image: ImageApiType,
+  formikContext: FormikContextType<ConceptFormValues>,
+) => {
+  const { setFieldValue } = formikContext;
+
+  if (image) {
+    const visualElement: ImageEmbed = {
+      resource: 'image',
+      resource_id: image.id,
+      size: 'full',
+      align: '',
+      alt: convertFieldWithFallback(image as Object, 'alttext', ''),
+      caption: convertFieldWithFallback(image as Object, 'caption', '') || '',
+    };
+    setTimeout(() => {
+      setFieldValue('visualElement', [defaultEmbedBlock(visualElement)], true);
+    }, 0);
+  }
+};
+
 const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
   const { t } = useTranslation();
-  const { values } = useFormikContext<ConceptFormValues>();
+  const formikContext = useFormikContext<ConceptFormValues>();
+  const { values } = formikContext;
 
   return (
     <>
@@ -38,6 +64,8 @@ const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
               metaImageId={field.value}
               setFieldTouched={form.setFieldTouched}
               showRemoveButton
+              showMetaImageCheckbox={true}
+              onSaveAsMetaImage={image => onSaveAsVisualElement(image, formikContext)}
               {...field}
             />
           )}

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -31,7 +31,7 @@ const onSaveAsVisualElement = (
   image: ImageApiType,
   formikContext: FormikContextType<ConceptFormValues>,
 ) => {
-  const { setFieldValue } = formikContext;
+  const { setFieldValue, setFieldTouched } = formikContext;
 
   if (image) {
     const visualElement: ImageEmbed = {
@@ -42,8 +42,9 @@ const onSaveAsVisualElement = (
       alt: convertFieldWithFallback(image as Object, 'alttext', ''),
       caption: convertFieldWithFallback(image as Object, 'caption', '') || '',
     };
+    setFieldValue('visualElement', [defaultEmbedBlock(visualElement)]);
     setTimeout(() => {
-      setFieldValue('visualElement', [defaultEmbedBlock(visualElement)], true);
+      setFieldTouched('visualElement', true, false);
     }, 0);
   }
 };

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -65,8 +65,8 @@ const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
               metaImageId={field.value}
               setFieldTouched={form.setFieldTouched}
               showRemoveButton
-              showMetaImageCheckbox={true}
-              onSaveAsMetaImage={image => onSaveAsVisualElement(image, formikContext)}
+              showCheckbox={true}
+              checkboxAction={image => onSaveAsVisualElement(image, formikContext)}
               {...field}
             />
           )}

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { FormikContextType, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
 import FormikField from '../../../components/FormikField';
 import AsyncSearchTags from '../../../components/Dropdown/asyncDropdown/AsyncSearchTags';
 import { MetaImageSearch } from '../../FormikForm';
@@ -16,38 +16,13 @@ import InlineImageSearch from './InlineImageSearch';
 import { SubjectType } from '../../../modules/taxonomy/taxonomyApiInterfaces';
 import MultiSelectDropdown from '../../../components/Dropdown/MultiSelectDropdown';
 import { ConceptTagsSearchResult } from '../../../modules/concept/conceptApiInterfaces';
-import { ImageApiType } from '../../../modules/image/imageApiInterfaces';
-import { convertFieldWithFallback } from '../../../util/convertFieldWithFallback';
-import { defaultEmbedBlock } from '../../../components/SlateEditor/plugins/embed/utils';
-import { ImageEmbed } from '../../../interfaces';
+import { onSaveAsVisualElement } from '../../FormikForm/utils';
 
 interface Props {
   subjects: SubjectType[];
   fetchTags: (input: string, language: string) => Promise<ConceptTagsSearchResult>;
   inModal: boolean;
 }
-
-const onSaveAsVisualElement = (
-  image: ImageApiType,
-  formikContext: FormikContextType<ConceptFormValues>,
-) => {
-  const { setFieldValue, setFieldTouched } = formikContext;
-
-  if (image) {
-    const visualElement: ImageEmbed = {
-      resource: 'image',
-      resource_id: image.id,
-      size: 'full',
-      align: '',
-      alt: convertFieldWithFallback(image as Object, 'alttext', ''),
-      caption: convertFieldWithFallback(image as Object, 'caption', '') || '',
-    };
-    setFieldValue('visualElement', [defaultEmbedBlock(visualElement)]);
-    setTimeout(() => {
-      setFieldTouched('visualElement', true, false);
-    }, 0);
-  }
-};
 
 const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
   const { t } = useTranslation();

--- a/src/containers/FormikForm/MetaDataField.jsx
+++ b/src/containers/FormikForm/MetaDataField.jsx
@@ -19,7 +19,7 @@ import { DRAFT_ADMIN_SCOPE } from '../../constants';
 import { ArticleShape } from '../../shapes';
 import { useSession } from '../Session/SessionProvider';
 
-const MetaDataField = ({ article, fetchSearchTags }) => {
+const MetaDataField = ({ article, fetchSearchTags, showCheckbox, checkboxAction }) => {
   const { t } = useTranslation();
   const { userAccess } = useSession();
   const plugins = [textTransformPlugin];
@@ -67,6 +67,8 @@ const MetaDataField = ({ article, fetchSearchTags }) => {
             metaImageId={field.value}
             setFieldTouched={form.setFieldTouched}
             showRemoveButton={false}
+            showCheckbox={showCheckbox}
+            checkboxAction={checkboxAction}
             {...field}
           />
         )}
@@ -78,6 +80,8 @@ const MetaDataField = ({ article, fetchSearchTags }) => {
 MetaDataField.propTypes = {
   article: ArticleShape.isRequired,
   fetchSearchTags: PropTypes.func,
+  showCheckbox: PropTypes.bool,
+  checkboxAction: PropTypes.func,
 };
 
 export default MetaDataField;

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -33,6 +33,8 @@ interface Props {
   setFieldTouched: (field: string, isTouched?: boolean, shouldValidate?: boolean) => void;
   onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
   showRemoveButton: boolean;
+  showMetaImageCheckbox: boolean;
+  onSaveAsMetaImage: (image: ImageApiType) => void;
 }
 
 const MetaImageSearch = ({
@@ -42,6 +44,8 @@ const MetaImageSearch = ({
   setFieldTouched,
   onChange,
   onImageLoad,
+  showMetaImageCheckbox,
+  onSaveAsMetaImage,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const [showImageSelect, setShowImageSelect] = useState(false);
@@ -124,6 +128,8 @@ const MetaImageSearch = ({
                 onError={onError}
                 updateImage={onImageUpdate}
                 image={image}
+                showMetaImageCheckbox={showMetaImageCheckbox}
+                onSaveAsMetaImage={onSaveAsMetaImage}
               />
             </ModalBody>
           </>

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -44,8 +44,8 @@ const MetaImageSearch = ({
   setFieldTouched,
   onChange,
   onImageLoad,
-  showCheckbox: showCheckbox,
-  checkboxAction: checkboxAction,
+  showCheckbox,
+  checkboxAction,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const [showImageSelect, setShowImageSelect] = useState(false);

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -33,8 +33,8 @@ interface Props {
   setFieldTouched: (field: string, isTouched?: boolean, shouldValidate?: boolean) => void;
   onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
   showRemoveButton: boolean;
-  showMetaImageCheckbox: boolean;
-  onSaveAsMetaImage: (image: ImageApiType) => void;
+  showCheckbox: boolean;
+  checkboxAction: (image: ImageApiType) => void;
 }
 
 const MetaImageSearch = ({
@@ -44,8 +44,8 @@ const MetaImageSearch = ({
   setFieldTouched,
   onChange,
   onImageLoad,
-  showMetaImageCheckbox,
-  onSaveAsMetaImage,
+  showCheckbox: showCheckbox,
+  checkboxAction: checkboxAction,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const [showImageSelect, setShowImageSelect] = useState(false);
@@ -128,8 +128,8 @@ const MetaImageSearch = ({
                 onError={onError}
                 updateImage={onImageUpdate}
                 image={image}
-                showMetaImageCheckbox={showMetaImageCheckbox}
-                onSaveAsMetaImage={onSaveAsMetaImage}
+                showCheckbox={showCheckbox}
+                checkboxAction={checkboxAction}
               />
             </ModalBody>
           </>

--- a/src/containers/FormikForm/formikConceptHooks.tsx
+++ b/src/containers/FormikForm/formikConceptHooks.tsx
@@ -84,21 +84,23 @@ export function useFetchConceptData(conceptId: number | undefined, locale: strin
   };
 
   const updateConceptAndStatus = async (
-    updatedConcept: ConceptPatchType,
+    conceptPatch: ConceptPatchType,
     newStatus: ConceptStatusType,
     dirty: boolean,
-  ) => {
+  ): Promise<ConceptApiType> => {
     const newConcept = dirty
-      ? await conceptApi.updateConcept(updatedConcept)
-      : await conceptApi.fetchConcept(updatedConcept.id, updatedConcept.language);
+      ? await conceptApi.updateConcept(conceptPatch)
+      : await conceptApi.fetchConcept(conceptPatch.id, conceptPatch.language);
     const convertedArticles = await fetchElementList(newConcept.articleIds);
-    const conceptChangedStatus = await conceptApi.updateConceptStatus(updatedConcept.id, newStatus);
-    setConcept({
+    const conceptChangedStatus = await conceptApi.updateConceptStatus(conceptPatch.id, newStatus);
+    const updatedConcept = {
       ...newConcept,
       status: conceptChangedStatus.status,
-    });
+    };
+    setConcept(updatedConcept);
     setConceptArticles(convertedArticles);
     setConceptChanged(false);
+    return updatedConcept;
   };
 
   return {

--- a/src/containers/FormikForm/utils.ts
+++ b/src/containers/FormikForm/utils.ts
@@ -1,0 +1,29 @@
+import { FormikContextType } from 'formik';
+import { defaultEmbedBlock } from '../../components/SlateEditor/plugins/embed/utils';
+import { ImageEmbed } from '../../interfaces';
+import { ImageApiType } from '../../modules/image/imageApiInterfaces';
+import { convertFieldWithFallback } from '../../util/convertFieldWithFallback';
+import { ConceptFormValues } from '../ConceptPage/conceptInterfaces';
+import { TopicArticleFormikType } from './articleFormHooks';
+
+export const onSaveAsVisualElement = (
+  image: ImageApiType,
+  formikContext: FormikContextType<ConceptFormValues> | FormikContextType<TopicArticleFormikType>,
+) => {
+  const { setFieldValue, setFieldTouched } = formikContext;
+
+  if (image) {
+    const visualElement: ImageEmbed = {
+      resource: 'image',
+      resource_id: image.id,
+      size: 'full',
+      align: '',
+      alt: convertFieldWithFallback(image as Object, 'alttext', ''),
+      caption: convertFieldWithFallback(image as Object, 'caption', '') || '',
+    };
+    setFieldValue('visualElement', [defaultEmbedBlock(visualElement)]);
+    setTimeout(() => {
+      setFieldTouched('visualElement', true, false);
+    }, 0);
+  }
+};

--- a/src/containers/FormikForm/utils.ts
+++ b/src/containers/FormikForm/utils.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { FormikContextType } from 'formik';
 import { defaultEmbedBlock } from '../../components/SlateEditor/plugins/embed/utils';
 import { ImageEmbed } from '../../interfaces';

--- a/src/containers/VisualElement/VisualElementSearch.jsx
+++ b/src/containers/VisualElement/VisualElementSearch.jsx
@@ -37,8 +37,8 @@ class VisualElementSearch extends Component {
       articleLanguage,
       videoTypes,
       i18n,
-      showMetaImageCheckbox,
-      onSaveAsMetaImage,
+      showCheckbox,
+      checkboxAction,
       t,
     } = this.props;
     const locale = i18n.language;
@@ -68,8 +68,8 @@ class VisualElementSearch extends Component {
                 metaData: image,
               });
             }}
-            showMetaImageCheckbox={showMetaImageCheckbox}
-            onSaveAsMetaImage={onSaveAsMetaImage}
+            showCheckbox={showCheckbox}
+            checkboxAction={checkboxAction}
           />
         );
       case 'video': {
@@ -239,8 +239,8 @@ VisualElementSearch.propTypes = {
   clearUploadedImage: PropTypes.func.isRequired,
   closeModal: PropTypes.func,
   videoTypes: PropTypes.array,
-  showMetaImageCheckbox: PropTypes.bool,
-  onSaveAsMetaImage: PropTypes.func,
+  showCheckbox: PropTypes.bool,
+  checkboxAction: PropTypes.func,
 };
 
 export default withTranslation()(VisualElementSearch);

--- a/src/containers/VisualElement/VisualElementSelectField.jsx
+++ b/src/containers/VisualElement/VisualElementSelectField.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import VisualElementSearch from './VisualElementSearch';
 import VisualElementModalWrapper from './VisualElementModalWrapper';
 
-export const onSaveAsMetaImage = (image, formikContext) => {
+export const checkboxAction = (image, formikContext) => {
   const { setFieldValue } = formikContext;
 
   if (setFieldValue && image) {
@@ -34,8 +34,7 @@ const VisualElementSelectField = ({
 
   const { values } = formikContext;
 
-  const showMetaImageCheckbox =
-    values.metaImageAlt !== undefined && values.metaImageId !== undefined;
+  const showCheckbox = values.metaImageAlt !== undefined && values.metaImageId !== undefined;
 
   const onImageLightboxClose = () => {
     resetSelectedResource();
@@ -64,8 +63,8 @@ const VisualElementSelectField = ({
           videoTypes={videoTypes}
           articleLanguage={articleLanguage}
           setH5pFetchFail={setH5pFetchFail}
-          showMetaImageCheckbox={showMetaImageCheckbox}
-          onSaveAsMetaImage={image => onSaveAsMetaImage(image, formikContext)}
+          showCheckbox={showCheckbox}
+          checkboxAction={image => checkboxAction(image, formikContext)}
         />
       )}
     </VisualElementModalWrapper>

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -289,6 +289,7 @@ const phrases = {
     buttonTitle: 'Search',
     useImage: 'Use image',
     metaImageCheckboxLabel: 'Set as meta image',
+    visualElementCheckboxLabel: 'Set as visual element',
     noTitle: 'No title',
     noResultsText: 'No images found. Would you like to upload a new image?',
     noResultsButtonText: 'Upload image',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -290,6 +290,7 @@ const phrases = {
     buttonTitle: 'Søk',
     useImage: 'Bruk bildet',
     metaImageCheckboxLabel: 'Sett som metabilde',
+    visualElementCheckboxLabel: 'Sett som visuelt element',
     noTitle: 'Ingen tittel',
     noResultsText: 'Fant ingen bilder på søk. Ønsker du å laste opp et nytt bilde?',
     noResultsButtonText: 'Last opp bilde',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -284,6 +284,7 @@ const phrases = {
     buttonTitle: 'Søk',
     useImage: 'Bruk bildet',
     metaImageCheckboxLabel: 'Sett som metabilde',
+    visualElementCheckboxLabel: 'Sett som visuelt element',
     noTitle: 'Ingen tittel',
     noResultsText: 'Fann ingen bilder på søk. Ønskjer du å laste opp eit nytt bilde?',
     noResultsButtonText: 'Last opp bilde',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,7 +2030,7 @@
     "@ndla/util" "^1.1.1"
     raven-js "^3.22.3"
 
-"@ndla/forms@1.0.29", "@ndla/forms@^1.0.29":
+"@ndla/forms@1.0.29":
   version "1.0.29"
   resolved "https://registry.yarnpkg.com/@ndla/forms/-/forms-1.0.29.tgz#581b615586974c67035293977ee67f2c6858f2f5"
   integrity sha512-Pp4uZpryFa649J1rFidKxfinIZPqQQlb+XhNBc+qCeDi4Jfu5Nx6sgUClvD+cv5otiOlyp5AFXoGVL3cs26PXg==
@@ -2039,12 +2039,29 @@
     "@ndla/icons" "^1.3.1"
     "@ndla/ui" "^3.0.11"
 
+"@ndla/forms@^1.0.34":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/@ndla/forms/-/forms-1.0.34.tgz#9ce6c1b92a6f41efe7a6d67ffee73cac702221c4"
+  integrity sha512-0r4N5wa5+9eliMq9fXJE00K3LiMukeQQ9rj+615VHwpSbLXlyGjTvsFWppXmPRVqSqoraLeD5B26z3ZjAfXOzQ==
+  dependencies:
+    "@ndla/core" "^0.7.2"
+    "@ndla/icons" "^1.3.1"
+    "@ndla/ui" "^3.1.0"
+
 "@ndla/hooks@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@ndla/hooks/-/hooks-1.0.5.tgz#2c291d93e7a942742ef854ef5c9bb66d332b0ca1"
   integrity sha512-sCaYCkHhIzTDF9XmCyCkGLeTo5OGyb8XXNdkxgZTtDTAwlUKy7nOfEHyw4GVx5bDFy99ZPgLBmPpYBOZhV2Mbg==
   dependencies:
     "@ndla/util" "^1.1.1"
+    lodash "^4.17.20"
+
+"@ndla/hooks@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@ndla/hooks/-/hooks-1.0.6.tgz#4384a2fb9c01c1bf9882e0abd431f1eb70febbe0"
+  integrity sha512-0jTSaUYrtp2OXee3j5a4io7QMchUW7XVzZ8xlPt5tYGpi7bEX3JgwAu4HwmxlcoibUh/VGbo2UljOlzUSFS8iw==
+  dependencies:
+    "@ndla/util" "^2.0.0"
     lodash "^4.17.20"
 
 "@ndla/howto@1.1.14":
@@ -2066,16 +2083,16 @@
   resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-1.3.1.tgz#e74df1bf1f6222845a4bc7508b29beedb81f3a0f"
   integrity sha512-5WiO5ES7NxgXprNWP4ikZTAKAh/r+QoQ070YH4z0xWLSsysTuXFf6RODXWBIsKVvfpT6zgXe4Jq2lhPX8JNP5w==
 
-"@ndla/image-search@1.1.24":
-  version "1.1.24"
-  resolved "https://registry.yarnpkg.com/@ndla/image-search/-/image-search-1.1.24.tgz#82cbe0ddb49ca0226e80232d50e290c70390a429"
-  integrity sha512-vEPxNI7R8BjWQCzbj+JXxwLp3qxLAkZK0cB2+HbVD4lvSc8YeGdvoqdHjPleykBKbfBpq7EtEaaBVWXQ2KXfBQ==
+"@ndla/image-search@1.1.30-alpha.5+059023e41":
+  version "1.1.30-alpha.5"
+  resolved "https://registry.yarnpkg.com/@ndla/image-search/-/image-search-1.1.30-alpha.5.tgz#2dc205a42e6bdab34a276161dda43d815ee37fdc"
+  integrity sha512-bJAFu9DizyYDnz7Lwz4DKd+tLs66D6PQISoHG1Foae3bucp71SGSEY7BOMUz0AojQO9kE5yjOC6ld9VNldo3Wg==
   dependencies:
     "@ndla/button" "^1.0.6"
     "@ndla/core" "^0.7.2"
-    "@ndla/forms" "^1.0.29"
+    "@ndla/forms" "^1.0.34"
     "@ndla/licenses" "^1.0.7"
-    "@ndla/util" "^1.1.1"
+    "@ndla/util" "^2.0.0"
 
 "@ndla/licenses@1.0.7", "@ndla/licenses@^1.0.7":
   version "1.0.7"
@@ -2104,6 +2121,16 @@
     "@ndla/button" "^1.0.6"
     "@ndla/core" "^0.7.2"
     "@ndla/util" "^1.1.1"
+    "@reach/dialog" "^0.2.9"
+
+"@ndla/modal@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@ndla/modal/-/modal-1.1.11.tgz#e1854b6c5ff39195babe5b2a06bb477f50471b55"
+  integrity sha512-yThpItN0jX7KiBsIYwSS+YUaT563YwbKYLekmdobF3t/vzoBrxDIWG3qI+n0oUJ8hvKA8hugCerZLwpBHXKRRA==
+  dependencies:
+    "@ndla/button" "^1.0.6"
+    "@ndla/core" "^0.7.2"
+    "@ndla/util" "^2.0.0"
     "@reach/dialog" "^0.2.9"
 
 "@ndla/notion@1.0.14":
@@ -2158,10 +2185,26 @@
     "@ndla/util" "^1.1.1"
     react-tabs "^3.0.0"
 
+"@ndla/tabs@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@ndla/tabs/-/tabs-1.0.8.tgz#4c024492b08876530b3eb431f3b1ef2d9563f3aa"
+  integrity sha512-HRJ8wmqufQwhn0VB7MjSH9wv1FrfPOUtehMFAVP1AMUq4rYgTB5s5wGAXs1J1fV9kp/s+fieX6eDS4vlAHhtuw==
+  dependencies:
+    "@ndla/core" "^0.7.2"
+    "@ndla/util" "^2.0.0"
+    react-tabs "^3.0.0"
+
 "@ndla/tooltip@^0.2.46":
   version "0.2.46"
   resolved "https://registry.yarnpkg.com/@ndla/tooltip/-/tooltip-0.2.46.tgz#ead81211c9bb835d45f7fe67c18667028180038d"
   integrity sha512-HX4NPKmPL8jJVo99o0BW4s0quG1ZyW/Km6A81HAm5ZmWFEHuVfRZiM/YjgvjjPl/prTfUAtqT9U/GwoLEj04fw==
+  dependencies:
+    "@ndla/core" "^0.7.2"
+
+"@ndla/tooltip@^0.2.47":
+  version "0.2.47"
+  resolved "https://registry.yarnpkg.com/@ndla/tooltip/-/tooltip-0.2.47.tgz#443d3ad413f59a904be9d220cd79b8ff72f75b64"
+  integrity sha512-UoiEpp8V0JOni3iy6T0mv687CNw4r/aNScYWm/aI8p3OxH8lVc/iLnpxDXomWey7AWpsyzStiKVgrhtpaV3V3A==
   dependencies:
     "@ndla/core" "^0.7.2"
 
@@ -2219,10 +2262,62 @@
     react-transition-group "^2.5.3"
     shave "^2.5.10"
 
+"@ndla/ui@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-3.1.0.tgz#a89eaf9b74f81427aef16ed1ff41304e001d0d5c"
+  integrity sha512-xkIsjWOQS/a9ntYuGPq4pXEa1i8zVq20pY58cEHutRo7JU2nRbhKVyfbDqhcGW05YtPeN2gktejlfK7/f+sicA==
+  dependencies:
+    "@ndla/button" "^1.0.6"
+    "@ndla/carousel" "^1.0.6"
+    "@ndla/core" "^0.7.2"
+    "@ndla/hooks" "^1.0.6"
+    "@ndla/icons" "^1.3.1"
+    "@ndla/licenses" "^1.0.7"
+    "@ndla/modal" "^1.1.11"
+    "@ndla/safelink" "^1.0.5"
+    "@ndla/switch" "^0.0.32"
+    "@ndla/tabs" "^1.0.8"
+    "@ndla/tooltip" "^0.2.47"
+    "@ndla/util" "^2.0.0"
+    "@reach/menu-button" "^0.12.1"
+    "@reach/slider" "^0.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/react-syntax-highlighter" "^13.5.2"
+    classnames "2.2.6"
+    focus-trap "^4.0.2"
+    focus-trap-react "^6.0.0"
+    hoist-non-react-statics "^3.3.0"
+    html-react-parser "^0.10.3"
+    i18next-browser-languagedetector "^6.1.1"
+    intl-format-cache "^4.3.1"
+    intl-messageformat "5.4.3"
+    invariant "^2.2.3"
+    jump.js "^1.0.2"
+    lodash "^4.17.20"
+    react-bem-helper "1.4.1"
+    react-device-detect "^1.6.2"
+    react-facebook "^6.0.15"
+    react-prop-types "0.4.0"
+    react-sticky-el "^2.0.6"
+    react-swipeable "^5.0.1"
+    react-syntax-highlighter "^15.4.4"
+    react-transition-group "^2.5.3"
+    shave "^2.5.10"
+
 "@ndla/util@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@ndla/util/-/util-1.1.1.tgz#b3b1b7a53c5f2d97cff00609ae040dddd8b9a209"
   integrity sha512-ob2QS48PaqAf0h03BVM5LC0v5vjMd1yiRNasBsH4cbit8XVJrviblocjjVEehdsZDHqw+EWHdByJekWrgfbkEw==
+  dependencies:
+    chalk "^4.1.2"
+    cli-table3 "^0.6.0"
+    defined "1.0.0"
+    remarkable "^2.0.1"
+
+"@ndla/util@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/util/-/util-2.0.0.tgz#85f8f996a125945bf1b9dbb16f1082b472b5b418"
+  integrity sha512-APyxYq3CLNrYruDVJNToX18E1zg1VOVGZ7XmX04ZpIpM1GJLoAPfRsXXCf8mCSkFe3u1TRsk2F7u79JFN1ptBQ==
   dependencies:
     chalk "^4.1.2"
     cli-table3 "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,10 +2083,10 @@
   resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-1.3.1.tgz#e74df1bf1f6222845a4bc7508b29beedb81f3a0f"
   integrity sha512-5WiO5ES7NxgXprNWP4ikZTAKAh/r+QoQ070YH4z0xWLSsysTuXFf6RODXWBIsKVvfpT6zgXe4Jq2lhPX8JNP5w==
 
-"@ndla/image-search@1.1.30-alpha.5+059023e41":
-  version "1.1.30-alpha.5"
-  resolved "https://registry.yarnpkg.com/@ndla/image-search/-/image-search-1.1.30-alpha.5.tgz#2dc205a42e6bdab34a276161dda43d815ee37fdc"
-  integrity sha512-bJAFu9DizyYDnz7Lwz4DKd+tLs66D6PQISoHG1Foae3bucp71SGSEY7BOMUz0AojQO9kE5yjOC6ld9VNldo3Wg==
+"@ndla/image-search@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/image-search/-/image-search-2.0.0.tgz#ee90b8543e1d3f5c4ae89d35f79b43b179464114"
+  integrity sha512-frkuT+xqwosZjBV4xlAUfEQ/ilsWgGVh4fAg/AtFdjmIb9K2hh6R4FzU+Sm8UN9A0x8hIetVWRH8VQj/7t3M/A==
   dependencies:
     "@ndla/button" "^1.0.6"
     "@ndla/core" "^0.7.2"


### PR DESCRIPTION
Fixes NDLANO/Issues#2770

Avventer https://github.com/NDLANO/frontend-packages/pull/929.

Hva er fikset:
- Forklarings-skjema viste delvis feil tilstand etter lagring. Feilen kan framprovoseres i test ved å velge et nytt visuelt element og deretter lagre. Visuelt element viser da gammelt innhold fram til man klikker hvor som helst i skjemaet, da endrer visuelt element seg til ny verdi. Dette er nå fikset.
- Har lagt til checkbox ved valg av metabilde i forklaring. Visuelt element settes til det samme dersom denne er markert.