### PR TITLE
Removes lang from toEditConcept

### DIFF
--- a/src/containers/SearchPage/components/results/SearchConcept/ContentView.tsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/ContentView.tsx
@@ -58,7 +58,7 @@ const ContentView = ({
   return (
     <StyledConceptView>
       <h2>
-        <StyledLink noShadow to={toEditConcept(concept.id, locale)}>
+        <StyledLink noShadow to={toEditConcept(concept.id)}>
           {title}
         </StyledLink>
         {canEdit && !editing && (

--- a/src/util/routeHelpers.ts
+++ b/src/util/routeHelpers.ts
@@ -37,8 +37,9 @@ export function toEditNdlaFilm(language?: string) {
   return `/film/${language ? language : 'nb'}`;
 }
 
-export function toEditConcept(conceptId: number, locale: string) {
-  return `/concept/${conceptId}/edit/${locale}`;
+export function toEditConcept(conceptId: number, locale?: string) {
+  const path = `/concept/${conceptId}/edit`;
+  return locale ? `${path}/${locale}` : path;
 }
 
 export function toEditMarkup(id: number | string, language: string) {


### PR DESCRIPTION
Fixes NDLANO/Issues#3041

Unngår å få ukjente språkvarianter for forklaringer fra søkeresultatet.