### PR TITLE
Bugfix: Lists can be indented using tab key

### DIFF
--- a/src/components/SlateEditor/plugins/list/handlers/onTab.ts
+++ b/src/components/SlateEditor/plugins/list/handlers/onTab.ts
@@ -23,8 +23,8 @@ const onTab = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEven
     return next && next(event);
   }
 
-  const [currentListNode, currentListPath] = listItemEntry;
-  const [currentItemNode, currentItemPath] = listEntry;
+  const [currentListNode, currentListPath] = listEntry;
+  const [currentItemNode, currentItemPath] = listItemEntry;
   const [[currentTextBlockNode, currentTextBlockPath]] = Editor.nodes(editor, {
     match: n => Element.isElement(n) && firstTextBlockElement.includes(n.type),
     mode: 'lowest',
@@ -43,6 +43,7 @@ const onTab = (event: KeyboardEvent, editor: Editor, next?: (event: KeyboardEven
     if (!editor.selection) {
       return next && next(event);
     }
+
     if (
       Path.isDescendant(editor.selection.anchor.path, currentItemPath) &&
       Path.isDescendant(editor.selection.focus.path, currentItemPath)


### PR DESCRIPTION
Fixes NDLANO/Issues#3004

Indentering av lister ved bruk av tab skal nå fungere igjen.

Hvordan teste:
Opprett en liste i en artikkel med flere punkter og test at tab og ctrl+tab fungerer.