### PR TITLE
Reset AlertModalWrapper nextLocation on cancel

### DIFF
--- a/src/containers/FormikForm/AlertModalWrapper.tsx
+++ b/src/containers/FormikForm/AlertModalWrapper.tsx
@@ -73,6 +73,7 @@ const AlertModalWrapper = ({ text, severity, isSubmitting, formIsDirty, onContin
   }, shouldBlock);
 
   const onCancel = () => {
+    setNextLocation(undefined);
     setOpenModal(false);
   };
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2917

Fikser en feil der AlertModal i artikkel-editor redirecter deg til annet språk etter lagring.

Hvordan reprodusere i test:
1. Gjør en endring i bokmål.
2. Trykk på nynorsk versjon i header.
3. Trykk avbryt så du forblir på bokmål-versjon
4. Lagre deretter artikkel
5. Du skal nå ha blitt redirected til nynorsk, men artikkelen har blitt lagret som forventet.

i PR-instans skal du i steg 5 forbli på bokmål.