### PR TITLE
Add type-property to iframe embed.

### DIFF
--- a/src/containers/VisualElement/VisualElementUrlPreview.tsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.tsx
@@ -125,6 +125,7 @@ const VisualElementUrlPreview = ({
             type: 'embed',
             value: {
               resource: 'iframe',
+              type: 'iframe',
               url,
               width: '708px',
               height: whiteListedUrl.height || '486px',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -165,6 +165,7 @@ export interface H5pEmbed {
 export interface ExternalEmbed {
   resource: 'external' | 'iframe';
   url: string;
+  type?: string;
   metaData?: any;
   caption?: string;
   title?: string;


### PR DESCRIPTION
Legger til lagring av type iframe for iframe-embeds for å være klar når https://github.com/NDLANO/backend/pull/33 deployes.

Test:
* Når du setter inn ressurs fra lenke så sendes data-type=iframe i payload.
* I test vil propertyen ignoreres og fjernes
* Om du kjører mot versjon fra pr så lagres det og returneres.

Neste steg er å utvide ressurs fra lenke til å kunne spesifisere tittel, caption og bilde.