### PR TITLE
Re-add file option in VisualElementSearch

### DIFF
--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
@@ -35,7 +35,7 @@ const DisplayExternalModal = ({
           selectedResource={allowedProvider.name}
           selectedResourceUrl={src}
           selectedResourceType={type}
-          handleVisualElementChange={onEditEmbed}
+          handleVisualElementChange={rt => (rt.type === 'embed' ? onEditEmbed(rt.value) : null)}
           closeModal={onClose}
           setH5pFetchFail={setH5pFetchFail}
         />

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
@@ -1,11 +1,12 @@
 import { Element } from 'slate';
 import { FormikContextType, useFormikContext } from 'formik';
-import VisualElementSearch from '../../../../containers/VisualElement/VisualElementSearch';
+import VisualElementSearch, {
+  VisualElementChangeReturnType,
+} from '../../../../containers/VisualElement/VisualElementSearch';
 import { defaultEmbedBlock } from '../embed/utils';
 import { defaultFileBlock } from '../file/utils';
 import VisualElementModalWrapper from '../../../../containers/VisualElement/VisualElementModalWrapper';
 import { ImageApiType } from '../../../../modules/image/imageApiInterfaces';
-import { Embed } from '../../../../interfaces';
 
 export const checkboxAction = (
   image: ImageApiType,
@@ -38,12 +39,12 @@ const SlateVisualElementPicker = ({
 
   const showCheckbox = values.metaImageAlt !== undefined && values.metaImageId !== undefined;
 
-  const onVisualElementAdd = (visualElement: Partial<Embed> | DOMStringMap[], type = 'embed') => {
-    if (type === 'embed') {
-      const blockToInsert = defaultEmbedBlock(visualElement as Partial<Embed>);
+  const onVisualElementAdd = (visualElement: VisualElementChangeReturnType) => {
+    if (visualElement.type === 'embed') {
+      const blockToInsert = defaultEmbedBlock(visualElement.value);
       onInsertBlock(blockToInsert);
-    } else if (type === 'file') {
-      const blockToInsert = defaultFileBlock(visualElement as DOMStringMap[]);
+    } else if (visualElement.type === 'file') {
+      const blockToInsert = defaultFileBlock(visualElement.value);
       onInsertBlock(blockToInsert);
     }
     onVisualElementClose();

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageBanner.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageBanner.tsx
@@ -51,7 +51,9 @@ const SubjectpageBanner = ({ field, form, title }: Props) => {
         <Lightbox display appearance={'big'} onClose={onImageSelectClose}>
           <VisualElementSearch
             selectedResource={'image'}
-            handleVisualElementChange={embed => onImageChange(embed as ImageEmbed)}
+            handleVisualElementChange={rt =>
+              rt.type === 'embed' ? onImageChange(rt.value as ImageEmbed) : null
+            }
             closeModal={onImageSelectClose}
           />
         </Lightbox>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2955
Viste seg å være ganske greit når man la inn en discriminated union.

Vi håndterer ikke filer som returtype i `SubjectPageBanner` og `DisplayExternalModal`, men det er det heller ikke behov for akkurat nå.