### PR TITLE
Slate performance improvements

### DIFF
--- a/src/components/SlateEditor/helpers.ts
+++ b/src/components/SlateEditor/helpers.ts
@@ -1,8 +1,16 @@
+import { TYPE_ASIDE } from './plugins/aside';
+import { TYPE_BODYBOX } from './plugins/bodybox';
+import { TYPE_CODEBLOCK } from './plugins/codeBlock';
 import { TYPE_CONCEPT } from './plugins/concept';
+import { TYPE_DETAILS } from './plugins/details';
+import { TYPE_EMBED } from './plugins/embed';
+import { TYPE_FILE } from './plugins/file';
 import { TYPE_FOOTNOTE } from './plugins/footnote';
 import { TYPE_CONTENT_LINK, TYPE_LINK } from './plugins/link';
 import { TYPE_MATHML } from './plugins/mathml';
+import { TYPE_RELATED } from './plugins/related';
 import { TYPE_SPAN } from './plugins/span';
+import { TYPE_TABLE } from './plugins/table/utils';
 
 export const inlines = [
   TYPE_CONCEPT,
@@ -11,4 +19,15 @@ export const inlines = [
   TYPE_CONTENT_LINK,
   TYPE_MATHML,
   TYPE_SPAN,
+];
+
+export const blocks = [
+  TYPE_ASIDE,
+  TYPE_BODYBOX,
+  TYPE_CODEBLOCK,
+  TYPE_DETAILS,
+  TYPE_EMBED,
+  TYPE_FILE,
+  TYPE_RELATED,
+  TYPE_TABLE,
 ];

--- a/src/components/SlateEditor/plugins/aside/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/aside/__tests__/serializer-test.ts
@@ -19,16 +19,21 @@ const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
       {
         type: TYPE_ASIDE,
         data: { type: 'factAside' },
         children: [{ type: TYPE_PARAGRAPH, children: [{ text: 'content' }] }],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
       {
         type: TYPE_ASIDE,
         data: { type: 'rightAside' },
         children: [{ type: TYPE_PARAGRAPH, children: [{ text: 'content' }] }],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/bodybox/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/bodybox/__tests__/serializer-test.ts
@@ -19,10 +19,12 @@ const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       {
         type: TYPE_BODYBOX,
         children: [{ type: TYPE_PARAGRAPH, children: [{ text: 'content' }] }],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/codeBlock/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/codeBlock/__tests__/serializer-test.ts
@@ -13,11 +13,13 @@ import {
   learningResourceContentToHTML,
 } from '../../../../../util/articleContentConverter';
 import { TYPE_CODEBLOCK } from '..';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
 
 const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       {
         type: TYPE_CODEBLOCK,
         data: {
@@ -29,6 +31,7 @@ const editor: Descendant[] = [
         children: [{ text: '' }],
         isFirstEdit: false,
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/concept/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/concept/__tests__/serializer-test.ts
@@ -22,6 +22,7 @@ const editor: Descendant[] = [
       {
         type: TYPE_PARAGRAPH,
         children: [
+          { text: '' },
           {
             type: TYPE_CONCEPT,
             data: {
@@ -32,6 +33,7 @@ const editor: Descendant[] = [
             },
             children: [{ text: 'my concept' }],
           },
+          { text: '' },
         ],
       },
     ],

--- a/src/components/SlateEditor/plugins/details/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/details/__tests__/serializer-test.ts
@@ -19,6 +19,8 @@ const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
       {
         type: TYPE_DETAILS,
         children: [
@@ -26,6 +28,7 @@ const editor: Descendant[] = [
           { type: TYPE_PARAGRAPH, children: [{ text: 'content' }] },
         ],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/embed/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/embed/__tests__/serializer-test.ts
@@ -13,12 +13,15 @@ import {
   learningResourceContentToHTML,
 } from '../../../../../util/articleContentConverter';
 import { TYPE_EMBED } from '..';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
 
 describe('embed image serializing tests', () => {
   const editorWithImage: Descendant[] = [
     {
       type: TYPE_SECTION,
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: TYPE_EMBED,
           children: [
@@ -36,6 +39,7 @@ describe('embed image serializing tests', () => {
             url: 'https://test.url',
           },
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
     },
   ];
@@ -58,6 +62,8 @@ describe('embed brightcove video serializing tests', () => {
   const editorWithBrightcove: Descendant[] = [
     {
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: 'embed',
           data: {
@@ -75,6 +81,7 @@ describe('embed brightcove video serializing tests', () => {
             },
           ],
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
       type: 'section',
     },
@@ -96,6 +103,8 @@ describe('embed youtube video serializing tests', () => {
   const editorWithYotube: Descendant[] = [
     {
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: 'embed',
           data: {
@@ -109,6 +118,7 @@ describe('embed youtube video serializing tests', () => {
             },
           ],
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
       type: 'section',
     },
@@ -131,10 +141,11 @@ describe('embed audio serializing tests', () => {
     {
       type: TYPE_SECTION,
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: TYPE_EMBED,
           data: {
-            caption: 'test-caption',
             resource: 'audio',
             resource_id: '123',
             type: 'standard',
@@ -146,12 +157,13 @@ describe('embed audio serializing tests', () => {
             },
           ],
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
     },
   ];
 
   const htmlWithAudio =
-    '<section><embed data-caption="test-caption" data-resource="audio" data-resource_id="123" data-type="standard" data-url="https://test.url"/></section>';
+    '<section><embed data-resource="audio" data-resource_id="123" data-type="standard" data-url="https://test.url"/></section>';
 
   test('serializing audio', () => {
     const res = learningResourceContentToHTML(editorWithAudio);
@@ -169,10 +181,11 @@ describe('embed podcast serializing tests', () => {
     {
       type: TYPE_SECTION,
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: TYPE_EMBED,
           data: {
-            caption: '',
             resource: 'audio',
             resource_id: '123',
             type: 'podcast',
@@ -184,12 +197,13 @@ describe('embed podcast serializing tests', () => {
             },
           ],
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
     },
   ];
 
   const htmlWithPodcast =
-    '<section><embed data-caption="" data-resource="audio" data-resource_id="123" data-type="podcast" data-url="https://test.url"/></section>';
+    '<section><embed data-resource="audio" data-resource_id="123" data-type="podcast" data-url="https://test.url"/></section>';
 
   test('serializing podcast', () => {
     const res = learningResourceContentToHTML(editorWithPodcast);
@@ -207,6 +221,8 @@ describe('embed h5p serializing tests', () => {
     {
       type: TYPE_SECTION,
       children: [
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
         {
           type: TYPE_EMBED,
           data: {
@@ -220,6 +236,7 @@ describe('embed h5p serializing tests', () => {
             },
           ],
         },
+        { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       ],
     },
   ];

--- a/src/components/SlateEditor/plugins/file/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/file/__tests__/serializer-test.ts
@@ -13,11 +13,13 @@ import {
   learningResourceContentToHTML,
 } from '../../../../../util/articleContentConverter';
 import { TYPE_FILE } from '..';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
 
 const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       {
         type: TYPE_FILE,
         data: [
@@ -46,6 +48,7 @@ const editor: Descendant[] = [
         ],
         children: [{ text: '' }],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/footnote/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/footnote/__tests__/serializer-test.ts
@@ -42,6 +42,7 @@ const editor: Descendant[] = [
               },
             ],
           },
+          { text: '' },
         ],
       },
     ],

--- a/src/components/SlateEditor/plugins/link/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/serializer-test.ts
@@ -22,6 +22,7 @@ const editor: Descendant[] = [
       {
         type: TYPE_PARAGRAPH,
         children: [
+          { text: '' },
           {
             type: TYPE_LINK,
             href: 'http://test.url/',
@@ -34,11 +35,13 @@ const editor: Descendant[] = [
               },
             ],
           },
+          { text: '' },
         ],
       },
       {
         type: TYPE_PARAGRAPH,
         children: [
+          { text: '' },
           {
             type: TYPE_CONTENT_LINK,
             'content-id': '123',
@@ -50,6 +53,7 @@ const editor: Descendant[] = [
               },
             ],
           },
+          { text: '' },
         ],
       },
     ],

--- a/src/components/SlateEditor/plugins/mathml/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/mathml/__tests__/serializer-test.ts
@@ -21,6 +21,7 @@ const editor: Descendant[] = [
     children: [
       {
         children: [
+          { text: '' },
           {
             type: TYPE_MATHML,
             data: {
@@ -33,6 +34,7 @@ const editor: Descendant[] = [
               },
             ],
           },
+          { text: '' },
         ],
         type: TYPE_PARAGRAPH,
       },

--- a/src/components/SlateEditor/plugins/noEmbed/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/noEmbed/__tests__/serializer-test.ts
@@ -13,11 +13,13 @@ import {
   topicArticleContentToHTML,
 } from '../../../../../util/articleContentConverter';
 import { TYPE_EMBED } from '../../embed';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
 
 const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       {
         type: TYPE_EMBED,
         children: [
@@ -35,6 +37,7 @@ const editor: Descendant[] = [
           url: 'https://test123.no',
         },
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/related/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/related/__tests__/serializer-test.ts
@@ -13,11 +13,13 @@ import {
   learningResourceContentToHTML,
 } from '../../../../../util/articleContentConverter';
 import { TYPE_RELATED } from '..';
+import { TYPE_PARAGRAPH } from '../../paragraph/utils';
 
 const editor: Descendant[] = [
   {
     type: TYPE_SECTION,
     children: [
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
       {
         type: TYPE_RELATED,
         data: {
@@ -39,6 +41,7 @@ const editor: Descendant[] = [
           },
         ],
       },
+      { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
     ],
   },
 ];

--- a/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/serializer-test.ts
@@ -21,7 +21,11 @@ const editor: Descendant[] = [
     children: [
       {
         type: TYPE_PARAGRAPH,
-        children: [{ type: TYPE_SPAN, data: { lang: 'en' }, children: [{ text: 'test' }] }],
+        children: [
+          { text: '' },
+          { type: TYPE_SPAN, data: { lang: 'en' }, children: [{ text: 'test' }] },
+          { text: '' },
+        ],
       },
     ],
   },
@@ -43,7 +47,10 @@ describe('span serializing tests', () => {
         children: [
           {
             type: TYPE_PARAGRAPH,
-            children: [{ type: TYPE_SPAN, children: [{ text: 'test' }] }],
+            children: [
+              { text: '' },
+              { type: TYPE_SPAN, children: [{ text: 'test' }, { text: '' }] },
+            ],
           },
         ],
       },

--- a/src/components/SlateEditor/plugins/table/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/serializer-test.ts
@@ -28,6 +28,8 @@ describe('table serializing tests', () => {
       {
         type: TYPE_SECTION,
         children: [
+          { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
           {
             type: TYPE_TABLE,
             rowHeaders: false,
@@ -182,6 +184,7 @@ describe('table serializing tests', () => {
               },
             ],
           },
+          { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
         ],
       },
     ];
@@ -201,6 +204,8 @@ describe('table serializing tests', () => {
       {
         type: TYPE_SECTION,
         children: [
+          { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
+
           {
             type: TYPE_TABLE,
             rowHeaders: true,
@@ -326,6 +331,7 @@ describe('table serializing tests', () => {
               },
             ],
           },
+          { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -306,7 +306,7 @@ export const tablePlugin = (editor: Editor) => {
         });
       }
 
-      // i. Make sure table contains the correct caption, tableHead and tableBody nodes.
+      // iii. Make sure table contains the correct caption, tableHead and tableBody nodes.
       for (const [index, child] of node.children.entries()) {
         // Caption can't be placed at any other index than 0. Otherwise: Remote it.
         if (index !== 0 && isTableCaption(child)) {
@@ -321,7 +321,7 @@ export const tablePlugin = (editor: Editor) => {
         }
       }
 
-      // iii. Normalize each tableBody using matrix convertion for help.
+      // iv. Normalize each tableBody using matrix convertion for help.
       for (const [index, child] of node.children.entries()) {
         if (isTableHead(child) || isTableBody(child)) {
           if (normalizeTableBodyAsMatrix(editor, child, [...path, index])) {
@@ -329,7 +329,7 @@ export const tablePlugin = (editor: Editor) => {
           }
         }
       }
-      // iii. Add surrounding paragraphs. Must be last since the table itself is not altered.
+      // v. Add surrounding paragraphs. Must be last since the table itself is not altered.
       if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
         return;
       }

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -35,6 +35,7 @@ import {
   learningResourceFormTypeToDraftApiType,
 } from '../../articleTransformers';
 import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
+import { learningResourceContentToHTML } from '../../../../util/articleContentConverter';
 
 interface Props {
   article?: DraftApiType;
@@ -83,6 +84,10 @@ const LearningResourceForm = ({
     articleLanguage,
   });
 
+  const initialHTML = useMemo(() => learningResourceContentToHTML(initialValues.content), [
+    initialValues,
+  ]);
+
   const [translateOnContinue, setTranslateOnContinue] = useState(false);
 
   const FormikChild = (formik: FormikProps<LearningResourceFormType>) => {
@@ -93,6 +98,7 @@ const LearningResourceForm = ({
       initialValues,
       dirty,
       changed: articleChanged,
+      initialHTML,
     });
     usePreventWindowUnload(formIsDirty);
     const getArticle = () =>

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -32,6 +32,7 @@ import {
 import { validateDraft } from '../../../../modules/draft/draftApi';
 import { formikCommonArticleRules, isFormikFormDirty } from '../../../../util/formHelper';
 import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
+import { learningResourceContentToHTML } from '../../../../util/articleContentConverter';
 
 interface Props {
   article?: DraftApiType;
@@ -82,6 +83,10 @@ const TopicArticleForm = ({
     articleLanguage,
   });
 
+  const initialHTML = useMemo(() => learningResourceContentToHTML(initialValues.content), [
+    initialValues,
+  ]);
+
   const [translateOnContinue, setTranslateOnContinue] = useState(false);
 
   const FormikChild = (formik: FormikProps<TopicArticleFormType>) => {
@@ -92,6 +97,7 @@ const TopicArticleForm = ({
       initialValues,
       dirty,
       changed: articleChanged,
+      initialHTML,
     });
     usePreventWindowUnload(formIsDirty);
     const getArticle = () => topicArticleFormTypeToDraftApiType(values, initialValues, licenses!);

--- a/src/style/table.css
+++ b/src/style/table.css
@@ -29,3 +29,10 @@
   border-right: 3px solid #a5bcd3;
   border-bottom: 1px solid rgb(239, 240, 242);
 }
+
+.c-bodybox .c-table__wrapper,
+.c-factbox .c-table__wrapper {
+  max-width: 100% !important;
+  right: unset !important;
+  left: unset !important;
+}

--- a/src/style/table.css
+++ b/src/style/table.css
@@ -30,8 +30,8 @@
   border-bottom: 1px solid rgb(239, 240, 242);
 }
 
-.c-bodybox .c-table__wrapper,
-.c-factbox .c-table__wrapper {
+.c-editor .c-bodybox .c-table__wrapper,
+.c-editor .c-factbox .c-table__wrapper {
   max-width: 100% !important;
   right: unset !important;
   left: unset !important;

--- a/src/util/formHelper.ts
+++ b/src/util/formHelper.ts
@@ -35,13 +35,15 @@ const checkIfContentHasChanged = (
   currentValue: Descendant[],
   initialContent: Descendant[],
   type: string,
+  initialHTML?: string,
 ) => {
   if (currentValue.length !== initialContent.length) return true;
   const toHTMLFunction =
     type === 'standard' ? learningResourceContentToHTML : topicArticleContentToHTML;
   const newHTML = toHTMLFunction(currentValue);
-  const oldHTML = toHTMLFunction(initialContent);
-  const diff = diffHTML(newHTML, oldHTML);
+
+  const diff = diffHTML(newHTML, initialHTML || toHTMLFunction(initialContent));
+
   if (diff.warn) {
     return true;
   }
@@ -65,6 +67,7 @@ interface FormikFormDirtyParams<T extends FormikFields> {
   initialValues: T;
   dirty?: boolean;
   changed?: boolean;
+  initialHTML?: string;
 }
 
 export const isFormikFormDirty = <T extends FormikFields>({
@@ -72,6 +75,7 @@ export const isFormikFormDirty = <T extends FormikFields>({
   initialValues,
   dirty = false,
   changed = false,
+  initialHTML,
 }: FormikFormDirtyParams<T>) => {
   if (!dirty) {
     return changed;
@@ -95,7 +99,12 @@ export const isFormikFormDirty = <T extends FormikFields>({
       if (slateFields.includes(key)) {
         if (key === 'content') {
           if (
-            checkIfContentHasChanged(values[key]!, initialValues[key]!, initialValues.articleType!)
+            checkIfContentHasChanged(
+              values[key]!,
+              initialValues[key]!,
+              initialValues.articleType!,
+              initialHTML,
+            )
           ) {
             dirtyFields.push(value);
           }


### PR DESCRIPTION
Forbedrer ytelsen på slate med et par endringer:
- Ved konvertering av html til Slate gjøres det samtidig noe manuell normalisering nå. Tomme tekstfragmenter settes inn rundt inline-elementer (linker, matte osv) og tomme paragrafer settes ut rundt blokker (bilder, video osv). Dersom dette gjøres av Slate sin innebygde normalisering blir prosessen mye tyngre.
- Memoiserer html-en av originalartikkel. Dette reduserer tiden det tar å diffe htmlen med ca 50%. (Fra 90-110ms til 40-50ms)
- Fikset samtidig css på tabeller inni ekspanderende boks/faktaboks/tekstboks. Brede tabeller kunne tidligere flyte over sidene av boksen. Dette gjelder kun stylingen i slate.