### PR TITLE
2975 remove audioembed caption

### DIFF
--- a/src/components/SlateEditor/plugins/embed/EditAudio.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditAudio.tsx
@@ -9,12 +9,10 @@
 import { useEffect, FormEvent, MouseEvent, createRef } from 'react';
 import { css } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
-import { Input } from '@ndla/forms';
 import { AudioPlayer } from '@ndla/ui';
 import ObjectSelector from '../../../ObjectSelector';
 import Overlay from '../../../Overlay';
 import { Portal } from '../../../Portal';
-import { useSlateContext } from '../../SlateContext';
 import FigureButtons from './FigureButtons';
 import { SlateAudio, AudioEmbed } from '../../../../interfaces';
 
@@ -51,7 +49,6 @@ const EditAudio = ({
   const { t } = useTranslation();
   let placeholderElement: any = createRef();
   let embedElement: any = createRef();
-  const { submitted } = useSlateContext();
 
   useEffect(() => {
     const bodyRect = document.body.getBoundingClientRect();
@@ -106,16 +103,6 @@ const EditAudio = ({
             ]}
           />
           <AudioPlayer src={audio.audioFile.url} title={audio.title} speech={speech} />
-          <Input
-            name="caption"
-            label={t('form.audio.caption.label')}
-            container="div"
-            type="text"
-            value={changes?.caption || embed?.caption}
-            onChange={onAudioFigureInputChange}
-            placeholder={t('form.audio.caption.placeholder')}
-            submitted={submitted}
-          />
           <FigureButtons
             figureType="audio"
             tooltip={t('form.audio.remove')}

--- a/src/components/SlateEditor/plugins/embed/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateAudio.tsx
@@ -56,7 +56,6 @@ const SlateAudio = ({
         const audio = await fetchAudio(parseInt(embed.resource_id), language);
         setAudio({
           ...audio,
-          caption: embed.caption,
           title: audio.title?.title || '',
         });
       } catch (error) {

--- a/src/components/SlateEditor/plugins/embed/SlatePodcast.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlatePodcast.tsx
@@ -46,7 +46,6 @@ const SlatePodcast = ({
         const audio = await fetchAudio(parseInt(embed.resource_id), language);
         setAudio({
           ...audio,
-          caption: embed.caption,
           title: audio.title?.title || '',
         });
       } catch (error) {

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -210,7 +210,6 @@ const VisualElementSearch = ({
             handleVisualElementChange({
               type: 'embed',
               value: {
-                caption: '', // Caption not supported by audio-api
                 resource: 'audio',
                 resource_id: audio.id.toString(),
                 type: audioType,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -146,7 +146,6 @@ export interface BrightcoveEmbed {
 export interface AudioEmbed {
   resource: 'audio';
   resource_id: string;
-  caption: string;
   type: string;
   url: string;
 }
@@ -204,7 +203,6 @@ export interface UnsavedFile {
 
 export interface SlateAudio extends Omit<AudioApiType, 'title'> {
   title: string;
-  caption: string;
 }
 
 export interface FormikInputEvent {


### PR DESCRIPTION
Fixes NDLANO/Issues#2975

Fjerner input-felt fra caption i slate. Dataen vil likevel aldri forsvinne fra eksisterende embeds med mindre det slettes i html-editor eller at det lages en ny migrasjon.

Det går an å skrive om Slate til å bli strengere og ikke ta med uønskede attributter, men det vil føre til at lagreknappen blir blå i alle artikler som har `data-caption`-feltet per nå. Noen tanker?

Hvordan teste:
- Legg inn Lyd i artikkel.
- Trykk på den etterpå for å redigere. Det skal ikke lenger finnes et felt for lydtekst.