### PR TITLE
Fix mathml edit crashing in tables

### DIFF
--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -254,7 +254,6 @@ export const tablePlugin = (editor: Editor) => {
           {
             at: path,
             match: n => n !== node,
-            mode: 'highest',
           },
         );
       }


### PR DESCRIPTION
Fikser en feil der redigering av matte i tabell feiler. Enten ved lukking av matte-editor eller lagring av matte-editor.

Hvordan teste:
- Åpne /subject-matter/learning-resource/31330/edit/nb i PR-instans. Rediger en av matteformlene i tabellen (ikke formelen på første rad). Siden skal ikke krasje ved lagring/lukking av matte-editor.