### PR TITLE
Mathjax will reinitialize properly on save

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -100,6 +100,7 @@ const RichTextEditor = ({ className, placeholder, plugins, value, onChange, subm
             Transforms.select(editor, editor.lastSelection);
             editor.lastSelection = undefined;
             editor.lastSelectedBlock = undefined;
+            prevSubmitted.current = submitted;
             return;
           }
         }


### PR DESCRIPTION
Oppdaget en feil da jeg testet kopiering av matte som fører til at matte ikke blir reinitialisert riktig ved lagring.

Feilen kan fraprovoseres på test ved å lagre en artikkel med matte to ganger. Da vil formateringen forsvinne.

Gjør det samme i PR-instans og det vil gå å lagre mange ganger etter hverandre uten at formatering forsvinner.