### PR TITLE
Added z-index to EditRelated in order to be above SlateImage when active

### DIFF
--- a/src/components/SlateEditor/plugins/related/EditRelated.tsx
+++ b/src/components/SlateEditor/plugins/related/EditRelated.tsx
@@ -26,6 +26,7 @@ import { RelatedArticleType, ExternalArticle } from './RelatedArticleBox';
 const StyledContainer = styled('div')`
   position: absolute;
   width: 100%;
+  z-index: 2;
 `;
 
 const StyledBorderDiv = styled('div')`

--- a/src/components/SlateEditor/plugins/related/__tests__/__snapshots__/RelatedArticleBox-test.tsx.snap
+++ b/src/components/SlateEditor/plugins/related/__tests__/__snapshots__/RelatedArticleBox-test.tsx.snap
@@ -8,6 +8,7 @@ exports[`it goes in and out of edit mode 1`] = `
 .emotion-50 {
   position: absolute;
   width: 100%;
+  z-index: 2;
 }
 
 .emotion-0 {
@@ -799,6 +800,7 @@ exports[`it goes in and out of edit mode 2`] = `
 .emotion-33 {
   position: absolute;
   width: 100%;
+  z-index: 2;
 }
 
 .emotion-0 {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2932

Kan testes ved å gjenskape bildet i linket issue.