### PR TITLE
Allow one to open image in new tab when viewing a slate concept or when previewing a concept

### DIFF
--- a/src/components/PreviewConcept/PreviewConcept.tsx
+++ b/src/components/PreviewConcept/PreviewConcept.tsx
@@ -17,6 +17,7 @@ import {
   NotionDialogText,
   NotionDialogTags,
 } from '@ndla/notion';
+import { ImageLink } from '@ndla/ui';
 import { Remarkable } from 'remarkable';
 import { getSrcSets } from '../../util/imageEditorUtil';
 import { SubjectType } from '../../modules/taxonomy/taxonomyApiInterfaces';
@@ -87,7 +88,11 @@ const PreviewConcept = ({ concept, visualElement }: Props) => {
     switch (visualElement?.resource) {
       case 'image':
         const srcSet = getSrcSets(visualElement.resource_id, visualElement);
-        return <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />;
+        return (
+          <ImageLink src={visualElement.url!}>
+            <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />{' '}
+          </ImageLink>
+        );
       case 'video':
       case 'brightcove':
       case 'external':

--- a/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useState, useEffect, ReactNode, useMemo, MouseEvent } from 'react';
+import { useState, useEffect, ReactNode, useMemo } from 'react';
 
 import { Editor, Element, Node, Transforms, Path } from 'slate';
 import { ReactEditor, RenderElementProps } from 'slate-react';

--- a/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/EditSlateConcept.tsx
@@ -48,10 +48,7 @@ const EditSlateConcept = (props: Props) => {
 
   const [showConcept, setShowConcept] = useState(false);
 
-  const toggleConceptModal = (evt?: MouseEvent) => {
-    if (evt) {
-      evt.preventDefault();
-    }
+  const toggleConceptModal = () => {
     setShowConcept(!showConcept);
   };
 
@@ -120,7 +117,7 @@ const EditSlateConcept = (props: Props) => {
 
   return (
     <>
-      <span {...attributes} onMouseDown={toggleConceptModal}>
+      <span {...attributes} onClick={toggleConceptModal}>
         <Notion
           id={uuid}
           title={concept?.title.title}

--- a/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
@@ -6,13 +6,14 @@
  *
  */
 
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Remarkable } from 'remarkable';
 import styled from '@emotion/styled';
 import { spacing, spacingUnit } from '@ndla/core';
 import { DeleteForever } from '@ndla/icons/editor';
 import { Link as LinkIcon } from '@ndla/icons/common';
+import { ImageLink } from '@ndla/ui';
 import { useTranslation } from 'react-i18next';
 import { NotionDialogContent, NotionDialogText, NotionDialogLicenses } from '@ndla/notion';
 import Tooltip from '@ndla/tooltip';
@@ -43,6 +44,13 @@ interface Props {
   handleRemove: () => void;
   id: number | string;
 }
+interface ImageWrapperProps {
+  children: ReactNode;
+  url?: string;
+}
+
+const ImageWrapper = ({ children, url }: ImageWrapperProps) =>
+  url ? <ImageLink src={url}>{children}</ImageLink> : <>children</>;
 
 const SlateConceptPreview = ({ concept, handleRemove, id }: Props) => {
   const { t } = useTranslation();
@@ -59,7 +67,11 @@ const SlateConceptPreview = ({ concept, handleRemove, id }: Props) => {
     switch (visualElement?.resource) {
       case 'image':
         const srcSet = getSrcSets(visualElement.resource_id, visualElement);
-        return <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />;
+        return (
+          <ImageWrapper url={visualElement.url}>
+            <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />
+          </ImageWrapper>
+        );
       case 'external':
         return (
           <iframe

--- a/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Remarkable } from 'remarkable';
 import styled from '@emotion/styled';
@@ -25,8 +25,6 @@ import { parseEmbedTag } from '../../../../util/embedTagHelpers';
 import config from '../../../../config';
 import { ConceptApiType } from '../../../../modules/concept/conceptApiInterfaces';
 import { Embed } from '../../../../interfaces';
-import { ImageApiType } from '../../../../modules/image/imageApiInterfaces';
-import { fetchImage } from '../../../../modules/image/imageApi';
 
 const StyledFigureButtons = styled('span')`
   position: absolute;

--- a/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/SlateConceptPreview.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Remarkable } from 'remarkable';
 import styled from '@emotion/styled';
@@ -25,6 +25,8 @@ import { parseEmbedTag } from '../../../../util/embedTagHelpers';
 import config from '../../../../config';
 import { ConceptApiType } from '../../../../modules/concept/conceptApiInterfaces';
 import { Embed } from '../../../../interfaces';
+import { ImageApiType } from '../../../../modules/image/imageApiInterfaces';
+import { fetchImage } from '../../../../modules/image/imageApi';
 
 const StyledFigureButtons = styled('span')`
   position: absolute;
@@ -50,7 +52,7 @@ interface ImageWrapperProps {
 }
 
 const ImageWrapper = ({ children, url }: ImageWrapperProps) =>
-  url ? <ImageLink src={url}>{children}</ImageLink> : <>children</>;
+  url ? <ImageLink src={url}>{children}</ImageLink> : <>{children}</>;
 
 const SlateConceptPreview = ({ concept, handleRemove, id }: Props) => {
   const { t } = useTranslation();
@@ -66,9 +68,10 @@ const SlateConceptPreview = ({ concept, handleRemove, id }: Props) => {
     if (!visualElement) return null;
     switch (visualElement?.resource) {
       case 'image':
+        const wrapperUrl = `${config.ndlaApiUrl}/image-api/raw/id/${visualElement.resource_id}`;
         const srcSet = getSrcSets(visualElement.resource_id, visualElement);
         return (
-          <ImageWrapper url={visualElement.url}>
+          <ImageWrapper url={wrapperUrl}>
             <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />
           </ImageWrapper>
         );


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2933
Er det noen flere steder dette kan oppstå? Det virker som at article-converter allerede håndterer forklaringer i artikler. 