### PR TITLE
3061 multi section in topic

### DIFF
--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -195,7 +195,7 @@ export function topicArticleContentToEditorValue(html: string) {
   if (!html) {
     return createEmptyValue();
   }
-  const deserialize = (el: HTMLElement | ChildNode) => {
+  const deserialize = (el: HTMLElement | ChildNode): Descendant | Descendant[] => {
     if (el.nodeType === 3) {
       return { text: el.textContent || '' };
     } else if (el.nodeType !== 1) {
@@ -224,13 +224,13 @@ export function topicArticleContentToEditorValue(html: string) {
       }
     }
 
-    return { text: el.textContent || '' };
+    return children;
   };
 
   const document = new DOMParser().parseFromString(html, 'text/html');
-  const nodes = deserialize(document.body.children[0]);
-  const normalizedNodes = convertFromHTML(Node.isNodeList(nodes) ? nodes[0] : nodes);
-  return normalizedNodes ? [normalizedNodes] : [];
+  const nodes = toArray(document.body.children).map(deserialize);
+  const normalizedNodes = compact(nodes.map(n => convertFromHTML(Node.isNodeList(n) ? n[0] : n)));
+  return normalizedNodes;
 }
 
 export function topicArticleContentToHTML(value: Descendant[]) {

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -113,11 +113,7 @@ const topicArticleRules: SlateSerializer[] = [
   spanSerializer,
 ];
 
-export const learningResourceContentToEditorValue = (html: string): Descendant[] => {
-  return articleContentToEditorValue(html, learningResourceRules);
-};
-
-export function learningResourceContentToHTML(contentValues: Descendant[]) {
+const articleContentToHTML = (value: Descendant[], rules: SlateSerializer[]) => {
   const serialize = (node: Descendant): JSX.Element | null => {
     let children: JSX.Element[];
     if (Text.isText(node)) {
@@ -126,7 +122,7 @@ export function learningResourceContentToHTML(contentValues: Descendant[]) {
       children = compact(node.children.map((n: Descendant) => serialize(n)));
     }
 
-    for (const rule of learningResourceRules) {
+    for (const rule of rules) {
       if (!rule.serialize) {
         continue;
       }
@@ -143,7 +139,7 @@ export function learningResourceContentToHTML(contentValues: Descendant[]) {
     return <>{children}</>;
   };
 
-  const elements = contentValues
+  const elements = value
     .map((descendant: Descendant) => {
       const html = serialize(descendant);
       return html ? renderToStaticMarkup(html) : '';
@@ -151,11 +147,7 @@ export function learningResourceContentToHTML(contentValues: Descendant[]) {
     .join('');
 
   return elements.replace(/<deleteme><\/deleteme>/g, '');
-}
-
-export function topicArticleContentToEditorValue(html: string) {
-  return articleContentToEditorValue(html, topicArticleRules);
-}
+};
 
 const articleContentToEditorValue = (html: string, rules: SlateSerializer[]) => {
   if (!html) {
@@ -197,40 +189,20 @@ const articleContentToEditorValue = (html: string, rules: SlateSerializer[]) => 
   return normalizedNodes;
 };
 
+export const learningResourceContentToEditorValue = (html: string): Descendant[] => {
+  return articleContentToEditorValue(html, learningResourceRules);
+};
+
+export function learningResourceContentToHTML(contentValues: Descendant[]) {
+  return articleContentToHTML(contentValues, learningResourceRules);
+}
+
+export function topicArticleContentToEditorValue(html: string) {
+  return articleContentToEditorValue(html, topicArticleRules);
+}
+
 export function topicArticleContentToHTML(value: Descendant[]) {
-  const serialize = (node: Descendant): JSX.Element | null => {
-    let children: JSX.Element[];
-    if (Text.isText(node)) {
-      children = [escapeHtml(node.text)];
-    } else {
-      children = compact(node.children.map((n: Descendant) => serialize(n)));
-    }
-
-    for (const rule of topicArticleRules) {
-      if (!rule.serialize) {
-        continue;
-      }
-      const ret = rule.serialize(node, children);
-
-      if (ret === undefined) {
-        continue;
-      } else if (ret === null) {
-        return null;
-      } else {
-        return ret;
-      }
-    }
-    return <>{children}</>;
-  };
-
-  const elements = value
-    .map((descendant: Descendant) => {
-      const html = serialize(descendant);
-      return html ? renderToStaticMarkup(html) : '';
-    })
-    .join('');
-
-  return elements.replace(/<deleteme><\/deleteme>/g, '');
+  return articleContentToHTML(value, topicArticleRules);
 }
 
 export function plainTextToEditorValue(text: string): Descendant[] {


### PR DESCRIPTION
Fixes NDLANO/Issues#3061

Emneartikler som har mer enn én seksjon skal nå vise alle seksjonene i ed. Har samtidig redusert mengden kode litt da flere av funksjonene var veldig like.

Hvordan teste:
1. Åpne eller lag artikkel med flere seksjoner. Feks /nn/subject-matter/topic-article/25555/edit/nn.
2. Redigering og lagring av flere seksjoner skal fungere. Sletting av seksjoner skal også fungere.