### PR TITLE
Add span plugin to handle span with language attribute

### DIFF
--- a/src/components/SlateEditor/helpers.ts
+++ b/src/components/SlateEditor/helpers.ts
@@ -2,5 +2,13 @@ import { TYPE_CONCEPT } from './plugins/concept';
 import { TYPE_FOOTNOTE } from './plugins/footnote';
 import { TYPE_CONTENT_LINK, TYPE_LINK } from './plugins/link';
 import { TYPE_MATHML } from './plugins/mathml';
+import { TYPE_SPAN } from './plugins/span';
 
-export const inlines = [TYPE_CONCEPT, TYPE_FOOTNOTE, TYPE_LINK, TYPE_CONTENT_LINK, TYPE_MATHML];
+export const inlines = [
+  TYPE_CONCEPT,
+  TYPE_FOOTNOTE,
+  TYPE_LINK,
+  TYPE_CONTENT_LINK,
+  TYPE_MATHML,
+  TYPE_SPAN,
+];

--- a/src/components/SlateEditor/interfaces.ts
+++ b/src/components/SlateEditor/interfaces.ts
@@ -36,6 +36,7 @@ import { EmbedElement } from './plugins/embed';
 import { BodyboxElement } from './plugins/bodybox';
 import { CodeblockElement } from './plugins/codeBlock';
 import { DivElement } from './plugins/div';
+import { SpanElement } from './plugins/span';
 
 export type SlatePlugin = (editor: Editor) => Editor;
 
@@ -86,7 +87,8 @@ declare module 'slate' {
       | RelatedElement
       | EmbedElement
       | BodyboxElement
-      | DivElement;
+      | DivElement
+      | SpanElement;
     Text: CustomTextWithMarks;
   }
 }

--- a/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { createEditor, Descendant, Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+import withPlugins from '../../../utils/withPlugins';
+import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { TYPE_SECTION } from '../../section';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
+import { TYPE_SPAN } from '..';
+
+const editor = withHistory(
+  withReact(withPlugins(createEditor(), plugins('nb', 'nb', { current: () => {} }))),
+);
+
+describe('paragraph normalizer tests', () => {
+  test('Remove serializeAsText from paragraph that is not placed in list-item', () => {
+    const editorValue: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [
+              { text: '' },
+              { type: TYPE_SPAN, data: { lang: 'en' }, children: [{ text: 'test' }] },
+              { text: '' },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [
+              { text: '' },
+              { type: TYPE_SPAN, data: { lang: 'en' }, children: [{ text: 'test' }] },
+              { text: '' },
+            ],
+          },
+        ],
+      },
+    ];
+
+    editor.children = editorValue;
+    Editor.normalize(editor, { force: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
+});

--- a/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2022-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,8 +19,8 @@ const editor = withHistory(
   withReact(withPlugins(createEditor(), plugins('nb', 'nb', { current: () => {} }))),
 );
 
-describe('paragraph normalizer tests', () => {
-  test('Remove serializeAsText from paragraph that is not placed in list-item', () => {
+describe('span normalizer tests', () => {
+  test('Span with language remains after normalization', () => {
     const editorValue: Descendant[] = [
       {
         type: TYPE_SECTION,

--- a/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Descendant } from 'slate';
+import { TYPE_SECTION } from '../../section';
+import {
+  learningResourceContentToEditorValue,
+  learningResourceContentToHTML,
+} from '../../../../../util/articleContentConverter';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
+import { TYPE_SPAN } from '..';
+
+const editor: Descendant[] = [
+  {
+    type: TYPE_SECTION,
+    children: [
+      {
+        type: TYPE_PARAGRAPH,
+        children: [{ type: TYPE_SPAN, data: { lang: 'en' }, children: [{ text: 'test' }] }],
+      },
+    ],
+  },
+];
+
+const html = '<section><p><span lang="en">test</span></p></section>';
+const htmlWithoutAttributes = '<section><p><span>test</span></p></section>';
+
+describe('span serializing tests', () => {
+  test('serializing', () => {
+    const res = learningResourceContentToHTML(editor);
+    expect(res).toMatch(html);
+  });
+
+  test('serializing handles spans without attributes', () => {
+    const editorWithoutAttributes: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [{ type: TYPE_SPAN, children: [{ text: 'test' }] }],
+          },
+        ],
+      },
+    ];
+
+    const res = learningResourceContentToHTML(editorWithoutAttributes);
+    expect(res).toMatch(htmlWithoutAttributes);
+  });
+
+  test('deserializing', () => {
+    const res = learningResourceContentToEditorValue(html);
+    expect(res).toEqual(editor);
+  });
+
+  test('deserializing handles span without attributes', () => {
+    const editorWithoutSpan: Descendant[] = [
+      {
+        type: TYPE_SECTION,
+        children: [
+          {
+            type: TYPE_PARAGRAPH,
+            children: [{ text: 'test' }],
+          },
+        ],
+      },
+    ];
+
+    const res = learningResourceContentToEditorValue(htmlWithoutAttributes);
+    expect(res).toEqual(editorWithoutSpan);
+  });
+});

--- a/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2022-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/span/index.tsx
+++ b/src/components/SlateEditor/plugins/span/index.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Dictionary, isEmpty } from 'lodash';
+import { Descendant, Editor, Element } from 'slate';
+import { jsx as slatejsx } from 'slate-hyperscript';
+import { RenderElementProps } from 'slate-react';
+import { createProps, reduceElementDataAttributes } from '../../../../util/embedTagHelpers';
+import { SlateSerializer } from '../../interfaces';
+
+export interface SpanElement {
+  type: 'span';
+  data?: Dictionary<string>;
+  children: Descendant[];
+}
+
+export const TYPE_SPAN = 'span';
+
+export const spanSerializer: SlateSerializer = {
+  deserialize(el: HTMLElement, children: Descendant[]) {
+    if (el.tagName.toLowerCase() !== 'span') return;
+
+    const attributes = reduceElementDataAttributes(el);
+
+    if (isEmpty(attributes)) return;
+
+    return slatejsx('element', { type: TYPE_SPAN, data: attributes }, children);
+  },
+  serialize(node: Descendant, children: JSX.Element[]) {
+    if (!Element.isElement(node)) return;
+    if (node.type !== TYPE_SPAN) return;
+
+    const props = node.data ? createProps(node.data) : {};
+
+    return <span {...props}>{children}</span>;
+  },
+};
+
+export const spanPlugin = (editor: Editor) => {
+  const { renderElement, isInline } = editor;
+
+  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
+    if (element.type === TYPE_SPAN) {
+      return <span {...attributes}>{children}</span>;
+    } else if (renderElement) {
+      return renderElement({ attributes, children, element });
+    }
+    return undefined;
+  };
+
+  editor.isInline = element => {
+    if (element.type === TYPE_SPAN) {
+      return true;
+    }
+    return isInline(element);
+  };
+
+  return editor;
+};

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -62,6 +62,7 @@ import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import { SessionProps } from '../../../Session/SessionProvider';
 import withSession from '../../../Session/withSession';
 import RichTextEditor from '../../../../components/SlateEditor/RichTextEditor';
+import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
 
 const byLineStyle = css`
   display: flex;
@@ -100,6 +101,7 @@ export const plugins = (
 ): SlatePlugin[] => {
   return [
     sectionPlugin,
+    spanPlugin,
     divPlugin,
     paragraphPlugin(
       articleLanguage,

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -45,6 +45,7 @@ import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { useSession } from '../../../Session/SessionProvider';
+import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
 
 const byLineStyle = css`
   display: flex;
@@ -71,6 +72,7 @@ const createPlugins = (language: string, handleSubmitRef: RefObject<() => void>)
   // Plugins are checked from last to first
   return [
     sectionPlugin,
+    spanPlugin,
     divPlugin,
     paragraphPlugin(
       language,

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -38,6 +38,7 @@ import { parseEmbedTag, createEmbedTag } from './embedTagHelpers';
 import { Embed } from '../interfaces';
 import { TYPE_PARAGRAPH } from '../components/SlateEditor/plugins/paragraph/utils';
 import { divSerializer } from '../components/SlateEditor/plugins/div';
+import { spanSerializer } from '../components/SlateEditor/plugins/span';
 
 export const sectionSplitter = (html: string) => {
   const node = document.createElement('div');
@@ -88,6 +89,7 @@ const learningResourceRules: SlateSerializer[] = [
   embedSerializer,
   bodyboxSerializer,
   divSerializer,
+  spanSerializer,
 ];
 
 // Rules are checked from first to last
@@ -105,6 +107,7 @@ const topicArticleRules: SlateSerializer[] = [
   conceptSerializer,
   noEmbedSerializer,
   divSerializer,
+  spanSerializer,
 ];
 
 export const learningResourceContentToEditorValue = (html?: string): Descendant[] => {


### PR DESCRIPTION
Fixes NDLANO/Issues#2963

Opprettet en ny plugin for å håndtere spans med language. Feks `<span lang="en">some English text</span>`

Hvordan teste:
1. Åpne en artikkel
2. Legg til en span tilsvarende den over i html-editor. Feks `<p>Engelsk tekst: <span lang="en">some English text</span></p>`
3. Lagre.
4. Gjør noen endring i slate-editor og lagre.
5. Gå tilbake til html-editor og sjekk at span med lang-attributt fortsatt finnes.