### PR TITLE
Added memoization for root nodes

### DIFF
--- a/src/containers/StructurePageBeta/NodeItem.tsx
+++ b/src/containers/StructurePageBeta/NodeItem.tsx
@@ -166,7 +166,7 @@ interface Props {
   parentActive: boolean;
   allRootNodes: NodeType[];
   isRoot?: boolean;
-  favoriteNodeIds?: string[];
+  isFavorite: boolean;
   toggleFavorite?: () => void;
   nodes?: ChildNodeType[];
   isLoading?: boolean;
@@ -185,7 +185,7 @@ const NodeItem = ({
   parentActive,
   allRootNodes,
   isRoot,
-  favoriteNodeIds,
+  isFavorite,
   toggleFavorite,
   isLoading,
   nodes,
@@ -217,16 +217,10 @@ const NodeItem = ({
       key={path}
       greyedOut={!parentActive && !isActive}>
       <StyledItemBar level={level} highlight={isActive}>
-        {favoriteNodeIds && (
+        {isRoot && (
           <RoundIcon
             onClick={toggleFavorite}
-            smallIcon={
-              <Star
-                color={
-                  favoriteNodeIds.includes(item.id) ? colors.favoriteColor : colors.brand.greyDark
-                }
-              />
-            }
+            smallIcon={<Star color={isFavorite ? colors.favoriteColor : colors.brand.greyDark} />}
           />
         )}
         <ItemTitleButton
@@ -266,6 +260,7 @@ const NodeItem = ({
               onDragEnd={res => onDragEnd(res, nodes!)}>
               {nodes.map(t => (
                 <NodeItem
+                  isFavorite={false}
                   renderBeforeTitle={renderBeforeTitle}
                   key={`${path}/${t.id}`}
                   allRootNodes={allRootNodes}

--- a/src/containers/StructurePageBeta/RootNode.tsx
+++ b/src/containers/StructurePageBeta/RootNode.tsx
@@ -4,11 +4,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { MutableRefObject } from 'react';
+import { memo, MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DropResult } from 'react-beautiful-dnd';
 import { useQueryClient } from 'react-query';
-import { partition, sortBy } from 'lodash';
+import { isEqual, partition, sortBy } from 'lodash';
 import { ChildNodeType, NodeType } from '../../modules/nodes/nodeApiTypes';
 import { useChildNodesWithArticleType } from '../../modules/nodes/nodeQueries';
 import { groupChildNodes } from '../../util/taxonomyHelpers';
@@ -20,7 +20,7 @@ interface Props {
   node: NodeType;
   toggleOpen: (path: string) => void;
   openedPaths: string[];
-  favoriteNodeIds?: string[];
+  isFavorite: boolean;
   toggleFavorite: () => void;
   onChildNodeSelected: (node?: ChildNodeType) => void;
   resourceSectionRef: MutableRefObject<HTMLDivElement | null>;
@@ -29,7 +29,7 @@ interface Props {
 }
 
 const RootNode = ({
-  favoriteNodeIds,
+  isFavorite,
   node,
   openedPaths,
   toggleOpen,
@@ -93,10 +93,25 @@ const RootNode = ({
       parentActive={true}
       allRootNodes={allRootNodes}
       isRoot={true}
-      favoriteNodeIds={favoriteNodeIds}
+      isFavorite={isFavorite}
       isLoading={childNodesQuery.isLoading}
     />
   );
 };
 
-export default RootNode;
+const propsAreEqual = (prevProps: Props, props: Props) => {
+  const isInPath = props.openedPaths[0] === props.node.id;
+  const noLongerInPath = prevProps.openedPaths[0] === prevProps.node.id && !isInPath;
+  if (isInPath) {
+    return false;
+  } else if (noLongerInPath) {
+    return false;
+  }
+
+  if (prevProps.isFavorite !== props.isFavorite) {
+    return false;
+  }
+  return isEqual(prevProps.node, props.node);
+};
+
+export default memo(RootNode, propsAreEqual);

--- a/src/containers/StructurePageBeta/StructureContainer.tsx
+++ b/src/containers/StructurePageBeta/StructureContainer.tsx
@@ -41,7 +41,12 @@ const StructureContainer = () => {
 
   const addNodeMutation = useAddNodeMutation();
   const userDataQuery = useUserData();
-  const favoriteNodes = userDataQuery.data?.favoriteSubjects ?? [];
+  const favoriteNodes =
+    userDataQuery.data?.favoriteSubjects?.reduce<{ [x: string]: boolean }>((acc, curr) => {
+      acc[curr] = true;
+      return acc;
+    }, {}) ?? {};
+  const favoriteNodeIds = Object.keys(favoriteNodes);
   const nodesQuery = useNodes(
     { language: i18n.language, isRoot: true },
     {
@@ -63,15 +68,17 @@ const StructureContainer = () => {
   };
 
   const updateUserDataMutation = useUpdateUserDataMutation();
-  const nodes = showFavorites ? getFavoriteNodes(nodesQuery.data, favoriteNodes) : nodesQuery.data!;
+  const nodes = showFavorites
+    ? getFavoriteNodes(nodesQuery.data, favoriteNodeIds)
+    : nodesQuery.data!;
 
   const toggleFavorite = (nodeId: string) => {
     if (!favoriteNodes) {
       return;
     }
-    const updatedFavorites = favoriteNodes.includes(nodeId)
-      ? favoriteNodes.filter(s => s !== nodeId)
-      : [...favoriteNodes, nodeId];
+    const updatedFavorites = favoriteNodeIds.includes(nodeId)
+      ? favoriteNodeIds.filter(s => s !== nodeId)
+      : [...favoriteNodeIds, nodeId];
     updateUserDataMutation.mutate({ favoriteSubjects: updatedFavorites });
   };
 
@@ -128,7 +135,7 @@ const StructureContainer = () => {
                     openedPaths={getPathsFromUrl(location.pathname)}
                     resourceSectionRef={resourceSection}
                     onChildNodeSelected={setCurrentNode}
-                    favoriteNodeIds={favoriteNodes}
+                    isFavorite={!!favoriteNodes[node.id]}
                     key={node.id}
                     node={node}
                     toggleOpen={handleStructureToggle}


### PR DESCRIPTION
Vet ikke om dette kan kalles prematurt, men jeg synes det blir veldig overkill å rerendre hvert eneste item i struktur hver gang man klikker på noe. Denne PR'en sørger for at det kun er treet til den nåværende og den forrige rotnoden som rerendres. For å få til dette endret jeg også på måten vi håndterer favoritter på, slik at man enkelt bare kan passere en boolean ned til rotnoden.