### PR TITLE
Bugfix: Save search now works when list is undefined

### DIFF
--- a/src/containers/SearchPage/SearchSaveButton.tsx
+++ b/src/containers/SearchPage/SearchSaveButton.tsx
@@ -70,7 +70,7 @@ const SearchSaveButton = () => {
   const saveSearch = async () => {
     setError('');
     setLoading(true);
-    const oldSearchList = data?.savedSearches;
+    const oldSearchList = savedSearches;
 
     if (!oldSearchList) {
       handleFailure('fetchFailed');


### PR DESCRIPTION
Fixes NDLANO/Issues#2913

Lagring av søk fra søkesiden feilet tidligere dersom dataen i databasen ikke eksisterte enda. Dette er nå fikset.

Hvordan teste:
1. Brukeren din i ed er nødt til å ikke ha lagret søk før.
2. Åpne søkesiden og forsøk å lagre et søk. Knappen skal indikere at søket er lagret og det skal bli synlig på søkesiden.

