### PR TITLE
Endrer funksjon for uthenting av start av url.

### DIFF
--- a/src/components/DisplayEmbed/DisplayExternal.tsx
+++ b/src/components/DisplayEmbed/DisplayExternal.tsx
@@ -15,7 +15,7 @@ import handleError from '../../util/handleError';
 import EditorErrorMessage from '../SlateEditor/EditorErrorMessage';
 import DisplayExternalModal from './helpers/DisplayExternalModal';
 import { fetchExternalOembed } from '../../util/apiHelpers';
-import { urlDomain, getIframeSrcFromHtmlString } from '../../util/htmlHelpers';
+import { urlOrigin, getIframeSrcFromHtmlString } from '../../util/htmlHelpers';
 import { EXTERNAL_WHITELIST_PROVIDERS } from '../../constants';
 import FigureButtons from '../SlateEditor/plugins/embed/FigureButtons';
 import config from '../../config';
@@ -101,7 +101,7 @@ export class DisplayExternal extends Component<Props, State> {
 
   async getPropsFromEmbed() {
     const { embed, language } = this.props;
-    const domain = embed.url ? urlDomain(embed.url) : config.h5pApiUrl;
+    const domain = embed.url ? urlOrigin(embed.url) : config.h5pApiUrl;
     const cssUrl = encodeURIComponent(`${config.ndlaFrontendDomain}/static/h5p-custom-css.css`);
     this.setState({ domain });
 

--- a/src/util/__tests__/htmlHelpers-test.js
+++ b/src/util/__tests__/htmlHelpers-test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
-import { isValidURL, isNDLAFrontendUrl } from '../htmlHelpers';
+import { isValidURL, isNDLAFrontendUrl, urlDomain, urlOrigin } from '../htmlHelpers';
 
 test('util/htmlHelpers isValidUrl', () => {
   expect(isValidURL('http://en.wikipedia.org/wiki/Procter_&_Gamble')).toBeTruthy();
@@ -45,4 +45,16 @@ test('util/isNDLAFrontendUrl', () => {
   expect(isNDLAFrontendUrl('https://test.ndla.no/nb/subject:6/topic:1:182849')).toBeTruthy();
   expect(isNDLAFrontendUrl('https://test.ndla.no/subject:6/topic:1:182849')).toBeTruthy();
   expect(isNDLAFrontendUrl('https://test.ndla.no/node/182849')).toBeTruthy();
+});
+
+test('urlDomain gets correct domain from url', () => {
+  expect(urlDomain('https://ndla.no')).toBe('ndla.no');
+});
+
+test('urlOrigin gets correct origin from url', () => {
+  expect(
+    urlOrigin(
+      'https://test.ndla.no/subjects/subject:6/topic:1:182849/topic:1:175043/resource:1:175253',
+    ),
+  ).toBe('https://test.ndla.no');
 });

--- a/src/util/htmlHelpers.ts
+++ b/src/util/htmlHelpers.ts
@@ -26,6 +26,11 @@ export const urlDomain = (url: string) => {
   return a.hostname;
 };
 
+export const urlOrigin = (url: string) => {
+  const urlObj = new URL(url);
+  return urlObj.origin;
+};
+
 export const isValidURL = (string: string) =>
   string.match(
     /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g,


### PR DESCRIPTION
Fikser visning av h5p som visuelt element i artikkel

Artikkel https://ed.test.ndla.no/subject-matter/topic-article/16978/edit/nb klarer ikkje vise h5p som visuelt element fordi kun domene hentes ut og dermed funker ikkje lenger oembed-kallet. Heile origin med skjema og port må være med.