### PR TITLE
Added back ability to add grep codes to structure resources

### DIFF
--- a/src/containers/StructurePageBeta/resourceComponents/GrepCodesForm.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/GrepCodesForm.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { IArticle } from '@ndla/types-draft-api';
+import { Form, Formik, FormikHelpers } from 'formik';
+import { useState } from 'react';
+import SaveMultiButton from '../../../components/SaveMultiButton';
+import GrepCodesField from '../../FormikForm/GrepCodesField';
+
+interface Props {
+  article: IArticle;
+  onUpdate: (grepCodes: string[]) => Promise<void>;
+}
+
+interface Values {
+  grepCodes: string[];
+}
+
+const GrepCodesForm = ({ article, onUpdate }: Props) => {
+  const [saved, setSaved] = useState(false);
+  const initialValues = { grepCodes: article.grepCodes };
+
+  const handleSubmit = async (values: Values, helpers: FormikHelpers<Values>) => {
+    await onUpdate(values.grepCodes);
+    helpers.resetForm({ values: values });
+    setSaved(true);
+  };
+
+  return (
+    <Formik initialValues={initialValues} onSubmit={handleSubmit} enableReinitialize>
+      {({ dirty, errors, isSubmitting, submitForm }) => {
+        if (saved && dirty) {
+          setSaved(false);
+        }
+        return (
+          <Form>
+            <GrepCodesField />
+            <SaveMultiButton
+              isSaving={isSubmitting}
+              formIsDirty={dirty}
+              showSaved={saved && !dirty}
+              onClick={submitForm}
+              disabled={!!Object.keys(errors).length}
+              hideSecondaryButton
+            />
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+};
+export default GrepCodesForm;

--- a/src/containers/StructurePageBeta/resourceComponents/GrepCodesModal.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/GrepCodesModal.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
+import Spinner from '../../../components/Spinner';
+import TaxonomyLightbox from '../../../components/Taxonomy/TaxonomyLightbox';
+import { useUpdateDraftMutation } from '../../../modules/draft/draftMutations';
+import { useDraft } from '../../../modules/draft/draftQueries';
+import { DRAFT } from '../../../queryKeys';
+import { getIdFromUrn } from '../../../util/taxonomyHelpers';
+import GrepCodesForm from './GrepCodesForm';
+
+interface Props {
+  contentUri: string;
+  onClose: (newGrepCodes?: string[]) => void;
+}
+const GrepCodesModal = ({ contentUri, onClose }: Props) => {
+  const { t, i18n } = useTranslation();
+  const draftId = getIdFromUrn(contentUri);
+  const { data, isLoading } = useDraft(draftId!, i18n.language, { enabled: !!draftId });
+  const updateDraft = useUpdateDraftMutation();
+  const qc = useQueryClient();
+
+  if (!data || !draftId) {
+    return null;
+  }
+
+  const onUpdateGrepCodes = async (newCodes: string[]) => {
+    await updateDraft.mutateAsync(
+      { id: draftId, body: { grepCodes: newCodes, revision: data.revision } },
+      {
+        onSuccess: data => {
+          const key = [DRAFT, draftId!, i18n.language];
+          qc.cancelQueries(key);
+          qc.setQueryData(key, data);
+          qc.invalidateQueries([DRAFT, draftId!, i18n.language]);
+        },
+      },
+    );
+  };
+
+  return (
+    <TaxonomyLightbox
+      title={t('form.name.grepCodes')}
+      onClose={() => onClose(data?.grepCodes)}
+      wide>
+      {isLoading ? <Spinner /> : <GrepCodesForm article={data!} onUpdate={onUpdateGrepCodes} />}
+    </TaxonomyLightbox>
+  );
+};
+
+export default GrepCodesModal;

--- a/src/modules/draft/draftMutations.ts
+++ b/src/modules/draft/draftMutations.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { IArticle, IUpdatedArticle } from '@ndla/types-draft-api';
+import { useMutation, UseMutationOptions } from 'react-query';
+import { updateDraft } from './draftApi';
+
+export const useUpdateDraftMutation = (
+  options?: UseMutationOptions<IArticle, unknown, { id: number; body: IUpdatedArticle }>,
+) => {
+  return useMutation<IArticle, undefined, { id: number; body: IUpdatedArticle }>(
+    vars => updateDraft(vars.id, vars.body),
+    options,
+  );
+};


### PR DESCRIPTION
Denne må endres dersom vi velger å ta inn https://github.com/NDLANO/editorial-frontend/pull/1402

Sjekk at grep-koder på ressurser blir oppdatert når du går ut av grepkode-modalen. Sjekk også at formet ikke blir dirty dersom du "går tilbake" til forrige `initialValues`-state.

Skulle gjerne tatt for meg `GrepCodesField`-komponenten også, men det virker som en større oppgave som heller kan tas senere. Virker som at `AsyncDropdown` helt fint kunne blitt erstattet med en React Query-ekvivalent for et bedre resultat.