### PR TITLE
Check if path before returning topics

### DIFF
--- a/src/containers/StructurePage/folderComponents/menuOptions/CopyResources.tsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/CopyResources.tsx
@@ -75,6 +75,7 @@ const CopyResources = ({
       .then(([topics, subjectTopics]: [Topic[], SubjectTopic[]]) => {
         setTopics(
           topics
+            .filter(topic => topic.path)
             .filter(topic => !subjectTopics.some(t => t.id === topic.id))
             .map(topic => ({
               ...topic,


### PR DESCRIPTION
Fixes NDLANO/Issues#2914

Ikkje bruk emner uten path.

Test:
* Åpne pr og gå til strukturredigering
* Velg et emne og klikk på tannhjulet
* Velg menyvalg for kopiering eller kloning av ressurser fra anna emne
* Søk etter feks HMS. Alle treff skal ha en breadcrumb, som viser at den finnes i strukturen. I test får du opp emner uten dette.