### PR TITLE
Don't delete audioType from audio query type

### DIFF
--- a/cypress/integration/Editor/slate_block_picker_spec.js
+++ b/cypress/integration/Editor/slate_block_picker_spec.js
@@ -102,7 +102,7 @@ describe('can enter both element types SlateBlockPicker and SlateVisualElementPi
   it('opens and closes podcast', () => {
     cy.apiroute(
       'GET',
-      '/audio-api/v1/audio/?audio-type=podcast&locale=nb&page=1&page-size=16&query=',
+      '/audio-api/v1/audio/?audio-type=podcast&language=nb&page=1&page-size=16&query=',
       'editor/audios/podcastList',
     );
     cy.apiroute('GET', '**/audio-api/v1/audio/*?language=nb', 'editor/audios/audio-1');
@@ -117,7 +117,7 @@ describe('can enter both element types SlateBlockPicker and SlateVisualElementPi
   it('opens and closes audio', () => {
     cy.apiroute(
       'GET',
-      '/audio-api/v1/audio/?audio-type=standard&locale=nb&page=1&page-size=16&query=',
+      '/audio-api/v1/audio/?audio-type=standard&language=nb&page=1&page-size=16&query=',
       'editor/audios/audioList',
     );
     cy.apiroute('GET', '**/audio-api/v1/audio/*?language=nb', 'editor/audios/audio-1');

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -57,19 +57,20 @@ interface Props {
 interface LocalAudioSearchParams extends Omit<AudioSearchParams, 'audio-type' | 'page-size'> {
   audioType?: string;
   pageSize?: number;
+  locale?: string;
 }
 
 const searchAudios = (query: LocalAudioSearchParams) => {
   // AudioSearch passes values that are not accepted by the API. They must be altered to have the correct key.
-  const audioType = query.audioType;
-  delete query.audioType;
-  delete query.pageSize;
-  const correctQuery: AudioSearchParams = {
-    ...query,
+  const correctedQuery: AudioSearchParams = {
+    language: query.language ?? query.locale,
+    page: query.page,
+    query: query.query,
+    sort: query.sort,
     'page-size': 16,
-    'audio-type': audioType,
+    'audio-type': query.audioType,
   };
-  return searchAudio(correctQuery);
+  return searchAudio(correctedQuery);
 };
 
 const VisualElementSearch = ({


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2972

`audioType` er ikke et parameter til API'et, så det har tidligere blitt slettet fra query-objektet. Da defaulter AudioSearch til standard. Gått over til å beholde `audioType` i query-objektet, og istedenfor transformere det til riktig form.