### PR TITLE
Fixed the ability to save in the html editor by pressing MOD+S

### DIFF
--- a/src/components/MonacoEditor/editorActions.js
+++ b/src/components/MonacoEditor/editorActions.js
@@ -44,7 +44,7 @@ export function createSaveAction(monaco, onSave) {
     contextMenuOrder: 0,
 
     run: async function(editor) {
-      await onSave();
+      await onSave(editor.getValue());
 
       return null;
     },

--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -235,7 +235,7 @@ const EditMarkupPage = () => {
             margin: ${spacing.normal};
           `}>
           <PreviewDraftLightbox
-            label={t('form.previewProductionArticle.published')}
+            label={t('form.previewProductionArticle.article')}
             typeOfPreview="preview"
             getArticle={() => {
               const content = standardizeContent(draft?.content?.content ?? '');

--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -156,11 +156,10 @@ const EditMarkupPage = () => {
     })();
   }, [draftId, language]);
 
-  const saveChanges = async () => {
+  const saveChanges = async (editorContent: string) => {
     try {
       setStatus('saving');
-      const stateContent = draft?.content?.content;
-      const content = standardizeContent(stateContent ?? '');
+      const content = standardizeContent(editorContent ?? '');
       const updatedDraft = await updateDraft({
         id: parseInt(draftId, 10),
         content,
@@ -236,7 +235,7 @@ const EditMarkupPage = () => {
             margin: ${spacing.normal};
           `}>
           <PreviewDraftLightbox
-            label={t('form.previewProductionArticle.article')}
+            label={t('form.previewProductionArticle.published')}
             typeOfPreview="preview"
             getArticle={() => {
               const content = standardizeContent(draft?.content?.content ?? '');
@@ -261,7 +260,7 @@ const EditMarkupPage = () => {
               isSaving={status === 'saving'}
               formIsDirty={status === 'edit'}
               showSaved={status === 'saved'}
-              onClick={saveChanges}
+              onClick={() => saveChanges(draft?.content?.content ?? '')}
             />
           </Row>
         </Row>

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -588,6 +588,7 @@ const phrases = {
       button: 'Compare current version with old version',
       version: 'Version {{revision}}',
       current: 'Current version',
+      published: 'Published version',
     },
     previewLanguageArticle: {
       button: 'Compare language versions',

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -588,7 +588,7 @@ const phrases = {
       button: 'Compare current version with old version',
       version: 'Version {{revision}}',
       current: 'Current version',
-      published: 'Published version',
+      article: 'Article',
     },
     previewLanguageArticle: {
       button: 'Compare language versions',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -590,6 +590,7 @@ const phrases = {
       button: 'Sammenlign gjeldende versjon med gammel versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
+      published: 'Publisert versjon',
     },
     previewLanguageArticle: {
       button: 'Sammenlign språkversjoner',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -590,7 +590,7 @@ const phrases = {
       button: 'Sammenlign gjeldende versjon med gammel versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
-      published: 'Publisert versjon',
+      article: 'Artikkel',
     },
     previewLanguageArticle: {
       button: 'Sammenlign språkversjoner',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -589,7 +589,7 @@ const phrases = {
       button: 'Samanlikn gjeldande versjon med gamal versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
-      published: 'Publisert versjon',
+      article: 'Artikkel',
     },
     previewLanguageArticle: {
       button: 'Samanlikn språkversjonar',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -589,6 +589,7 @@ const phrases = {
       button: 'Samanlikn gjeldande versjon med gamal versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
+      published: 'Publisert versjon',
     },
     previewLanguageArticle: {
       button: 'Samanlikn språkversjonar',


### PR DESCRIPTION
Feilen ble introdusert i https://github.com/NDLANO/editorial-frontend/pull/1284, og kommer antageligvis av endringen fra klassekomponent til funksjonskomponent. Jeg er ikke helt sikker på hva feilen er, men det virker som at funksjonen som passeres inn til Monaco tar i bruk state-verdiene den innehar når Monaco-instansen blir opprettet. 

`draft`-verdien i `EditMarkupPage` sin state er riktig helt inntil den kalles på inne i `saveChanges`. Derfor mente jeg den mest logiske løsningen var å heller la Monaco håndtere denne staten i størst mulig grad. Den brukes dog fortsatt for å oppnå lagring ved knappetrykk. 

Fikset også en oversettelse som ser ut til å ha falt bort for en stund siden. La inn en ny nøkkel for å fikse det.