### PR TITLE
Focus LinkForm title on mount

### DIFF
--- a/src/components/SlateEditor/plugins/link/LinkForm.jsx
+++ b/src/components/SlateEditor/plugins/link/LinkForm.jsx
@@ -101,7 +101,12 @@ class LinkForm extends Component {
         validate={values => validateFormik(values, linkValidationRules, t, 'linkForm')}>
         {({ submitForm, values }) => (
           <Form data-cy="link_form">
-            <FormikField name="text" type="text" label={t('form.content.link.text')} />
+            <FormikField
+              name="text"
+              type="text"
+              label={t('form.content.link.text')}
+              autoFocus={true}
+            />
             <FormikField
               name="href"
               description={t('form.content.link.description', {


### PR DESCRIPTION
Fixes NDLANO/Issues#2822

Ved åpning av modal for redigering av lenker i artikkel vil tittelfeltet fokuseres automatisk.

Hvordan teste:
1. Åpne en artikkel/forklaring
2. Marker noe tekst og sett inn lenke enten via toolbar eller med CTRL+ALT+L.
3. Modal skal åpnes og markøren skal være plassert i tittelfeltet.