### PR TITLE
Fixed preview render bugs when an article included a CodeDiv

### DIFF
--- a/src/components/PreviewDraft/PreviewDraftLightbox.tsx
+++ b/src/components/PreviewDraft/PreviewDraftLightbox.tsx
@@ -12,6 +12,7 @@ import Button from '@ndla/button';
 import { spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { OneColumn } from '@ndla/ui';
 import * as articleApi from '../../modules/article/articleApi';
 import * as draftApi from '../../modules/draft/draftApi';
 import Lightbox, { closeLightboxButtonStyle, StyledCross } from '../Lightbox';
@@ -191,12 +192,14 @@ const PreviewDraftLightbox = ({ getArticle, typeOfPreview, version, label, child
             onChangePreviewLanguage={onChangePreviewLanguage}
             previewLanguage={previewLanguage!}
             getEntityPreview={(article, label, contentType) => (
-              <PreviewDraft
-                article={article as ArticleConverterApiType}
-                label={label}
-                contentType={contentType}
-                language={previewLanguage! as LocaleType}
-              />
+              <OneColumn>
+                <PreviewDraft
+                  article={article as ArticleConverterApiType}
+                  label={label}
+                  contentType={contentType}
+                  language={previewLanguage! as LocaleType}
+                />
+              </OneColumn>
             )}
           />
         </Lightbox>

--- a/src/components/PreviewDraft/PreviewLightboxContent.tsx
+++ b/src/components/PreviewDraft/PreviewLightboxContent.tsx
@@ -77,6 +77,7 @@ const PreviewLightboxContent = ({
         contentType={contentType}
         secondEntity={entities[1]}
         previewLanguage={previewLanguage}
+        getEntityPreview={getEntityPreview}
       />
     );
   }

--- a/src/components/PreviewDraft/PreviewProduction.tsx
+++ b/src/components/PreviewDraft/PreviewProduction.tsx
@@ -6,10 +6,17 @@
  *
  */
 
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArticleConverterApiType } from '../../modules/article/articleApiInterfaces';
-import PreviewDraft from './PreviewDraft';
+import { ConceptPreviewType } from '../PreviewConcept/PreviewConceptLightbox';
 import StyledPreviewTwoArticles from './StyledPreviewTwoArticles';
+
+const StyledPreview = styled.div`
+  display: inline-block;
+  width: 100%;
+`;
 
 interface Props {
   firstEntity: ArticleConverterApiType;
@@ -17,6 +24,11 @@ interface Props {
   contentType?: string;
   label: string;
   previewLanguage: string;
+  getEntityPreview: (
+    entity: ArticleConverterApiType | ConceptPreviewType,
+    label: string,
+    contentType?: string,
+  ) => ReactNode;
 }
 
 const PreviewProduction = ({
@@ -25,33 +37,24 @@ const PreviewProduction = ({
   label,
   previewLanguage,
   contentType,
+  getEntityPreview,
 }: Props) => {
   const { t } = useTranslation();
   return (
-    <>
+    <StyledPreview>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
           {t('form.previewProductionArticle.current')}
         </h2>
-        <PreviewDraft
-          article={firstEntity}
-          label={label}
-          contentType={contentType}
-          language={previewLanguage}
-        />
+        {getEntityPreview(firstEntity, label, contentType)}
       </StyledPreviewTwoArticles>
       <StyledPreviewTwoArticles>
         <h2 className="u-4/6@desktop u-push-1/6@desktop">
           {t('form.previewProductionArticle.version', { revision: secondEntity.revision })}
         </h2>
-        <PreviewDraft
-          article={secondEntity}
-          label={label}
-          contentType={contentType}
-          language={previewLanguage}
-        />
+        {getEntityPreview(secondEntity, label, contentType)}
       </StyledPreviewTwoArticles>
-    </>
+    </StyledPreview>
   );
 };
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2878

Synderen var hverken bilder eller H5P, men HTML! 

Forskjellen kan testes ved å se på forskjellen på [denne](https://ed.test.ndla.no/nn/subject-matter/learning-resource/31359/edit/nb) i test og i PR-instansen ved sammenligning av språk, i versjonshistorien og på forhåndsvisningssiden. 

