### PR TITLE
2911 Disable delete language button when resource only has one language version and is in use elsewhere

### DIFF
--- a/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
+++ b/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
@@ -51,10 +51,11 @@ interface Props {
     supportedLanguages: string[];
     articleType?: string;
   };
+  disabled: boolean;
   type: string;
 }
 
-const DeleteLanguageVersion = ({ values, type }: Props) => {
+const DeleteLanguageVersion = ({ values, type, disabled }: Props) => {
   const { t } = useTranslation();
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
   const { createMessage } = useMessages();
@@ -134,7 +135,11 @@ const DeleteLanguageVersion = ({ values, type }: Props) => {
 
   return (
     <StyledWrapper>
-      <StyledFilledButton type="button" deletable onClick={toggleShowDeleteWarning}>
+      <StyledFilledButton
+        type="button"
+        disabled={disabled}
+        deletable
+        onClick={toggleShowDeleteWarning}>
         <DeleteForever />
         {t('form.workflow.deleteLanguageVersion.button', {
           languageVersion: t(`language.${language}`).toLowerCase(),

--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -68,6 +68,7 @@ interface Props {
   noStatus: boolean;
   setTranslateOnContinue?: (translateOnContinue: boolean) => void;
   translateToNN?: () => void;
+  disableDelete: boolean;
   type: string;
   values: {
     articleType?: string;
@@ -87,6 +88,7 @@ const HeaderActions = ({
   setTranslateOnContinue,
   type,
   translateToNN,
+  disableDelete,
   values,
 }: Props) => {
   const { t } = useTranslation();
@@ -149,7 +151,7 @@ const HeaderActions = ({
               />
             </>
           )}
-        <DeleteLanguageVersion values={values} type={type} />
+        {<DeleteLanguageVersion values={values} type={type} disabled={disableDelete} />}
       </>
     );
   }

--- a/src/components/HeaderWithLanguage/HeaderInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderInformation.tsx
@@ -109,6 +109,7 @@ interface Props {
   formIsDirty?: boolean;
   taxonomyPaths?: string[];
   id?: number;
+  setHasConnections?: (hasConnections: boolean) => void;
 }
 
 const HeaderInformation = ({
@@ -122,6 +123,7 @@ const HeaderInformation = ({
   formIsDirty,
   getEntity,
   taxonomyPaths,
+  setHasConnections,
 }: Props) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
@@ -177,6 +179,7 @@ const HeaderInformation = ({
         taxonomyPaths={taxonomyPaths}
         type={type}
         id={id}
+        setHasConnections={setHasConnections}
       />
     </StyledHeader>
   );

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -4,7 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Children, isValidElement, ReactElement, ReactNode, useState } from 'react';
+import { Children, isValidElement, ReactElement, ReactNode, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import SafeLink from '@ndla/safelink';
@@ -61,6 +61,7 @@ interface Props {
   fontSize?: number;
   type?: string;
   id?: number;
+  setHasConnections?: (hasConnections: boolean) => void;
 }
 
 const HeaderStatusInformation = ({
@@ -73,11 +74,18 @@ const HeaderStatusInformation = ({
   fontSize,
   type,
   id,
+  setHasConnections,
 }: Props) => {
   const { t } = useTranslation();
   const [learningpaths, setLearningpaths] = useState<Learningpath[]>([]);
   const [articles, setArticles] = useState<MultiSearchSummary[]>([]);
   const [concepts, setConcepts] = useState<SearchConceptType[]>([]);
+
+  useEffect(() => {
+    const allConnections = [...learningpaths, ...articles, ...concepts];
+    setHasConnections?.(allConnections.length > 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [learningpaths, articles, concepts]);
 
   const StyledStatus = styled.p`
     ${fonts.sizes(fontSize || 18, 1.1)};

--- a/src/components/HeaderWithLanguage/HeaderWithLanguage.tsx
+++ b/src/components/HeaderWithLanguage/HeaderWithLanguage.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import { spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
@@ -82,6 +83,8 @@ const HeaderWithLanguage = ({
   const { t, i18n } = useTranslation();
   const { articleType } = values;
   const { id, title, status } = content;
+  // true by default to disable language deletions until connections are retrieved.
+  const [hasConnections, setHasConnections] = useState(true);
 
   const language = content.language ?? i18n.language;
   const supportedLanguages = values.supportedLanguages ?? [language];
@@ -107,10 +110,12 @@ const HeaderWithLanguage = ({
         id={id}
         published={published}
         taxonomyPaths={taxonomyPaths}
+        setHasConnections={setHasConnections}
         {...rest}
       />
       <StyledLanguageWrapper>
         <HeaderActions
+          disableDelete={hasConnections && supportedLanguages.length === 1}
           values={safeValues}
           noStatus={noStatus}
           isNewLanguage={isNewLanguage}

--- a/src/components/StyledFilledButton/StyledFilledButton.jsx
+++ b/src/components/StyledFilledButton/StyledFilledButton.jsx
@@ -40,12 +40,23 @@ const StyledFilledButton = styled.button`
     background: ${colors.brand.primary};
     ${props =>
       props.deletable &&
+      !props.disabled &&
       css`
         background: ${colors.support.red};
       `}
     transform: translate(1px, 1px);
     .c-icon {
       color: #fff;
+    }
+  }
+  &:disabled {
+    background: ${colors.brand.greyLight};
+    color: ${colors.brand.grey};
+    cursor: not-allowed;
+    pointer-events: auto;
+    transform: translate(0px, 0px);
+    .c-icon {
+      color: ${colors.support.red};
     }
   }
 `;


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2911

Forsøkte først å legge til en tooltip, men det ser ut som at `@ndla/tooltip` ikke fungerer særlig bra på knapper som er disabled. Flere av ressursene (emneartikkel, læringsressurs, konsept) skjuler allerede slett språkversjon-knappen fullstendig dersom en ressurs kun har en språkversjon igjen. For andre typer så jeg på det som mer hensiktsmessig å bare disable den, men kan også fint endre det til å oppføre seg likt som de tidligere nevnte ressursene.