### PR TITLE
2907 mathml UI improvements

### DIFF
--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -76,22 +76,14 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
   };
 
   const onExit = () => {
-    setEditMode(false);
-    setShowMenu(false);
     const elementPath = ReactEditor.findPath(editor, element);
     let leafPath: Path;
 
     if (isFirstEdit) {
       leafPath = Path.previous(elementPath);
-      const oldLeafLength = Editor.string(editor, leafPath, { voids: true }).length;
-      const mathLength = Node.string(element).length;
+      ReactEditor.focus(editor);
+      Transforms.select(editor, Editor.start(editor, Path.next(elementPath)));
       handleRemove();
-      setTimeout(() => {
-        Transforms.select(editor, {
-          anchor: { path: leafPath, offset: oldLeafLength + mathLength },
-          focus: { path: leafPath, offset: oldLeafLength + mathLength },
-        });
-      }, 0);
     } else {
       leafPath = Path.next(elementPath);
       ReactEditor.focus(editor);
@@ -99,6 +91,8 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
         anchor: { path: leafPath, offset: 0 },
         focus: { path: leafPath, offset: 0 },
       });
+      setEditMode(false);
+      setShowMenu(false);
     }
   };
 
@@ -133,17 +127,15 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       });
     }
 
+    ReactEditor.focus(editor);
+    Transforms.select(editor, {
+      anchor: { path: leafPath, offset: 0 },
+      focus: { path: leafPath, offset: 0 },
+    });
+
     setIsFirstEdit(false);
     setEditMode(false);
     setShowMenu(false);
-
-    setTimeout(() => {
-      ReactEditor.focus(editor);
-      Transforms.select(editor, {
-        anchor: { path: leafPath, offset: 0 },
-        focus: { path: leafPath, offset: 0 },
-      });
-    }, 0);
   };
 
   const handleRemove = () => {

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -7,7 +7,7 @@
  */
 
 import { MouseEvent, useEffect, useState } from 'react';
-import { Editor, Element, Node, Path, Transforms } from 'slate';
+import { Editor, Node, Path, Transforms } from 'slate';
 import { ReactEditor, RenderElementProps, useFocused, useSelected } from 'slate-react';
 import { colors } from '@ndla/core';
 import he from 'he';
@@ -15,7 +15,7 @@ import { Portal } from '../../../Portal';
 import EditMath from './EditMath';
 import MathML from './MathML';
 import BlockMenu from './BlockMenu';
-import { MathmlElement, TYPE_MATHML } from '.';
+import { MathmlElement } from '.';
 import mergeLastUndos from '../../utils/mergeLastUndos';
 
 const getInfoFromNode = (node: MathmlElement) => {
@@ -107,7 +107,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       Transforms.setNodes(editor, properties, {
         at: path,
         voids: true,
-        match: node => Element.isElement(node) && node.type === TYPE_MATHML,
+        match: node => node === element,
       });
 
       const mathAsString = new DOMParser().parseFromString(mathML, 'text/xml').firstChild
@@ -123,7 +123,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       Transforms.setNodes(editor, properties, {
         at: path,
         voids: true,
-        match: node => Element.isElement(node) && node.type === TYPE_MATHML,
+        match: node => node === element,
       });
     }
 
@@ -143,7 +143,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
 
     Transforms.unwrapNodes(editor, {
       at: path,
-      match: node => Element.isElement(node) && node.type === TYPE_MATHML,
+      match: node => node === element,
       voids: true,
     });
   };

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -77,6 +77,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
 
   const onExit = () => {
     setEditMode(false);
+    setShowMenu(false);
     const elementPath = ReactEditor.findPath(editor, element);
     let leafPath: Path;
 
@@ -134,6 +135,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
 
     setIsFirstEdit(false);
     setEditMode(false);
+    setShowMenu(false);
 
     setTimeout(() => {
       ReactEditor.focus(editor);

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -77,19 +77,15 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
 
   const onExit = () => {
     const elementPath = ReactEditor.findPath(editor, element);
-    let leafPath: Path;
 
     if (isFirstEdit) {
-      leafPath = Path.previous(elementPath);
-      ReactEditor.focus(editor);
-      Transforms.select(editor, Editor.start(editor, Path.next(elementPath)));
       handleRemove();
     } else {
-      leafPath = Path.next(elementPath);
+      const nextPath = Path.next(elementPath);
       ReactEditor.focus(editor);
       Transforms.select(editor, {
-        anchor: { path: leafPath, offset: 0 },
-        focus: { path: leafPath, offset: 0 },
+        anchor: { path: nextPath, offset: 0 },
+        focus: { path: nextPath, offset: 0 },
       });
       setEditMode(false);
       setShowMenu(false);
@@ -140,6 +136,8 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
 
   const handleRemove = () => {
     const path = ReactEditor.findPath(editor, element);
+    ReactEditor.focus(editor);
+    Transforms.select(editor, Editor.start(editor, Path.next(path)));
 
     Transforms.unwrapNodes(editor, {
       at: path,


### PR DESCRIPTION
Fixes NDLANO/Issues#2907

Forbedrer hvordan mathml-plugin håndterer fokus i Slate. Først og fremst skal den nå holde fokus ved mathml etter lukking av matte-editor uten å flytte fokus til toppen av nettsiden.

Test følgende i artikkel/emne:
1. Fokus skal settes ved mathml ved lagring, fjerning og lukking.