### PR TITLE
Re-added grep-codes to both root and child nodes

### DIFF
--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -13,6 +13,7 @@ import { NodeType, SUBJECT_NODE, TOPIC_NODE } from '../../../modules/nodes/nodeA
 import { getNodeTypeFromNodeId } from '../../../modules/nodes/nodeUtil';
 import { useSession } from '../../Session/SessionProvider';
 import EditCustomFields from './sharedMenuOptions/EditCustomFields';
+import EditGrepCodes from './sharedMenuOptions/EditGrepCodes';
 import ToggleVisibility from './sharedMenuOptions/ToggleVisibility';
 import EditSubjectpageOption from './subjectMenuOptions/EditSubjectpageOption';
 
@@ -52,7 +53,7 @@ const SettingsMenuDropdownType = ({ rootNodeId, node, onClose, structure }: Prop
           rootNodeId={rootNodeId}
         /> */}
         <ToggleVisibility node={node} editModeHandler={editModeHandler} rootNodeId={rootNodeId} />
-        {/* <EditGrepCodes node={node} editModeHandler={editModeHandler} /> */}
+        <EditGrepCodes node={node} editModeHandler={editModeHandler} />
         <EditSubjectpageOption node={node} />
         {/* <DeleteNode node={node} editModeHandler={editModeHandler} /> */}
       </>
@@ -71,8 +72,8 @@ const SettingsMenuDropdownType = ({ rootNodeId, node, onClose, structure }: Prop
           structure={structure}
         /> */}
         <ToggleVisibility node={node} editModeHandler={editModeHandler} rootNodeId={rootNodeId} />
-        {/* <EditGrepCodes node={node} editModeHandler={editModeHandler} />
-        <CopyResources toNode={node} structure={structure} onClose={onClose} /> */}
+        <EditGrepCodes node={node} editModeHandler={editModeHandler} />
+        {/* <CopyResources toNode={node} structure={structure} onClose={onClose} /> */}
       </>
     );
   } else return null;

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Button from '@ndla/button';
+import { Plus, Pencil } from '@ndla/icons/action';
+import { DeleteForever } from '@ndla/icons/editor';
+import styled from '@emotion/styled';
+import { spacing } from '@ndla/core';
+import { EditModeHandler } from '../SettingsMenuDropdownType';
+import { NodeType } from '../../../../modules/nodes/nodeApiTypes';
+import { useUpdateNodeMetadataMutation } from '../../../../modules/nodes/nodeMutations';
+import Spinner from '../../../../components/Spinner';
+import RoundIcon from '../../../../components/RoundIcon';
+import MenuItemButton from './components/MenuItemButton';
+import { useGrepCodes } from '../../../../modules/grep/grepQueries';
+import MenuItemEditField from './components/MenuItemEditField';
+import { getRootIdForNode, isRootNode } from '../../../../modules/nodes/nodeUtil';
+
+interface Props {
+  editModeHandler: EditModeHandler;
+  node: NodeType;
+}
+
+export const DropDownWrapper = styled('div')`
+  font-size: 0.9rem;
+  background-color: white;
+  padding: calc(${spacing.small} / 2);
+`;
+
+const StyledGrepItem = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  margin: calc(var(--spacing--small) / 2);
+`;
+
+const EditGrepCodes = ({ node, editModeHandler: { editMode, toggleEditMode } }: Props) => {
+  const rootId = getRootIdForNode(node);
+  const { t } = useTranslation();
+  const { id, metadata } = node;
+  const [grepCodes, setGrepCodes] = useState<string[]>(metadata?.grepCodes ?? []);
+  const [addingNewGrepCode, setAddingNewGrepCode] = useState(false);
+  const { mutateAsync: patchMetadata } = useUpdateNodeMetadataMutation();
+  const grepCodesWithName = useGrepCodes(grepCodes, editMode === 'editGrepCodes');
+
+  const updateMetadata = async (codes: string[]) => {
+    await patchMetadata({
+      id,
+      metadata: { grepCodes: codes, visible: metadata.visible },
+      rootId: isRootNode(node) ? undefined : rootId,
+    });
+    setGrepCodes(codes);
+  };
+
+  const toggleEditModes = () => toggleEditMode('editGrepCodes');
+
+  const addGrepCode = async (code: string) => updateMetadata([...grepCodes, code.toUpperCase()]);
+
+  const deleteGrepCode = (code: string) => updateMetadata(grepCodes.filter(c => c !== code));
+
+  const grepCodesList = (
+    <DropDownWrapper>
+      {grepCodesWithName?.length > 0 ? (
+        grepCodesWithName.map((grepCode, index) => {
+          if (grepCode.isLoading) {
+            return <Spinner key={index} />;
+          }
+          if (!grepCode.data) {
+            return null;
+          }
+          return (
+            <StyledGrepItem key={index}>
+              {grepCode.data.title}
+              <Button
+                stripped
+                data-testid="deleteGrepCode"
+                onClick={() => deleteGrepCode(grepCode.data.code)}>
+                <RoundIcon small icon={<DeleteForever />} />
+              </Button>
+            </StyledGrepItem>
+          );
+        })
+      ) : (
+        <p>{t('taxonomy.grepCodes.empty')}</p>
+      )}
+
+      {addingNewGrepCode ? (
+        <MenuItemEditField
+          currentVal=""
+          messages={{ errorMessage: t('taxonomy.errorMessage') }}
+          dataTestid="addGrepCopde"
+          onClose={() => setAddingNewGrepCode(!addingNewGrepCode)}
+          onSubmit={addGrepCode}
+          icon={<Pencil />}
+          placeholder={t('form.grepCodes.placeholder')}
+        />
+      ) : (
+        <Button
+          stripped
+          data-testid="addFilterButton"
+          onClick={() => setAddingNewGrepCode(!addingNewGrepCode)}>
+          <Plus />
+          {t('taxonomy.grepCodes.addNew')}
+        </Button>
+      )}
+    </DropDownWrapper>
+  );
+
+  return (
+    <>
+      <MenuItemButton stripped data-testid="editGrepCodes" onClick={() => toggleEditModes()}>
+        <RoundIcon small icon={<Pencil />} />
+        {t('taxonomy.grepCodes.edit')}
+      </MenuItemButton>
+      {editMode === 'editGrepCodes' && grepCodesList}
+    </>
+  );
+};
+
+export default EditGrepCodes;

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemEditField.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemEditField.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactNode, useState, KeyboardEvent } from 'react';
+import { spacing } from '@ndla/core';
+import styled from '@emotion/styled';
+import { Done } from '@ndla/icons/editor';
+import RoundIcon from '../../../../../components/RoundIcon';
+import { StyledErrorMessage, StyledMenuItemInputField } from '../../styles';
+import Spinner from '../../../../../components/Spinner';
+import handleError from '../../../../../util/handleError';
+import CustomFieldButton from './CustomFieldButton';
+
+const StyledMenuItemEditField = styled('div')`
+  display: flex;
+  align-items: center;
+  margin: calc(${spacing.small} / 2);
+`;
+
+interface Props {
+  onSubmit: (input: string) => Promise<void>;
+  onClose: () => void;
+  currentVal?: string;
+  icon?: ReactNode;
+  messages?: {
+    errorMessage?: string;
+  };
+  dataTestid?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  initialValue?: string;
+}
+
+const MenuItemEditField = ({
+  onSubmit,
+  onClose,
+  currentVal = '',
+  icon,
+  messages = {},
+  dataTestid = 'inlineEditInput',
+  placeholder,
+  autoFocus,
+}: Props) => {
+  const [status, setStatus] = useState('initial');
+  const [input, setInput] = useState<string>(currentVal);
+
+  const handleSubmit = async () => {
+    setStatus('loading');
+    try {
+      await onSubmit(input);
+      setStatus('success');
+      onClose();
+    } catch (e) {
+      handleError(e);
+      setStatus('error');
+    }
+  };
+
+  const handleKeyPress = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setStatus('initial');
+    }
+    if (e.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
+  const value = input ?? currentVal;
+  return (
+    <>
+      <StyledMenuItemEditField>
+        <RoundIcon open small icon={icon} />
+        <StyledMenuItemInputField
+          type="text"
+          placeholder={placeholder}
+          value={value}
+          data-testid={dataTestid}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyPress}
+          autoFocus={autoFocus}
+        />
+        <CustomFieldButton
+          data-testid="inlineEditSaveButton"
+          disabled={status === 'loading'}
+          onClick={handleSubmit}>
+          {status === 'loading' ? (
+            <Spinner appearance="small" data-testid="inlineEditSpinner" />
+          ) : (
+            <Done className="c-icon--small" />
+          )}
+        </CustomFieldButton>
+      </StyledMenuItemEditField>
+      {status === 'error' && (
+        <StyledErrorMessage data-testid="inlineEditErrorMessage">
+          {messages.errorMessage}
+        </StyledErrorMessage>
+      )}
+    </>
+  );
+};
+
+export default MenuItemEditField;

--- a/src/modules/grep/grepApiInterfaces.ts
+++ b/src/modules/grep/grepApiInterfaces.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export interface GrepCode {
+  code: string;
+  title: string;
+}

--- a/src/modules/grep/grepQueries.ts
+++ b/src/modules/grep/grepQueries.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { GREP_CODE } from '../../queryKeys';
+import { useQueriesTyped } from '../../util/queryUtils';
+import { fetchGrepCodeTitle } from './grepApi';
+import { GrepCode } from './grepApiInterfaces';
+
+const grepToGrepCodeObject = (grepCode: string, grepCodeTitle: string | undefined): GrepCode => ({
+  code: grepCode,
+  title: grepCodeTitle ? `${grepCode} - ${grepCodeTitle}` : grepCode,
+});
+
+export const useGrepCodes = (grepCodes: string[], enabled = true) => {
+  return useQueriesTyped(
+    grepCodes.map(grepCode => {
+      return {
+        queryKey: [GREP_CODE, grepCode],
+        queryFn: () => fetchGrepCodeTitle(grepCode),
+        select: (grepCodeTitle: any) => grepToGrepCodeObject(grepCode, grepCodeTitle as string),
+        enabled,
+      };
+    }),
+  );
+};

--- a/src/queryKeys.ts
+++ b/src/queryKeys.ts
@@ -49,3 +49,5 @@ export const CONNECTIONS_FOR_NODE = 'connectionsForNode';
 export const NODE_RESOURCES = 'resourcesForNode';
 export const RESOURCES_WITH_NODE_CONNECTION = 'resourcesWithNodeConnection';
 export const NODE_RESOURCE_STATUS_GREP_QUERY = 'nodeResourceWithStatusAndGrep';
+
+export const GREP_CODE = 'grepCode';

--- a/src/util/queryUtils.ts
+++ b/src/util/queryUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useQueries, UseQueryOptions, UseQueryResult } from 'react-query';
+
+// From https://blog.johnnyreilly.com/2021/01/03/strongly-typing-react-query-s-usequeries/
+// Should be used instead of useQueries until react-query figures out how to handle typed useQueries.
+type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
+
+export function useQueriesTyped<TQueries extends readonly UseQueryOptions[]>(
+  queries: [...TQueries],
+): {
+  [ArrayElement in keyof TQueries]: UseQueryResult<
+    TQueries[ArrayElement] extends { select: infer TSelect }
+      ? TSelect extends (data: any) => any
+        ? ReturnType<TSelect>
+        : never
+      : Awaited<
+          ReturnType<NonNullable<Extract<TQueries[ArrayElement], UseQueryOptions>['queryFn']>>
+        >
+  >;
+} {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useQueries(queries as UseQueryOptions<unknown, unknown, unknown>[]) as any;
+}


### PR DESCRIPTION
Her la jeg også inn en endring som påvirker endring av synlighet, gruppering av ressurser og endring av `customFields`. Ser ikke ut til å ha påvirket noe, men gjerne sjekk at endringer holder seg selv etter at du har klikket deg rundt til andre noder. Sjekk også at det ikke går an å møte på en race condition når du sletter flere grep-koder rett etter hverandre.