### PR TITLE
Hide save and publish for non admins.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export const DRAFT_WRITE_SCOPE = 'drafts:write';
 export const DRAFT_HTML_SCOPE = 'drafts:html';
 export const DRAFT_PUBLISH_SCOPE = 'drafts:publish';
 
+export const CONCEPT_ADMIN_SCOPE = 'concept:admin';
 export const CONCEPT_WRITE_SCOPE = 'concept:write';
 
 export const TAXONOMY_WRITE_SCOPE = 'taxonomy:write';

--- a/src/containers/SearchPage/components/results/SearchConcept/ConceptForm.tsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/ConceptForm.tsx
@@ -23,6 +23,8 @@ import { getLicensesWithTranslations } from '../../../../../util/licenseHelpers'
 import { useLicenses } from '../../../../../modules/draft/draftQueries';
 import { PUBLISHED, QUALITY_ASSURED } from '../../../../../util/constants/ConceptStatus';
 import { ConceptStatusType } from '../../../../../interfaces';
+import { CONCEPT_ADMIN_SCOPE } from '../../../../../constants';
+import { useSession } from '../../../../Session/SessionProvider';
 
 export interface InlineFormConcept {
   title: string;
@@ -65,6 +67,8 @@ const validate = (values: InlineFormConcept): ErrorsType => {
 
 const ConceptForm = ({ initialValues, status, language, onSubmit, allSubjects, cancel }: Props) => {
   const { t } = useTranslation();
+  const { userPermissions } = useSession();
+  const canPublish = !!userPermissions?.includes(CONCEPT_ADMIN_SCOPE);
   const { data: licenses } = useLicenses({ placeholderData: [] });
   const licensesWithTranslations = getLicensesWithTranslations(licenses!, language);
   const formik = useFormik<InlineFormConcept>({
@@ -92,6 +96,15 @@ const ConceptForm = ({ initialValues, status, language, onSubmit, allSubjects, c
     const newStatus = getStatus(value, status);
     onSubmit({ ...values, newStatus });
   };
+
+  const secondaryButtons = canPublish
+    ? [
+        {
+          label: t('form.saveAndPublish'),
+          value: 'saveAndPublish',
+        },
+      ]
+    : [];
 
   return (
     <form>
@@ -180,12 +193,7 @@ const ConceptForm = ({ initialValues, status, language, onSubmit, allSubjects, c
           disabled={!hasChanges || Object.keys(errors).length > 0}
           onClick={value => handleClick(value)}
           mainButton={{ value: 'save', label: t(`form.save`) }}
-          secondaryButtons={[
-            {
-              label: t('form.saveAndPublish'),
-              value: 'saveAndPublish',
-            },
-          ]}
+          secondaryButtons={secondaryButtons}
         />
       </div>
     </form>


### PR DESCRIPTION
NDLANO/Issues#3047

Fikser sånn at kun admin kan publisere forklaring fra inline-skjema.

Test:
* Må nesten testes lokalt. Endre på konstant CONCEPT_ADMIN_SCOPE og sjekk at du ikkje lenger har lov å lagre og publisere fra inlineredigering.