### PR TITLE
Always set metadata invisible for new topic.

### DIFF
--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -129,7 +129,6 @@ const TopicArticleTaxonomy = ({ article, setIsOpen, updateNotes, taxonomy }: Pro
   const stageTaxonomyChanges = async ({ path, locale }: { path: string; locale?: LocaleType }) => {
     if (path) {
       const breadcrumb = await getBreadcrumbFromPath(path, locale);
-      const allStatuses = article.status ? article.status.other.concat(article.status.current) : [];
       const newTopic: StagedTopic = {
         id: 'staged',
         name: article.title?.title ?? '',
@@ -137,7 +136,7 @@ const TopicArticleTaxonomy = ({ article, setIsOpen, updateNotes, taxonomy }: Pro
         breadcrumb,
         metadata: {
           grepCodes: [],
-          visible: allStatuses.some(s => s === 'PUBLISHED'),
+          visible: false,
           customFields: {},
         },
       };


### PR DESCRIPTION
Fixes NDLANO/Issues#2980

Gjør alltid nye emner usynlige i taksonomi.

Test:
* Plasser et emne på en ny plass og lagre. Emnet skal være markert som usynlig.