### PR TITLE
Secondary button on SaveMultiButton can be enable with override

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@ndla/accordion": "^1.0.2",
     "@ndla/article-scripts": "^2.0.4",
     "@ndla/audio-search": "1.0.11",
-    "@ndla/button": "1.0.7-alpha.28+17b732739",
+    "@ndla/button": "1.0.7-alpha.37+22d6282b4",
     "@ndla/carousel": "1.0.6",
     "@ndla/code": "1.0.12",
     "@ndla/editor": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@ndla/accordion": "^1.0.2",
     "@ndla/article-scripts": "^2.0.4",
     "@ndla/audio-search": "1.0.11",
-    "@ndla/button": "1.0.6",
+    "@ndla/button": "1.0.7-alpha.28+17b732739",
     "@ndla/carousel": "1.0.6",
     "@ndla/code": "1.0.12",
     "@ndla/editor": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@ndla/accordion": "^1.0.2",
     "@ndla/article-scripts": "^2.0.4",
     "@ndla/audio-search": "1.0.11",
-    "@ndla/button": "^1.1.0",
+    "@ndla/button": "1.1.1",
     "@ndla/carousel": "1.0.6",
     "@ndla/code": "1.0.12",
     "@ndla/editor": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@ndla/accordion": "^1.0.2",
     "@ndla/article-scripts": "^2.0.4",
     "@ndla/audio-search": "1.0.11",
-    "@ndla/button": "1.0.7-alpha.37+22d6282b4",
+    "@ndla/button": "^1.1.0",
     "@ndla/carousel": "1.0.6",
     "@ndla/code": "1.0.12",
     "@ndla/editor": "^1.1.6",

--- a/src/components/SaveMultiButton.tsx
+++ b/src/components/SaveMultiButton.tsx
@@ -52,12 +52,14 @@ const SaveMultiButton = ({
   const { t } = useTranslation();
   const modifier = getModifier();
   const disabledButton = isSaving || !formIsDirty || disabled;
+  const enableSecondary = !(isSaving || showSaved);
 
   return (
     <>
       <Wrapper modifier={modifier} data-testid="saveLearningResourceButtonWrapper">
         <MultiButton
           disabled={disabledButton}
+          enableSecondary={enableSecondary}
           onClick={(value: string) => {
             const saveAsNewVersion = value === 'saveAsNew';
             onClick(saveAsNewVersion);
@@ -70,6 +72,7 @@ const SaveMultiButton = ({
                   {
                     label: t('form.saveAsNewVersion'),
                     value: 'saveAsNew',
+                    alwaysEnable: true,
                   },
                   {
                     label: t('form.save'),

--- a/src/components/SaveMultiButton.tsx
+++ b/src/components/SaveMultiButton.tsx
@@ -11,7 +11,7 @@ const StyledSpan = styled('span')`
 `;
 
 const Wrapper = styled('div')`
-  button {
+  div > button:disabled {
     ${(props: { modifier: string }) => {
       return saveButtonAppearances[props.modifier];
     }}
@@ -52,14 +52,12 @@ const SaveMultiButton = ({
   const { t } = useTranslation();
   const modifier = getModifier();
   const disabledButton = isSaving || !formIsDirty || disabled;
-  const enableSecondary = !(isSaving || showSaved);
 
   return (
     <>
       <Wrapper modifier={modifier} data-testid="saveLearningResourceButtonWrapper">
         <MultiButton
           disabled={disabledButton}
-          enableSecondary={enableSecondary}
           onClick={(value: string) => {
             const saveAsNewVersion = value === 'saveAsNew';
             onClick(saveAsNewVersion);
@@ -72,7 +70,7 @@ const SaveMultiButton = ({
                   {
                     label: t('form.saveAsNewVersion'),
                     value: 'saveAsNew',
-                    alwaysEnable: true,
+                    enable: !isSaving,
                   },
                   {
                     label: t('form.save'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,7 +1967,15 @@
     "@ndla/licenses" "^1.0.7"
     "@ndla/util" "^1.1.1"
 
-"@ndla/button@1.0.6", "@ndla/button@^1.0.6":
+"@ndla/button@1.0.7-alpha.28+17b732739":
+  version "1.0.7-alpha.28"
+  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.7-alpha.28.tgz#f9674028aa269a5696e6cc865ed34db3fc7b3710"
+  integrity sha512-lmZ9pNfFAOeOUdh7/n5kuQxbPa0QRR3sSg8MDbNBg/10atutFfpy398KvLyGdGj4ek9iRGODNUJ9LOnhYvddfA==
+  dependencies:
+    "@ndla/core" "^0.7.2"
+    "@ndla/icons" "^1.3.1"
+
+"@ndla/button@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.6.tgz#747dce7976e96e0ff8ee9cc73ba46710e1339ccc"
   integrity sha512-nbxQ9e0Ph8P9jdeAh/a5I1ch2C/uJBHVEmAqn+RnaU+laGlnpydMnuMGCNIittDfWHCziEntoSJ/RuaHDuWSOA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,10 +1967,10 @@
     "@ndla/licenses" "^1.0.7"
     "@ndla/util" "^1.1.1"
 
-"@ndla/button@1.0.7-alpha.28+17b732739":
-  version "1.0.7-alpha.28"
-  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.7-alpha.28.tgz#f9674028aa269a5696e6cc865ed34db3fc7b3710"
-  integrity sha512-lmZ9pNfFAOeOUdh7/n5kuQxbPa0QRR3sSg8MDbNBg/10atutFfpy398KvLyGdGj4ek9iRGODNUJ9LOnhYvddfA==
+"@ndla/button@1.0.7-alpha.37+22d6282b4":
+  version "1.0.7-alpha.37"
+  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.7-alpha.37.tgz#b742692e1b29ec5f9c386f0540607e83415910ba"
+  integrity sha512-+UniIuPZF4ZbQGW9YGLj1/6WuOjfnGgJaGTsUJvc7dhfTmWmIN1kLfuoZ/SY8aTNc2zMeyJizP2DC6o1Jt8CNw==
   dependencies:
     "@ndla/core" "^0.7.2"
     "@ndla/icons" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,15 +1967,15 @@
     "@ndla/licenses" "^1.0.7"
     "@ndla/util" "^1.1.1"
 
-"@ndla/button@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.6.tgz#747dce7976e96e0ff8ee9cc73ba46710e1339ccc"
-  integrity sha512-nbxQ9e0Ph8P9jdeAh/a5I1ch2C/uJBHVEmAqn+RnaU+laGlnpydMnuMGCNIittDfWHCziEntoSJ/RuaHDuWSOA==
+"@ndla/button@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.1.1.tgz#0c142af4bcc5e5bc76e3d0224532d49971b89fd7"
+  integrity sha512-NOyB0x/MRLFUJItym7a+/bKWn/akC/2lmjBSCi+9wyDLiWW5c0rs/W+XiDQwQLICT9q2BVi48f1wnUmEtZuLEg==
   dependencies:
     "@ndla/core" "^0.7.2"
     "@ndla/icons" "^1.3.1"
 
-"@ndla/button@^1.1.0":
+"@ndla/button@^1.0.6":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.1.0.tgz#21a0caf054e89834c03867223ffa2fca2a179ba4"
   integrity sha512-Hmqho6cHoCxspah3NLYK8i7OkINDYQ8IBGmSY8BIiw3Nf8ccTy6AHgqzZixRnm2Y/L7t95jg8B0RVHkGm2BKRg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,18 +1967,18 @@
     "@ndla/licenses" "^1.0.7"
     "@ndla/util" "^1.1.1"
 
-"@ndla/button@1.0.7-alpha.37+22d6282b4":
-  version "1.0.7-alpha.37"
-  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.7-alpha.37.tgz#b742692e1b29ec5f9c386f0540607e83415910ba"
-  integrity sha512-+UniIuPZF4ZbQGW9YGLj1/6WuOjfnGgJaGTsUJvc7dhfTmWmIN1kLfuoZ/SY8aTNc2zMeyJizP2DC6o1Jt8CNw==
-  dependencies:
-    "@ndla/core" "^0.7.2"
-    "@ndla/icons" "^1.3.1"
-
 "@ndla/button@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.0.6.tgz#747dce7976e96e0ff8ee9cc73ba46710e1339ccc"
   integrity sha512-nbxQ9e0Ph8P9jdeAh/a5I1ch2C/uJBHVEmAqn+RnaU+laGlnpydMnuMGCNIittDfWHCziEntoSJ/RuaHDuWSOA==
+  dependencies:
+    "@ndla/core" "^0.7.2"
+    "@ndla/icons" "^1.3.1"
+
+"@ndla/button@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ndla/button/-/button-1.1.0.tgz#21a0caf054e89834c03867223ffa2fca2a179ba4"
+  integrity sha512-Hmqho6cHoCxspah3NLYK8i7OkINDYQ8IBGmSY8BIiw3Nf8ccTy6AHgqzZixRnm2Y/L7t95jg8B0RVHkGm2BKRg==
   dependencies:
     "@ndla/core" "^0.7.2"
     "@ndla/icons" "^1.3.1"


### PR DESCRIPTION
Fixes NDLANO/Issues#2902

Denne PRen bruker alpha-pakker fra https://github.com/NDLANO/frontend-packages/pull/952

Har oppdatert MultiButton til å støtte overstyring av disabled-parameter for secondary-button og buttons i tilhørende dropdown. 
Dropdown er per nå tilgjengelig når lagreknapp er grå. Ikke når knappen er grønn/lagret.

Alternativt kunne man byttet ut MultiDropdown med to separate knapper, en for lagring og en for lagring av ny versjon.


Hvordan teste:
- Åpne en artikkel.
- Dropdown på lagreknapp skal være tilgjengelig selv om ingen endringer er gjort eller den er markert som grønn/lagret.
- MultiButton brukes også i redigering av forklaring fra søkesiden. Se at den fungerer fint der også.