### PR TITLE
Checks if is number before using value for alternative video

### DIFF
--- a/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
@@ -17,6 +17,7 @@ import { parseMarkdown } from '@ndla/util';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import SafeLink from '@ndla/safelink';
+import { isNumeric } from '../../../../components/validators';
 import FigureButtons from './FigureButtons';
 import EditVideo from './EditVideo';
 import IconButton from '../../../IconButton';
@@ -80,7 +81,9 @@ const SlateVideo = ({
     visualElementApi
       .fetchBrightcoveVideo(idWithoutTimestamp)
       .then((v: { link?: { text: string } }) => {
-        setLinkedVideoId(v.link?.text);
+        if (isNumeric(v.link?.text)) {
+          setLinkedVideoId(v.link?.text);
+        }
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [(embed as BrightcoveEmbed).videoid]);


### PR DESCRIPTION
NDLANO/Issues#2688

Sjekker at relatert id er et tall før det brukes.

Test:
* Artikkel 31334 i test har to videoer med verdi i related-feltet. Kun den første er synstolka og skal ha knapp. 