### PR TITLE
Only show primary connection button when user has taxonomy admin scope

### DIFF
--- a/src/components/Taxonomy/ActiveTopicConnection.tsx
+++ b/src/components/Taxonomy/ActiveTopicConnection.tsx
@@ -20,6 +20,8 @@ import Breadcrumb from './Breadcrumb';
 import RelevanceOption from '../../containers/StructurePage/folderComponents/menuOptions/RelevanceOption';
 import RemoveButton from '../RemoveButton';
 import { StagedTopic } from '../../containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy';
+import { useSession } from '../../containers/Session/SessionProvider';
+import { TAXONOMY_ADMIN_SCOPE } from '../../constants';
 
 interface Props {
   removeConnection?: (id: string) => void;
@@ -42,6 +44,7 @@ const ActiveTopicConnection = ({
   topic,
 }: Props) => {
   const { t } = useTranslation();
+  const { userAccess } = useSession();
   if (!topic.breadcrumb) {
     return (
       <StyledConnections error>
@@ -70,12 +73,14 @@ const ActiveTopicConnection = ({
     <>
       <StyledConnections>
         <StyledFlexWrapper>
-          <StyledPrimaryConnectionButton
-            primary={topic.primary}
-            type="button"
-            onClick={() => setPrimaryConnection && setPrimaryConnection(topic.id)}>
-            {t('form.topics.primaryTopic')}
-          </StyledPrimaryConnectionButton>
+          {userAccess?.includes(TAXONOMY_ADMIN_SCOPE) && (
+            <StyledPrimaryConnectionButton
+              primary={topic.primary}
+              type="button"
+              onClick={() => setPrimaryConnection?.(topic.id)}>
+              {t('form.topics.primaryTopic')}
+            </StyledPrimaryConnectionButton>
+          )}
           <Breadcrumb breadcrumb={topic.breadcrumb} />
         </StyledFlexWrapper>
         <StyledFlexWrapper>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2921

Hvordan teste:
1. Gå inn på en læringsressurs som inneholder en eller flere emnetilknytninger. Primærtilknytning-knappen skal vises.
2. Fjern taxonomy:admin-scopet fra brukeren din.
3. Logg ut og inn av brukeren din.
4. Gå inn på samme læringsressurs. Primærtilknytning-knappen skal ikke vises.