### PR TITLE
Add css prop to force inline after math.

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -57,6 +57,10 @@ mjx-container.MathJax[jax='CHTML'][display='true'] {
   padding: 1px 4px;
   margin: 0;
   max-width: -webkit-stretch;
+
+  &::after {
+    display: inline;  
+  }
 }
 
 /* Override @ndla/ui styles */

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -59,7 +59,7 @@ mjx-container.MathJax[jax='CHTML'][display='true'] {
   max-width: -webkit-stretch;
 
   &::after {
-    display: inline;  
+    display: inline;
   }
 }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#3026

Matte-kontainer har display: inline-flex, som gjør at neste element mister knytninga til elementet. Ved å legge på display: inline på ::after så gjenopprettes koblinga og problemet med at punktum rett etter formel havner på ny linje fikses.

Test:
* /preview/31425/nb, Rett etter setinga 'Merk at dette resultatet kan vi sette opp direkte uten å gå veien om' så kjem det en formel `u` med et punktum. I test så kjem punktumet på ny linje, men ikkje i pr. 
* Visninga av formler ellers på sida _burde_ ikkje ha store endringer.