### PR TITLE
Adds support for sketchup urls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,8 +101,9 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'VG', url: ['www.vg.no'] },
   { name: 'Trinket', url: ['trinket.io'], height: '700px' },
   { name: 'Codepen', url: ['codepen.io'], height: '500px' },
-  { name: 'Flourish studio', url: ['public.flourish.studio'] },
+  { name: 'Flourish studio', url: ['public.flourish.studio', 'flo.uri.sh'], height: '650px' },
   { name: 'Our World in Data', url: ['ourworldindata.org'] },
+  { name: 'SketchUp 3D Warehouse', url: ['3dwarehouse.sketchup.com'] },
 ];
 
 export const SearchTypeValues = [

--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.js
@@ -109,3 +109,34 @@ test('transformUrlIfNeeded replaces www with embed for ted.com', async () => {
   const url1 = await transformUrlIfNeeded('https://www.ted.com/talks/some_fancy_talk');
   expect(url1).toMatch('https://embed.ted.com/talks/some_fancy_talk');
 });
+
+test('transformUrlIfNeeded returns original for flourish', async () => {
+  const url1 = await transformUrlIfNeeded(
+    'https://public.flourish.studio/visualisation/8515737/embed',
+  );
+  expect(url1).toMatch('https://public.flourish.studio/visualisation/8515737/embed');
+  const url2 = await transformUrlIfNeeded('https://flo.uri.sh/visualisation/8515737/embed');
+  expect(url2).toMatch('https://flo.uri.sh/visualisation/8515737/embed');
+});
+
+test('transformUrlIfNeeded adds /embed for flourish', async () => {
+  const url1 = await transformUrlIfNeeded('https://public.flourish.studio/visualisation/8515737/');
+  expect(url1).toMatch('https://public.flourish.studio/visualisation/8515737/embed');
+  const url2 = await transformUrlIfNeeded('https://flo.uri.sh/visualisation/8515737');
+  expect(url2).toMatch('https://flo.uri.sh/visualisation/8515737/embed');
+});
+
+test('transformUrlIfNeeded creates embed-url for sketchup model if needed', async () => {
+  const url1 = await transformUrlIfNeeded(
+    'https://3dwarehouse.sketchup.com/model/eb498ef3-3de5-42ca-a621-34ea29cc08c4/Oppbygging-av-ringmur',
+  );
+  expect(url1).toMatch(
+    'https://3dwarehouse.sketchup.com/embed/eb498ef3-3de5-42ca-a621-34ea29cc08c4',
+  );
+  const url2 = await transformUrlIfNeeded(
+    'https://3dwarehouse.sketchup.com/embed/eb498ef3-3de5-42ca-a621-34ea29cc08c4',
+  );
+  expect(url2).toMatch(
+    'https://3dwarehouse.sketchup.com/embed/eb498ef3-3de5-42ca-a621-34ea29cc08c4',
+  );
+});

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -174,8 +174,7 @@ const frameSrc = (() => {
     'public.flourish.studio',
     'flo.uri.sh',
     'ourworldindata.org',
-    '3dwarehouse.sketchup.com',
-    'app.sketchup.com',
+    '*.sketchup.com',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -174,6 +174,7 @@ const frameSrc = (() => {
     'public.flourish.studio',
     'flo.uri.sh',
     'ourworldindata.org',
+    '3dwarehouse.sketchup.com',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -175,6 +175,7 @@ const frameSrc = (() => {
     'flo.uri.sh',
     'ourworldindata.org',
     '3dwarehouse.sketchup.com',
+    'app.sketchup.com',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [


### PR DESCRIPTION
Fixes NDLANO/Issues#3013

Legger til støtte for sketchup embeds.

Test
* Sjekk at du kan legge til feks https://3dwarehouse.sketchup.com/model/eb498ef3-3de5-42ca-a621-34ea29cc08c4/Oppbygging-av-ringmur og at dette lagres med embed-url uten tittel.