### PR TITLE
Added taxonomyVersion parameter to every node api call

### DIFF
--- a/src/containers/StructurePageBeta/RootNode.tsx
+++ b/src/containers/StructurePageBeta/RootNode.tsx
@@ -63,7 +63,7 @@ const RootNode = ({
   };
 
   const { mutateAsync: updateNodeConnection } = useUpdateNodeConnectionMutation({
-    onMutate: ({ vars }) => onUpdateRank(vars.id, vars.body.rank!),
+    onMutate: ({ params }) => onUpdateRank(params.id, params.body.rank!),
     onSettled: () => qc.invalidateQueries([CHILD_NODES_WITH_ARTICLE_TYPE, node.id, locale]),
   });
 
@@ -75,7 +75,7 @@ const RootNode = ({
     if (currentRank === destinationRank) return;
     const newRank = currentRank > destinationRank ? destinationRank : destinationRank + 1;
     await updateNodeConnection({
-      vars: { id: draggableId, body: { rank: newRank } },
+      params: { id: draggableId, body: { rank: newRank } },
       taxonomyVersion,
     });
   };

--- a/src/containers/StructurePageBeta/StructureContainer.tsx
+++ b/src/containers/StructurePageBeta/StructureContainer.tsx
@@ -21,6 +21,7 @@ import { getPathsFromUrl, removeLastItemFromUrl } from '../../util/routeHelpers'
 import StructureErrorIcon from './folderComponents/StructureErrorIcon';
 import StructureResources from './resourceComponents/StructureResources';
 import Footer from '../App/components/Footer';
+import { useTaxonomyVersion } from '../StructureVersion/TaxonomyVersionProvider';
 
 const StructureWrapper = styled.ul`
   margin: 0;
@@ -34,6 +35,7 @@ const StructureContainer = () => {
   const params = { subject, topic, subtopics };
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
+  const { taxonomyVersion } = useTaxonomyVersion();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [currentNode, setCurrentNode] = useState<ChildNodeType | undefined>(undefined);
 
@@ -52,13 +54,10 @@ const StructureContainer = () => {
       return acc;
     }, {}) ?? {};
   const favoriteNodeIds = Object.keys(favoriteNodes);
-  const nodesQuery = useNodes(
-    { language: i18n.language, isRoot: true },
-    {
-      select: nodes => nodes.sort((a, b) => a.name?.localeCompare(b.name)),
-      placeholderData: [],
-    },
-  );
+  const nodesQuery = useNodes({ language: i18n.language, isRoot: true }, taxonomyVersion, {
+    select: nodes => nodes.sort((a, b) => a.name?.localeCompare(b.name)),
+    placeholderData: [],
+  });
   const handleStructureToggle = (path: string) => {
     const { search } = location;
     const currentPath = location.pathname.replace('/structureBeta/', '');
@@ -97,7 +96,10 @@ const StructureContainer = () => {
   };
 
   const addNode = async (name: string) => {
-    await addNodeMutation.mutateAsync({ name, nodeType: 'SUBJECT', root: true });
+    await addNodeMutation.mutateAsync({
+      vars: { name, nodeType: 'SUBJECT', root: true },
+      taxonomyVersion,
+    });
   };
 
   const isTaxonomyAdmin = userPermissions?.includes(TAXONOMY_ADMIN_SCOPE);

--- a/src/containers/StructurePageBeta/StructureContainer.tsx
+++ b/src/containers/StructurePageBeta/StructureContainer.tsx
@@ -97,7 +97,7 @@ const StructureContainer = () => {
 
   const addNode = async (name: string) => {
     await addNodeMutation.mutateAsync({
-      vars: { name, nodeType: 'SUBJECT', root: true },
+      params: { name, nodeType: 'SUBJECT', root: true },
       taxonomyVersion,
     });
   };

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
@@ -22,6 +22,7 @@ import MenuItemButton from './components/MenuItemButton';
 import { useGrepCodes } from '../../../../modules/grep/grepQueries';
 import MenuItemEditField from './components/MenuItemEditField';
 import { getRootIdForNode, isRootNode } from '../../../../modules/nodes/nodeUtil';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   editModeHandler: EditModeHandler;
@@ -46,14 +47,18 @@ const EditGrepCodes = ({ node, editModeHandler: { editMode, toggleEditMode } }: 
   const { id, metadata } = node;
   const [grepCodes, setGrepCodes] = useState<string[]>(metadata?.grepCodes ?? []);
   const [addingNewGrepCode, setAddingNewGrepCode] = useState(false);
+  const { taxonomyVersion } = useTaxonomyVersion();
   const { mutateAsync: patchMetadata } = useUpdateNodeMetadataMutation();
   const grepCodesWithName = useGrepCodes(grepCodes, editMode === 'editGrepCodes');
 
   const updateMetadata = async (codes: string[]) => {
     await patchMetadata({
-      id,
-      metadata: { grepCodes: codes, visible: metadata.visible },
-      rootId: isRootNode(node) ? undefined : rootId,
+      vars: {
+        id,
+        metadata: { grepCodes: codes, visible: metadata.visible },
+        rootId: isRootNode(node) ? undefined : rootId,
+      },
+      taxonomyVersion,
     });
     setGrepCodes(codes);
   };

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/EditGrepCodes.tsx
@@ -53,7 +53,7 @@ const EditGrepCodes = ({ node, editModeHandler: { editMode, toggleEditMode } }: 
 
   const updateMetadata = async (codes: string[]) => {
     await patchMetadata({
-      vars: {
+      params: {
         id,
         metadata: { grepCodes: codes, visible: metadata.visible },
         rootId: isRootNode(node) ? undefined : rootId,

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
@@ -17,6 +17,7 @@ import { EditModeHandler } from '../SettingsMenuDropdownType';
 import { useUpdateNodeMetadataMutation } from '../../../../modules/nodes/nodeMutations';
 import RoundIcon from '../../../../components/RoundIcon';
 import MenuItemButton from './components/MenuItemButton';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   node: NodeType;
@@ -40,13 +41,17 @@ const ToggleVisibility = ({
   const { t } = useTranslation();
   const { name, id, metadata } = node;
   const [visible, setVisible] = useState(metadata?.visible);
+  const { taxonomyVersion } = useTaxonomyVersion();
   const { mutateAsync: updateMetadata } = useUpdateNodeMetadataMutation();
 
   const toggleVisibility = async () => {
     await updateMetadata({
-      id,
-      metadata: { grepCodes: metadata.grepCodes, visible: !visible },
-      rootId: rootNodeId !== node.id ? rootNodeId : undefined,
+      vars: {
+        id,
+        metadata: { grepCodes: metadata.grepCodes, visible: !visible },
+        rootId: rootNodeId !== node.id ? rootNodeId : undefined,
+      },
+      taxonomyVersion,
     });
     setVisible(!visible);
   };

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
@@ -46,7 +46,7 @@ const ToggleVisibility = ({
 
   const toggleVisibility = async () => {
     await updateMetadata({
-      vars: {
+      params: {
         id,
         metadata: { grepCodes: metadata.grepCodes, visible: !visible },
         rootId: rootNodeId !== node.id ? rootNodeId : undefined,

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemCustomField.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemCustomField.tsx
@@ -33,6 +33,7 @@ import SubjectCategorySelector from '../../subjectMenuOptions/SubjectCategorySel
 import ToggleExplanationSubject from '../../subjectMenuOptions/ToggleExplanationSubject';
 import ConstantMetaField from './ConstantMetaField';
 import CustomFieldComponent from './CustomFieldComponent';
+import { useTaxonomyVersion } from '../../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   node: NodeType;
@@ -50,6 +51,7 @@ const MenuItemCustomField = ({ node, onCurrentNodeChanged }: Props) => {
   const { id, metadata } = node;
   const nodeType = getNodeTypeFromNodeId(id);
   const [isOpen, setOpen] = useState<boolean>(false);
+  const { taxonomyVersion } = useTaxonomyVersion();
   const [customFields, setCustomFields] = useState<TaxonomyMetadata['customFields']>(
     metadata.customFields,
   );
@@ -59,9 +61,12 @@ const MenuItemCustomField = ({ node, onCurrentNodeChanged }: Props) => {
   useEffect(() => {
     if (customFields !== metadata.customFields) {
       updateMetadata({
-        id,
-        metadata: { customFields },
-        rootId: isRootNode(node) ? undefined : getRootIdForNode(node),
+        vars: {
+          id,
+          metadata: { customFields },
+          rootId: isRootNode(node) ? undefined : getRootIdForNode(node),
+        },
+        taxonomyVersion,
       });
     }
   }, [customFields]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemCustomField.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/components/MenuItemCustomField.tsx
@@ -61,7 +61,7 @@ const MenuItemCustomField = ({ node, onCurrentNodeChanged }: Props) => {
   useEffect(() => {
     if (customFields !== metadata.customFields) {
       updateMetadata({
-        vars: {
+        params: {
           id,
           metadata: { customFields },
           rootId: isRootNode(node) ? undefined : getRootIdForNode(node),

--- a/src/containers/StructurePageBeta/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
@@ -127,11 +127,11 @@ const ChangeNodeNameModal = ({ onClose, node }: ModalProps) => {
     const toUpdate = Object.entries(newValues).filter(([key, value]) => value !== initial[key]);
 
     const deleteCalls = deleted.map(([, d]) =>
-      deleteNodeTranslation({ vars: { subjectId: id, locale: d.language }, taxonomyVersion }),
+      deleteNodeTranslation({ params: { subjectId: id, locale: d.language }, taxonomyVersion }),
     );
     const updateCalls = toUpdate.map(([, u]) =>
       updateNodeTranslation({
-        vars: { id, locale: u.language, newTranslation: { name: u.name } },
+        params: { id, locale: u.language, newTranslation: { name: u.name } },
         taxonomyVersion,
       }),
     );

--- a/src/containers/StructurePageBeta/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
@@ -41,6 +41,7 @@ import DeleteButton from '../../../../components/DeleteButton';
 import AddNodeTranslation from './AddNodeTranslation';
 import SaveButton from '../../../../components/SaveButton';
 import UIField from '../../../../components/Field';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 const buttonStyle = css`
   flex-grow: 1;
@@ -97,14 +98,19 @@ const ChangeNodeNameModal = ({ onClose, node }: ModalProps) => {
   const [loadError, setLoadError] = useState('');
   const [updateError, setUpdateError] = useState('');
   const [saved, setSaved] = useState(false);
+  const { taxonomyVersion } = useTaxonomyVersion();
   const { id, name } = node;
 
-  const { data: translations, isLoading: loading, refetch } = useNodeTranslations(id, {
-    onError: e => {
-      handleError(e);
-      setLoadError(t('taxonomy.changeName.loadError'));
+  const { data: translations, isLoading: loading, refetch } = useNodeTranslations(
+    id,
+    taxonomyVersion,
+    {
+      onError: e => {
+        handleError(e);
+        setLoadError(t('taxonomy.changeName.loadError'));
+      },
     },
-  });
+  );
   const { mutateAsync: deleteNodeTranslation } = useDeleteNodeTranslationMutation();
   const { mutateAsync: updateNodeTranslation } = useUpdateNodeTranslationMutation();
   const qc = useQueryClient();
@@ -121,10 +127,13 @@ const ChangeNodeNameModal = ({ onClose, node }: ModalProps) => {
     const toUpdate = Object.entries(newValues).filter(([key, value]) => value !== initial[key]);
 
     const deleteCalls = deleted.map(([, d]) =>
-      deleteNodeTranslation({ subjectId: id, locale: d.language }),
+      deleteNodeTranslation({ vars: { subjectId: id, locale: d.language }, taxonomyVersion }),
     );
     const updateCalls = toUpdate.map(([, u]) =>
-      updateNodeTranslation({ id, locale: u.language, newTranslation: { name: u.name } }),
+      updateNodeTranslation({
+        vars: { id, locale: u.language, newTranslation: { name: u.name } },
+        taxonomyVersion,
+      }),
     );
     const promises = [...deleteCalls, ...updateCalls];
     try {

--- a/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/GroupTopicResources.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/GroupTopicResources.tsx
@@ -23,6 +23,7 @@ import { CHILD_NODES_WITH_ARTICLE_TYPE } from '../../../../queryKeys';
 import { NodeType } from '../../../../modules/nodes/nodeApiTypes';
 import { useUpdateNodeMetadataMutation } from '../../../../modules/nodes/nodeMutations';
 import { getRootIdForNode, isRootNode } from '../../../../modules/nodes/nodeUtil';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   node: NodeType;
@@ -35,6 +36,7 @@ const GroupTopicResources = ({ node, hideIcon, onChanged }: Props) => {
   const updateNodeMetadata = useUpdateNodeMetadataMutation();
   const qc = useQueryClient();
   const rootNodeId = getRootIdForNode(node);
+  const { taxonomyVersion } = useTaxonomyVersion();
   const updateMetadata = async () => {
     const customFields = {
       ...node.metadata.customFields,
@@ -44,9 +46,12 @@ const GroupTopicResources = ({ node, hideIcon, onChanged }: Props) => {
     };
     updateNodeMetadata.mutate(
       {
-        id: node.id,
-        metadata: { customFields },
-        rootId: isRootNode(node) ? undefined : rootNodeId,
+        vars: {
+          id: node.id,
+          metadata: { customFields },
+          rootId: isRootNode(node) ? undefined : rootNodeId,
+        },
+        taxonomyVersion,
       },
       {
         onSettled: () => {

--- a/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/GroupTopicResources.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/GroupTopicResources.tsx
@@ -46,7 +46,7 @@ const GroupTopicResources = ({ node, hideIcon, onChanged }: Props) => {
     };
     updateNodeMetadata.mutate(
       {
-        vars: {
+        params: {
           id: node.id,
           metadata: { customFields },
           rootId: isRootNode(node) ? undefined : rootNodeId,

--- a/src/containers/StructurePageBeta/resourceComponents/AddResourceModal.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/AddResourceModal.tsx
@@ -140,7 +140,7 @@ const AddResourceModal = ({
       return;
     }
 
-    await createNodeResource({ vars: { body: { resourceId, nodeId } }, taxonomyVersion })
+    await createNodeResource({ params: { body: { resourceId, nodeId } }, taxonomyVersion })
       .then(_ => onClose())
       .catch(err => setError('taxonomy.resource.creationFailed'));
     setLoading(false);

--- a/src/containers/StructurePageBeta/resourceComponents/AddResourceModal.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/AddResourceModal.tsx
@@ -35,6 +35,7 @@ import { getArticle } from '../../../modules/article/articleApi';
 import handleError from '../../../util/handleError';
 import { usePostResourceForNodeMutation } from '../../../modules/nodes/nodeMutations';
 import { RESOURCES_WITH_NODE_CONNECTION } from '../../../queryKeys';
+import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 
 const StyledOrDivider = styled.div`
   display: flex;
@@ -99,6 +100,7 @@ const AddResourceModal = ({
   const [selectedType, setSelectedType] = useState(type);
   const [pastedUrl, setPastedUrl] = useState('');
   const qc = useQueryClient();
+  const { taxonomyVersion } = useTaxonomyVersion();
   const { mutateAsync: createNodeResource } = usePostResourceForNodeMutation({
     onSuccess: _ => {
       qc.invalidateQueries([RESOURCES_WITH_NODE_CONNECTION, nodeId, { language: i18n.language }]);
@@ -138,7 +140,7 @@ const AddResourceModal = ({
       return;
     }
 
-    await createNodeResource({ body: { resourceId, nodeId } })
+    await createNodeResource({ vars: { body: { resourceId, nodeId } }, taxonomyVersion })
       .then(_ => onClose())
       .catch(err => setError('taxonomy.resource.creationFailed'));
     setLoading(false);

--- a/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
@@ -41,6 +41,7 @@ import RemoveButton from '../../../components/RemoveButton';
 import { classes } from './ResourceGroup';
 import ResourceItemLink from './ResourceItemLink';
 import GrepCodesModal from './GrepCodesModal';
+import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 
 const StyledCheckIcon = styled(Check)`
   height: 24px;
@@ -120,6 +121,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
   const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [showGrepCodes, setShowGrepCodes] = useState(false);
   const qc = useQueryClient();
+  const { taxonomyVersion } = useTaxonomyVersion();
 
   const onUpdateConnection = async (id: string, { relevanceId }: NodeConnectionPutType) => {
     const key = [RESOURCES_WITH_NODE_CONNECTION, currentNodeId, { language: i18n.language }];
@@ -137,7 +139,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
   };
 
   const { mutateAsync: updateNodeConnection } = useUpdateNodeConnectionMutation({
-    onMutate: async ({ id, body }) => onUpdateConnection(id, body),
+    onMutate: async ({ vars: { id, body } }) => onUpdateConnection(id, body),
     onSettled: () =>
       qc.invalidateQueries([
         RESOURCES_WITH_NODE_CONNECTION,
@@ -146,7 +148,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
       ]),
   });
   const { mutateAsync: updateResourceConnection } = usePutResourceForNodeMutation({
-    onMutate: async ({ id, body }) => onUpdateConnection(id, body),
+    onMutate: async ({ vars: { id, body } }) => onUpdateConnection(id, body),
     onSettled: () =>
       qc.invalidateQueries([
         RESOURCES_WITH_NODE_CONNECTION,
@@ -208,7 +210,10 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
       connectionId.includes('subject-topic') || connectionId.includes('topic-subtopic')
         ? updateNodeConnection
         : updateResourceConnection;
-    await func({ id: connectionId, body: { relevanceId, primary, rank: rank } });
+    await func({
+      vars: { id: connectionId, body: { relevanceId, primary, rank: rank } },
+      taxonomyVersion,
+    });
   };
 
   return (

--- a/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
@@ -139,7 +139,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
   };
 
   const { mutateAsync: updateNodeConnection } = useUpdateNodeConnectionMutation({
-    onMutate: async ({ vars: { id, body } }) => onUpdateConnection(id, body),
+    onMutate: async ({ params: { id, body } }) => onUpdateConnection(id, body),
     onSettled: () =>
       qc.invalidateQueries([
         RESOURCES_WITH_NODE_CONNECTION,
@@ -148,7 +148,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
       ]),
   });
   const { mutateAsync: updateResourceConnection } = usePutResourceForNodeMutation({
-    onMutate: async ({ vars: { id, body } }) => onUpdateConnection(id, body),
+    onMutate: async ({ params: { id, body } }) => onUpdateConnection(id, body),
     onSettled: () =>
       qc.invalidateQueries([
         RESOURCES_WITH_NODE_CONNECTION,
@@ -211,7 +211,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
         ? updateNodeConnection
         : updateResourceConnection;
     await func({
-      vars: { id: connectionId, body: { relevanceId, primary, rank: rank } },
+      params: { id: connectionId, body: { relevanceId, primary, rank: rank } },
       taxonomyVersion,
     });
   };

--- a/src/containers/StructurePageBeta/resourceComponents/ResourceItems.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/ResourceItems.tsx
@@ -50,10 +50,10 @@ const ResourceItems = ({ resources, currentNodeId }: Props) => {
   const qc = useQueryClient();
   const compKey = [RESOURCES_WITH_NODE_CONNECTION, currentNodeId, { language: i18n.language }];
   const deleteNodeResource = useDeleteResourceForNodeMutation({
-    onMutate: async ({ vars }) => {
+    onMutate: async ({ params }) => {
       await qc.cancelQueries(compKey);
       const prevData = qc.getQueryData<ResourceWithNodeConnection[]>(compKey) ?? [];
-      const withoutDeleted = prevData.filter(res => res.connectionId !== vars.id);
+      const withoutDeleted = prevData.filter(res => res.connectionId !== params.id);
       qc.setQueryData<ResourceWithNodeConnection[]>(compKey, withoutDeleted);
       return prevData;
     },
@@ -72,7 +72,7 @@ const ResourceItems = ({ resources, currentNodeId }: Props) => {
   };
 
   const { mutateAsync: updateNodeResource } = usePutResourceForNodeMutation({
-    onMutate: ({ vars }) => onUpdateRank(vars.id, vars.body.rank as number),
+    onMutate: ({ params }) => onUpdateRank(params.id, params.body.rank as number),
     onError: e => handleError(e),
     onSuccess: () => qc.invalidateQueries(compKey),
   });
@@ -80,7 +80,7 @@ const ResourceItems = ({ resources, currentNodeId }: Props) => {
   const onDelete = async (deleteId: string) => {
     setDeleteId('');
     await deleteNodeResource.mutateAsync(
-      { vars: { id: deleteId }, taxonomyVersion },
+      { params: { id: deleteId }, taxonomyVersion },
       { onSuccess: () => qc.invalidateQueries(compKey) },
     );
   };
@@ -93,7 +93,7 @@ const ResourceItems = ({ resources, currentNodeId }: Props) => {
       return;
     }
     await updateNodeResource({
-      vars: {
+      params: {
         id: connectionId,
         body: {
           primary,

--- a/src/containers/StructurePageBeta/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/StructureResources.tsx
@@ -25,6 +25,7 @@ import AllResourcesGroup from './AllResourcesGroup';
 import ResourceGroup from './ResourceGroup';
 import { groupSortResourceTypesFromNodeResources } from '../../../util/taxonomyHelpers';
 import GroupTopicResources from '../folderComponents/topicMenuOptions/GroupTopicResources';
+import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const StyledDiv = styled('div')`
@@ -53,11 +54,13 @@ const withMissing = (r: ResourceWithNodeConnection): ResourceWithNodeConnection 
 
 const StructureResources = ({ currentChildNode, resourceRef, onCurrentNodeChanged }: Props) => {
   const { t, i18n } = useTranslation();
+  const { taxonomyVersion } = useTaxonomyVersion();
   const grouped = currentChildNode?.metadata?.customFields['topic-resources'] ?? 'grouped';
 
   const { data: nodeResources } = useResourcesWithNodeConnection(
     currentChildNode.id,
     { language: i18n.language },
+    taxonomyVersion,
     {
       select: resources => resources.map(r => (r.resourceTypes.length > 0 ? r : withMissing(r))),
       onError: e => handleError(e),

--- a/src/containers/StructureVersion/TaxonomyVersionProvider.tsx
+++ b/src/containers/StructureVersion/TaxonomyVersionProvider.tsx
@@ -1,0 +1,29 @@
+import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
+
+const TaxonomyVersionContext = createContext<
+  [string | undefined, Dispatch<SetStateAction<string | undefined>>] | undefined
+>(undefined);
+
+interface Props {
+  children: ReactNode;
+}
+
+export const TaxonomyVersionProvider = ({ children }: Props) => {
+  const versionState = useState<string | undefined>(undefined);
+  return (
+    <TaxonomyVersionContext.Provider value={versionState}>
+      {children}
+    </TaxonomyVersionContext.Provider>
+  );
+};
+
+interface TaxonomyVersion {
+  taxonomyVersion: string;
+}
+
+export const useTaxonomyVersion = (): TaxonomyVersion => {
+  const versionContext = useContext(TaxonomyVersionContext);
+  return {
+    taxonomyVersion: versionContext?.[0] ?? 'default',
+  };
+};

--- a/src/containers/StructureVersion/TaxonomyVersionProvider.tsx
+++ b/src/containers/StructureVersion/TaxonomyVersionProvider.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
 
 const TaxonomyVersionContext = createContext<

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -196,7 +196,7 @@ export interface ReturnType<TType, TReturnType> {
   value: TReturnType;
 }
 
-export interface TaxonomyVars<T> {
+export interface TaxonomyParameters<T> {
   taxonomyVersion: string;
-  vars: T;
+  params: T;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -195,3 +195,8 @@ export interface ReturnType<TType, TReturnType> {
   type: TType;
   value: TReturnType;
 }
+
+export interface TaxonomyVars<T> {
+  taxonomyVersion: string;
+  vars: T;
+}

--- a/src/modules/nodes/nodeApi.ts
+++ b/src/modules/nodes/nodeApi.ts
@@ -39,45 +39,79 @@ const { postAndResolve, fetchAndResolve, putAndResolve, deleteAndResolve } = htt
 
 const stringifyQuery = (object: Record<string, any> = {}) => `?${queryString.stringify(object)}`;
 
-export const fetchNode = (id: string, language?: string): Promise<NodeType> => {
-  return fetchAndResolve({ url: `${baseUrl}/${id}${stringifyQuery({ language })}` });
+export const fetchNode = (
+  id: string,
+  taxonomyVersion: string,
+  language?: string,
+): Promise<NodeType> => {
+  return fetchAndResolve({
+    url: `${baseUrl}/${id}${stringifyQuery({ language })}`,
+    taxonomyVersion,
+  });
 };
 
-export const fetchNodes = (params: GetNodeParams): Promise<NodeType[]> =>
-  fetchAndResolve({ url: `${baseUrl}${stringifyQuery(params)}` });
+export const fetchNodes = (params: GetNodeParams, taxonomyVersion: string): Promise<NodeType[]> =>
+  fetchAndResolve({
+    url: `${baseUrl}${stringifyQuery(params)}`,
+    taxonomyVersion,
+  });
 
-export const postNode = (newNode: NodePostPatchType): Promise<string> =>
+export const postNode = (newNode: NodePostPatchType, taxonomyVersion: string): Promise<string> =>
   postAndResolve({
     url: baseUrl,
     body: JSON.stringify(newNode),
     alternateResolve: resolveLocation,
+    taxonomyVersion,
   });
 
-export const fetchConnectionsForNode = (id: string): Promise<ConnectionForNode[]> =>
-  fetchAndResolve({ url: `${baseUrl}/${id}/connections` });
+export const fetchConnectionsForNode = (
+  id: string,
+  taxonomyVersion: string,
+): Promise<ConnectionForNode[]> =>
+  fetchAndResolve({
+    url: `${baseUrl}/${id}/connections`,
+    taxonomyVersion,
+  });
 
-export const deleteNode = (id: string): Promise<void> =>
-  deleteAndResolve({ url: `${baseUrl}/${id}` });
+export const deleteNode = (id: string, taxonomyVersion: string): Promise<void> =>
+  deleteAndResolve({ url: `${baseUrl}/${id}`, taxonomyVersion });
 
 export const putNodeMetadata = (
   id: string,
   meta: Partial<TaxonomyMetadata>,
+  taxonomyVersion: string,
 ): Promise<TaxonomyMetadata> =>
-  putAndResolve({ body: JSON.stringify(meta), url: `${baseUrl}/${id}/metadata` });
+  putAndResolve({
+    body: JSON.stringify(meta),
+    url: `${baseUrl}/${id}/metadata`,
+    taxonomyVersion,
+  });
 
 export const fetchChildNodes = (
   id: string,
+  taxonomyVersion: string,
   params?: GetChildNodesParams,
 ): Promise<ChildNodeType[]> =>
-  fetchAndResolve({ url: `${baseUrl}/${id}/nodes${stringifyQuery(params)}` });
+  fetchAndResolve({
+    url: `${baseUrl}/${id}/nodes${stringifyQuery(params)}`,
+    taxonomyVersion,
+  });
 
-export const fetchNodeTranslations = (id: string): Promise<NodeTranslation[]> =>
-  fetchAndResolve({ url: `${baseUrl}/${id}/translations` });
+export const fetchNodeTranslations = (
+  id: string,
+  taxonomyVersion: string,
+): Promise<NodeTranslation[]> =>
+  fetchAndResolve({ url: `${baseUrl}/${id}/translations`, taxonomyVersion });
 
-export const deleteNodeTranslation = (id: string, language: string): Promise<void> => {
+export const deleteNodeTranslation = (
+  id: string,
+  language: string,
+  taxonomyVersion: string,
+): Promise<void> => {
   return deleteAndResolve({
     url: `${baseUrl}/${id}/translations/${language}`,
     alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
   });
 };
 
@@ -85,50 +119,82 @@ export const putNodeTranslation = (
   id: string,
   language: string,
   translation: NodeTranslationPutType,
+  taxonomyVersion: string,
 ): Promise<void> =>
   putAndResolve({
     url: `${baseUrl}/${id}/translations/${language}`,
     body: JSON.stringify(translation),
     alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
   });
 
 export const fetchNodeResources = (
   id: string,
+  taxonomyVersion: string,
   params?: GetNodeResourcesParams,
 ): Promise<ResourceWithNodeConnection[]> => {
-  return fetchAndResolve({ url: `${baseUrl}/${id}/resources${stringifyQuery(params)}` });
+  return fetchAndResolve({
+    url: `${baseUrl}/${id}/resources${stringifyQuery(params)}`,
+    taxonomyVersion,
+  });
 };
 
-export const deleteNodeConnection = (id: string): Promise<void> =>
-  deleteAndResolve({ url: `${connUrl}/${id}`, alternateResolve: resolveVoidOrRejectWithError });
+export const deleteNodeConnection = (id: string, taxonomyVersion: string): Promise<void> =>
+  deleteAndResolve({
+    url: `${connUrl}/${id}`,
+    alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
+  });
 
-export const putNodeConnection = (id: string, body: NodeConnectionPutType): Promise<void> =>
+export const putNodeConnection = (
+  id: string,
+  body: NodeConnectionPutType,
+  taxonomyVersion: string,
+): Promise<void> =>
   putAndResolve({
     url: `${connUrl}/${id}`,
     body: JSON.stringify(body),
     alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
   });
 
-export const postNodeConnection = (body: NodeConnectionPostType): Promise<string> =>
+export const postNodeConnection = (
+  body: NodeConnectionPostType,
+  taxonomyVersion: string,
+): Promise<string> =>
   postAndResolve({
     url: `${connUrl}`,
     body: JSON.stringify(body),
     alternateResolve: resolveLocation,
+    taxonomyVersion,
   });
 
-export const postResourceForNode = (body: NodeResourcePostType): Promise<void> =>
+export const postResourceForNode = (
+  body: NodeResourcePostType,
+  taxonomyVersion: string,
+): Promise<void> =>
   postAndResolve({
     url: resUrl,
     body: JSON.stringify(body),
     alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
   });
 
-export const deleteResourceForNode = (id: string): Promise<void> =>
-  deleteAndResolve({ url: `${resUrl}/${id}`, alternateResolve: resolveVoidOrRejectWithError });
+export const deleteResourceForNode = (id: string, taxonomyVersion: string): Promise<void> =>
+  deleteAndResolve({
+    url: `${resUrl}/${id}`,
+    alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
+  });
 
-export const putResourceForNode = (id: string, body: NodeResourcePutType): Promise<void> =>
+export const putResourceForNode = (
+  id: string,
+  body: NodeResourcePutType,
+  taxonomyVersion: string,
+): Promise<void> =>
   putAndResolve({
     url: `${resUrl}/${id}`,
     body: JSON.stringify(body),
     alternateResolve: resolveVoidOrRejectWithError,
+    taxonomyVersion,
   });

--- a/src/modules/nodes/nodeMutations.ts
+++ b/src/modules/nodes/nodeMutations.ts
@@ -8,6 +8,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+import { TaxonomyVars } from '../../interfaces';
 import { CHILD_NODES_WITH_ARTICLE_TYPE, NODES } from '../../queryKeys';
 import handleError from '../../util/handleError';
 import { TaxonomyMetadata } from '../taxonomy/taxonomyApiInterfaces';
@@ -36,23 +37,27 @@ import {
 
 export const useAddNodeMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation<string, undefined, NodePostPatchType>(data => postNode(data), {
-    onMutate: async newNode => {
-      await queryClient.cancelQueries(NODES);
-      const previousNodes = queryClient.getQueryData<NodeType[]>(NODES) ?? [];
-      const optimisticNode: NodeType = {
-        ...newNode,
-        contentUri: newNode.contentUri ?? '',
-        id: newNode.id ?? '',
-        path: '',
-        metadata: { visible: true, grepCodes: [], customFields: {} },
-      };
-      queryClient.setQueryData<NodeType[]>(NODES, [...previousNodes, optimisticNode]);
-      return previousNodes;
+  return useMutation<string, undefined, TaxonomyVars<NodePostPatchType>>(
+    data => postNode(data.vars, data.taxonomyVersion),
+    {
+      onMutate: async data => {
+        const newNode = data.vars;
+        await queryClient.cancelQueries(NODES);
+        const previousNodes = queryClient.getQueryData<NodeType[]>(NODES) ?? [];
+        const optimisticNode: NodeType = {
+          ...newNode,
+          contentUri: newNode.contentUri ?? '',
+          id: newNode.id ?? '',
+          path: '',
+          metadata: { visible: true, grepCodes: [], customFields: {} },
+        };
+        queryClient.setQueryData<NodeType[]>(NODES, [...previousNodes, optimisticNode]);
+        return previousNodes;
+      },
+      onError: e => handleError(e),
+      onSettled: () => queryClient.invalidateQueries(NODES),
     },
-    onError: e => handleError(e),
-    onSettled: () => queryClient.invalidateQueries(NODES),
-  });
+  );
 };
 
 export const useUpdateNodeMetadataMutation = () => {
@@ -61,9 +66,10 @@ export const useUpdateNodeMetadataMutation = () => {
   return useMutation<
     TaxonomyMetadata,
     unknown,
-    { id: string; metadata: Partial<TaxonomyMetadata>; rootId?: string }
-  >(data => putNodeMetadata(data.id, data.metadata), {
-    onMutate: async ({ id, metadata, rootId }) => {
+    TaxonomyVars<{ id: string; metadata: Partial<TaxonomyMetadata>; rootId?: string }>
+  >(data => putNodeMetadata(data.vars.id, data.vars.metadata, data.taxonomyVersion), {
+    onMutate: async vars => {
+      const { id, metadata, rootId } = vars.vars;
       const key = rootId ? [CHILD_NODES_WITH_ARTICLE_TYPE, rootId, i18n.language] : NODES;
       await qc.cancelQueries(key);
       const prevNodes = qc.getQueryData<NodeType[]>(key) ?? [];
@@ -74,8 +80,10 @@ export const useUpdateNodeMetadataMutation = () => {
       });
       qc.setQueryData<NodeType[]>(key, newNodes);
     },
-    onSettled: (_, __, { rootId }) => {
-      const key = rootId ? [CHILD_NODES_WITH_ARTICLE_TYPE, rootId, i18n.language] : NODES;
+    onSettled: (_, __, vars) => {
+      const key = vars.vars.rootId
+        ? [CHILD_NODES_WITH_ARTICLE_TYPE, vars.vars.rootId, i18n.language]
+        : NODES;
       qc.invalidateQueries(key);
     },
   });
@@ -83,20 +91,24 @@ export const useUpdateNodeMetadataMutation = () => {
 
 export const useDeleteNodeMutation = () => {
   const qc = useQueryClient();
-  return useMutation<void, unknown, string>(id => deleteNode(id), {
-    onMutate: async id => {
-      await qc.cancelQueries(NODES);
-      const prevNodes = qc.getQueryData<NodeType[]>(NODES) ?? [];
-      const withoutDeleted = prevNodes.filter(s => s.id !== id);
-      qc.setQueryData<NodeType[]>(NODES, withoutDeleted);
+  return useMutation<void, unknown, TaxonomyVars<{ id: string }>>(
+    data => deleteNode(data.vars.id, data.taxonomyVersion),
+    {
+      onMutate: async vars => {
+        const id = vars.vars.id;
+        await qc.cancelQueries(NODES);
+        const prevNodes = qc.getQueryData<NodeType[]>(NODES) ?? [];
+        const withoutDeleted = prevNodes.filter(s => s.id !== id);
+        qc.setQueryData<NodeType[]>(NODES, withoutDeleted);
+      },
+      onSettled: () => qc.invalidateQueries(NODES),
     },
-    onSettled: () => qc.invalidateQueries(NODES),
-  });
+  );
 };
 
 export const useDeleteNodeTranslationMutation = () => {
-  return useMutation<void, unknown, { subjectId: string; locale: string }>(data =>
-    deleteNodeTranslation(data.subjectId, data.locale),
+  return useMutation<void, unknown, TaxonomyVars<{ subjectId: string; locale: string }>>(data =>
+    deleteNodeTranslation(data.vars.subjectId, data.vars.locale, data.taxonomyVersion),
   );
 };
 
@@ -104,57 +116,75 @@ export const useUpdateNodeTranslationMutation = () => {
   return useMutation<
     void,
     unknown,
-    { id: string; locale: string; newTranslation: NodeTranslationPutType }
-  >(data => putNodeTranslation(data.id, data.locale, data.newTranslation));
+    TaxonomyVars<{ id: string; locale: string; newTranslation: NodeTranslationPutType }>
+  >(data =>
+    putNodeTranslation(
+      data.vars.id,
+      data.vars.locale,
+      data.vars.newTranslation,
+      data.taxonomyVersion,
+    ),
+  );
 };
 
 export const useDeleteNodeConnectionMutation = (
-  options?: UseMutationOptions<void, unknown, { id: string }>,
+  options?: UseMutationOptions<void, unknown, TaxonomyVars<{ id: string }>>,
 ) => {
-  return useMutation<void, unknown, { id: string }>(data => deleteNodeConnection(data.id), options);
+  return useMutation<void, unknown, TaxonomyVars<{ id: string }>>(
+    data => deleteNodeConnection(data.vars.id, data.taxonomyVersion),
+    options,
+  );
 };
 
 export const useUpdateNodeConnectionMutation = (
-  options?: UseMutationOptions<void, unknown, { id: string; body: NodeConnectionPutType }>,
+  options?: UseMutationOptions<
+    void,
+    unknown,
+    TaxonomyVars<{ id: string; body: NodeConnectionPutType }>
+  >,
 ) => {
-  return useMutation<void, unknown, { id: string; body: NodeConnectionPutType }>(
-    data => putNodeConnection(data.id, data.body),
+  return useMutation<void, unknown, TaxonomyVars<{ id: string; body: NodeConnectionPutType }>>(
+    data => putNodeConnection(data.vars.id, data.vars.body, data.taxonomyVersion),
     options,
   );
 };
 
 export const usePostNodeConnectionMutation = (
-  options?: UseMutationOptions<string, unknown, { body: NodeConnectionPostType }>,
+  options?: UseMutationOptions<string, unknown, TaxonomyVars<{ body: NodeConnectionPostType }>>,
 ) => {
-  return useMutation<string, unknown, { body: NodeConnectionPostType }>(
-    data => postNodeConnection(data.body),
+  return useMutation<string, unknown, TaxonomyVars<{ body: NodeConnectionPostType }>>(
+    data => postNodeConnection(data.vars.body, data.taxonomyVersion),
     options,
   );
 };
 
 export const usePostResourceForNodeMutation = (
-  options?: UseMutationOptions<void, unknown, { body: NodeResourcePostType }>,
+  options?: UseMutationOptions<void, unknown, TaxonomyVars<{ body: NodeResourcePostType }>>,
 ) => {
-  return useMutation<void, unknown, { body: NodeResourcePostType }>(
-    data => postResourceForNode(data.body),
+  return useMutation<void, unknown, TaxonomyVars<{ body: NodeResourcePostType }>>(
+    data => postResourceForNode(data.vars.body, data.taxonomyVersion),
     options,
   );
 };
 
 export const useDeleteResourceForNodeMutation = (
-  options?: UseMutationOptions<void, unknown, { id: string }>,
+  options?: UseMutationOptions<void, unknown, TaxonomyVars<{ id: string }>>,
 ) => {
-  return useMutation<void, unknown, { id: string }>(
-    data => deleteResourceForNode(data.id),
+  return useMutation<void, unknown, TaxonomyVars<{ id: string }>>(
+    data => deleteResourceForNode(data.vars.id, data.taxonomyVersion),
     options,
   );
 };
 
 export const usePutResourceForNodeMutation = (
-  options?: UseMutationOptions<void, unknown, { id: string; body: NodeResourcePutType }>,
+  options?: UseMutationOptions<
+    void,
+    unknown,
+    TaxonomyVars<{ id: string; body: NodeResourcePutType }>
+  >,
 ) => {
-  return useMutation<void, unknown, { id: string; body: NodeResourcePutType }>(
-    data => putResourceForNode(data.id, data.body),
+  return useMutation<void, unknown, TaxonomyVars<{ id: string; body: NodeResourcePutType }>>(
+    data => putResourceForNode(data.vars.id, data.vars.body, data.taxonomyVersion),
     options,
   );
 };

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -34,14 +34,23 @@ import {
   ResourceWithNodeConnection,
 } from './nodeApiTypes';
 
-export const useNodes = (params: GetNodeParams, options?: UseQueryOptions<NodeType[]>) => {
+export const useNodes = (
+  params: GetNodeParams,
+  taxonomyVersion: string,
+  options?: UseQueryOptions<NodeType[]>,
+) => {
   const query = queryString.stringify(params);
-  return useQuery<NodeType[]>(['nodes', query], () => fetchNodes(params), options);
+  return useQuery<NodeType[]>(['nodes', query], () => fetchNodes(params, taxonomyVersion), options);
 };
 
-export const useNode = (id: string, language?: string, options?: UseQueryOptions<NodeType>) => {
+export const useNode = (
+  id: string,
+  taxonomyVersion: string,
+  language?: string,
+  options?: UseQueryOptions<NodeType>,
+) => {
   const qc = useQueryClient();
-  return useQuery<NodeType>([NODE, id, language], () => fetchNode(id, language), {
+  return useQuery<NodeType>([NODE, id, language], () => fetchNode(id, taxonomyVersion, language), {
     placeholderData: qc.getQueryData<NodeType[]>(NODE)?.find(s => s.id === id),
     ...options,
   });
@@ -50,10 +59,11 @@ export const useNode = (id: string, language?: string, options?: UseQueryOptions
 const fetchChildNodesWithArticleType = async (
   id: string,
   language: string,
+  taxonomyVersion: string,
 ): Promise<(ChildNodeType & {
   articleType?: string;
 })[]> => {
-  const childNodes = await fetchChildNodes(id, { language, recursive: true });
+  const childNodes = await fetchChildNodes(id, taxonomyVersion, { language, recursive: true });
   if (childNodes.length === 0) return [];
 
   const childIds = childNodes.map(n => Number(n.contentUri?.split(':').pop())).filter(id => !!id);
@@ -74,30 +84,36 @@ const fetchChildNodesWithArticleType = async (
 export const useChildNodesWithArticleType = (
   id: string,
   language: string,
+  taxonomyVersion: string,
   options?: UseQueryOptions<(ChildNodeType & { articleType?: string })[]>,
 ) => {
   return useQuery<ChildNodeType[]>(
     [CHILD_NODES_WITH_ARTICLE_TYPE, id, language],
-    () => fetchChildNodesWithArticleType(id, language),
+    () => fetchChildNodesWithArticleType(id, language, taxonomyVersion),
     options,
   );
 };
 
 export const useConnectionsForNode = (
   id: string,
+  taxonomyVersion: string,
   options?: UseQueryOptions<ConnectionForNode[]>,
 ) => {
   return useQuery<ConnectionForNode[]>(
     [CONNECTIONS_FOR_NODE, id],
-    () => fetchConnectionsForNode(id),
+    () => fetchConnectionsForNode(id, taxonomyVersion),
     options,
   );
 };
 
-export const useNodeTranslations = (id: string, options?: UseQueryOptions<NodeTranslation[]>) => {
+export const useNodeTranslations = (
+  id: string,
+  taxonomyVersion: string,
+  options?: UseQueryOptions<NodeTranslation[]>,
+) => {
   return useQuery<NodeTranslation[]>(
     [NODE_TRANSLATIONS, id],
-    () => fetchNodeTranslations(id),
+    () => fetchNodeTranslations(id, taxonomyVersion),
     options,
   );
 };
@@ -105,11 +121,12 @@ export const useNodeTranslations = (id: string, options?: UseQueryOptions<NodeTr
 export const useResourcesWithNodeConnection = (
   id: string,
   params: GetNodeResourcesParams,
+  taxonomyVersion: string,
   options?: UseQueryOptions<ResourceWithNodeConnection[]>,
 ) => {
   return useQuery<ResourceWithNodeConnection[]>(
     [RESOURCES_WITH_NODE_CONNECTION, id, params],
-    () => fetchNodeResources(id, params),
+    () => fetchNodeResources(id, taxonomyVersion, params),
     options,
   );
 };

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -32,6 +32,7 @@ export const formatErrorMessage = (error: {
 export interface HttpHeadersType {
   'Content-Type': string;
   Authorization: string;
+  VersionHash: string;
 }
 
 export interface FetchConfigType {
@@ -71,6 +72,7 @@ export const fetchWithAuthorization = async (
   const headers: HeadersInit = {
     ...extraHeaders,
     ...cacheControl,
+    VersionHash: config.headers?.VersionHash ?? 'default',
     Authorization: `Bearer ${getAccessToken()}`,
   };
 
@@ -85,6 +87,7 @@ const defaultHeaders = { 'Content-Type': 'application/json' };
 interface DoAndResolveType<Type> extends FetchConfigType {
   url: string;
   alternateResolve?: (res: Response) => Promise<Type>;
+  taxonomyVersion: string;
 }
 
 interface HttpConfig<T> extends Omit<DoAndResolveType<T>, 'method'> {}
@@ -93,9 +96,13 @@ const httpResolve = <Type>({
   url,
   headers,
   alternateResolve,
+  taxonomyVersion,
   ...config
 }: DoAndResolveType<Type>): Promise<Type> => {
-  return fetchAuthorized(url, { ...config, headers: { ...defaultHeaders, ...headers } }).then(r => {
+  return fetchAuthorized(url, {
+    ...config,
+    headers: { ...defaultHeaders, VersionHash: taxonomyVersion, ...headers },
+  }).then(r => {
     return alternateResolve?.(r) ?? resolveJsonOrRejectWithError(r);
   });
 };


### PR DESCRIPTION
Det er ikke sjans i havet at dette går uten at hvertfall en ting brekker. 

Bestemte meg for å ikke inkludere `taxonomyVersion` i `react-query`-kallene sin cache; Hvis vi først endrer taxonomy-versjon kan vi likesågodt invalidere hele cachen.