### PR TITLE
2962 Add grepCodes field when converting TopicArticleFormType to UpdatedDraftApiType

### DIFF
--- a/src/containers/ArticlePage/articleTransformers.ts
+++ b/src/containers/ArticlePage/articleTransformers.ts
@@ -179,6 +179,7 @@ export const topicArticleFormTypeToDraftApiType = (
     copyright: copyright,
     articleType: article.articleType,
     notes: article.notes,
+    grepCodes: article.grepCodes,
     conceptIds: article.conceptIds,
     availability: article.availability,
     relatedContent: article.relatedContent,


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2962

Hvordan teste: Legg til en læreplankobling på en topic-article. Etter lagring og refreshing av siden skal grepCoden forbli.