### PR TITLE
Unhang range when toggling list items

### DIFF
--- a/src/components/SlateEditor/plugins/list/utils/toggleList.ts
+++ b/src/components/SlateEditor/plugins/list/utils/toggleList.ts
@@ -58,6 +58,7 @@ export const toggleList = (editor: Editor, type: string) => {
     const nodes = [
       ...Editor.nodes(editor, {
         match: node => Element.isElement(node) && firstTextBlockElement.includes(node.type),
+        at: Editor.unhangRange(editor, editor.selection),
       }),
     ];
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2942

Ved trippelklikk på en paragraf, slik at hele paragrafen blir markert + et ekstra mellomrom på høyre side, fikk man en rar interaksjon. Spesielt om den markerte paragrafen var siste element i en liste. Dette skjer fordi Slate har et konsept om at siste punkt på en linje tilsvarere første punkt på neste. 

Ved toggling av liste på siste paragraf i en boks endte slate derfor opp med å toggle liste _etter_ boksen heller.

Hvordan teste:
1. Åpne en artikkel og sett inn en av boks-typene.
2. Trippel-klikk siste paragraf på linja slik at du markerer alt + det ekstra "usynlige" mellomrommet på høyre side.
3. Toggle liste
4. Lista skal nå toggles inni boksen og ikke utenfor.

