### PR TITLE
2965 inline notion bugfix

### DIFF
--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -116,14 +116,7 @@ const InlineConcept = (props: Props) => {
 
   return (
     <>
-      <SlateNotion
-        handleRemove={handleRemove}
-        attributes={attributes}
-        element={element}
-        locale={locale}
-        editor={editor}
-        concept={concept}
-        id={uuid}>
+      <SlateNotion handleRemove={handleRemove} attributes={attributes} concept={concept} id={uuid}>
         {children}
       </SlateNotion>
       <ConceptModal

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -26,6 +26,7 @@ import { useFetchConceptData } from '../../../../../containers/FormikForm/formik
 import mergeLastUndos from '../../../utils/mergeLastUndos';
 import { TYPE_CONCEPT_INLINE } from './types';
 import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
+import SlateNotion from './SlateNotion';
 
 const getConceptDataAttributes = ({ id, title: { title } }: Dictionary<any>) => ({
   type: TYPE_CONCEPT_INLINE,
@@ -36,20 +37,6 @@ const getConceptDataAttributes = ({ id, title: { title } }: Dictionary<any>) => 
     type: 'inline',
   },
 });
-
-const StyledCheckIcon = styled(Check)`
-  margin-left: 10px;
-  width: ${spacing.normal};
-  height: ${spacing.normal};
-  fill: ${colors.support.green};
-`;
-
-const StyledWarnIcon = styled(AlertCircle)`
-  margin-left: 5px;
-  height: ${spacing.normal};
-  width: ${spacing.normal};
-  fill: ${colors.brand.grey};
-`;
 
 interface Props {
   element: ConceptInlineElement;
@@ -139,8 +126,16 @@ const InlineConcept = (props: Props) => {
 
   return (
     <>
-      <span {...attributes} onClick={toggleConceptModal}>
-        <Notion
+      <SlateNotion
+        attributes={attributes}
+        element={element}
+        locale={locale}
+        editor={editor}
+        concept={concept}
+        id={uuid}>
+        {children}
+      </SlateNotion>
+      {/* <Notion
           id={uuid}
           title={concept?.title.title ?? ''}
           subTitle={t('conceptform.title')}
@@ -178,8 +173,7 @@ const InlineConcept = (props: Props) => {
           }
           ariaLabel={t('notions.edit')}>
           {children}
-        </Notion>
-      </span>
+        </Notion> */}
       <ConceptModal
         isOpen={!concept?.id && showConcept}
         onClose={onClose}

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -10,22 +10,13 @@ import { useState, useEffect, ReactNode, useMemo } from 'react';
 
 import { Editor, Element, Node, Transforms, Path } from 'slate';
 import { ReactEditor, RenderElementProps } from 'slate-react';
-import { useTranslation } from 'react-i18next';
 import { Dictionary, uniqueId } from 'lodash';
-import { css } from '@emotion/core';
-import styled from '@emotion/styled';
-import { colors, spacing } from '@ndla/core';
-import { Check, AlertCircle } from '@ndla/icons/editor';
-import Notion from '@ndla/notion';
-import Tooltip from '@ndla/tooltip';
 import { IConcept } from '@ndla/types-concept-api';
 import { ConceptInlineElement } from '../inline/interfaces';
 import ConceptModal from '../ConceptModal';
-import SlateConceptPreview from '../SlateConceptPreview';
 import { useFetchConceptData } from '../../../../../containers/FormikForm/formikConceptHooks';
 import mergeLastUndos from '../../../utils/mergeLastUndos';
 import { TYPE_CONCEPT_INLINE } from './types';
-import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
 import SlateNotion from './SlateNotion';
 
 const getConceptDataAttributes = ({ id, title: { title } }: Dictionary<any>) => ({
@@ -50,7 +41,6 @@ const InlineConcept = (props: Props) => {
   const { children, element, locale, editor, attributes } = props;
   const nodeText = Node.string(element).trim();
   const uuid = useMemo(() => uniqueId(), []);
-  const { t } = useTranslation();
   const [showConcept, setShowConcept] = useState(false);
 
   const toggleConceptModal = () => {
@@ -127,6 +117,7 @@ const InlineConcept = (props: Props) => {
   return (
     <>
       <SlateNotion
+        handleRemove={handleRemove}
         attributes={attributes}
         element={element}
         locale={locale}
@@ -135,45 +126,6 @@ const InlineConcept = (props: Props) => {
         id={uuid}>
         {children}
       </SlateNotion>
-      {/* <Notion
-          id={uuid}
-          title={concept?.title.title ?? ''}
-          subTitle={t('conceptform.title')}
-          headerContent={
-            <div
-              css={css`
-                display: flex;
-                flex: 1;
-                flex-direction: inherit;
-              `}>
-              {(concept?.status.current === PUBLISHED ||
-                concept?.status.other.includes(PUBLISHED)) && (
-                <Tooltip
-                  tooltip={t('form.workflow.published')}
-                  css={css`
-                    margin-right: auto;
-                  `}>
-                  <StyledCheckIcon />
-                </Tooltip>
-              )}
-              {concept?.status.current !== PUBLISHED && (
-                <Tooltip
-                  tooltip={t('form.workflow.currentStatus', {
-                    status: t(`form.status.${concept?.status.current.toLowerCase()}`),
-                  })}>
-                  <StyledWarnIcon />
-                </Tooltip>
-              )}
-            </div>
-          }
-          content={
-            concept && (
-              <SlateConceptPreview concept={concept} handleRemove={handleRemove} id={concept.id} />
-            )
-          }
-          ariaLabel={t('notions.edit')}>
-          {children}
-        </Notion> */}
       <ConceptModal
         isOpen={!concept?.id && showConcept}
         onClose={onClose}

--- a/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
@@ -4,12 +4,10 @@ import { colors, spacing } from '@ndla/core';
 import { NotionDialog } from '@ndla/notion';
 import { IConcept } from '@ndla/types-concept-api';
 import { ReactNode } from 'react';
-import { Editor } from 'slate';
 import { RenderElementProps } from 'slate-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { AlertCircle, Check } from '@ndla/icons/lib/editor';
-import { ConceptInlineElement } from './interfaces';
 import SlateConceptPreview from '../SlateConceptPreview';
 import { Portal } from '../../../../Portal';
 import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
@@ -28,7 +26,7 @@ const StyledWarnIcon = styled(AlertCircle)`
   fill: ${colors.brand.grey};
 `;
 
-const afterCSS = css`
+const NotionArrow = styled.div`
   display: inline-block;
   position: absolute;
   margin: calc(1em + 4px) auto 0;
@@ -45,15 +43,11 @@ const afterCSS = css`
 
 const NotionCSS = css`
   display: inline;
-  background: none;
-  border: none;
   font-family: inherit;
   font-style: inherit;
   line-height: 1em;
   padding: 0 0 4px 0;
   margin-bottom: -4px;
-  text-decoration: none;
-  color: #000;
   border-bottom: 1px solid ${colors.brand.tertiary};
   position: relative;
   cursor: pointer;
@@ -68,9 +62,6 @@ const NotionCSS = css`
 `;
 
 interface Props {
-  element: ConceptInlineElement;
-  locale: string;
-  editor: Editor;
   attributes: RenderElementProps['attributes'];
   concept?: IConcept;
   id: string;
@@ -78,22 +69,13 @@ interface Props {
   children: ReactNode;
 }
 
-const SlateNotion = ({
-  children,
-  element,
-  locale,
-  editor,
-  attributes,
-  id,
-  concept,
-  handleRemove,
-}: Props) => {
+const SlateNotion = ({ children, attributes, id, concept, handleRemove }: Props) => {
   const { t } = useTranslation();
 
   return (
     <span data-notion id={id}>
       <span css={NotionCSS} data-notion-link {...attributes}>
-        <div contentEditable={false} css={afterCSS} />
+        <NotionArrow contentEditable={false} />
         <Portal isOpened>
           <NotionDialog
             title={concept?.title.title ?? ''}

--- a/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
@@ -1,0 +1,168 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { colors, spacing } from '@ndla/core';
+import { NotionDialog } from '@ndla/notion';
+import { IConcept } from '@ndla/types-concept-api';
+import { ReactNode, useEffect, useState } from 'react';
+import { Editor } from 'slate';
+import { RenderElementProps, useSelected } from 'slate-react';
+import { ConceptInlineElement } from './interfaces';
+import { Portal } from '../../../../Portal';
+import Tooltip from '@ndla/tooltip';
+import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, Check } from '@ndla/icons/lib/editor';
+import SlateConceptPreview from '../SlateConceptPreview';
+import { NotionDialogStyledWrapper } from '@ndla/notion/lib/NotionDialog';
+import NotionHeader from '@ndla/notion/lib/NotionHeader';
+import NotionBody from '@ndla/notion/lib/NotionBody';
+
+const StyledCheckIcon = styled(Check)`
+  margin-left: 10px;
+  width: ${spacing.normal};
+  height: ${spacing.normal};
+  fill: ${colors.support.green};
+`;
+
+const StyledWarnIcon = styled(AlertCircle)`
+  margin-left: 5px;
+  height: ${spacing.normal};
+  width: ${spacing.normal};
+  fill: ${colors.brand.grey};
+`;
+
+const afterCSS = css`
+  display: inline-block;
+  position: absolute;
+  margin: calc(1em + 4px) auto 0;
+  left: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  top: 5px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid ${colors.brand.primary};
+  transition: transform 0.1s ease;
+`;
+
+const NotionCSS = css`
+  display: inline;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-style: inherit;
+  line-height: 1em;
+  padding: 0 0 4px 0;
+  margin-bottom: -4px;
+  text-decoration: none;
+  color: #000;
+  border-bottom: 1px solid ${colors.brand.tertiary};
+  position: relative;
+  cursor: pointer;
+  &:hover,
+  &:focus {
+    border-color: ${colors.brand.primary};
+    outline: none;
+    &:after {
+      transform: scale(1.4) translateY(1px);
+    }
+  }
+`;
+
+const SlateNotionModal = styled.div`
+  position: absolute;
+  z-index: 1;
+  min-width: 600px;
+  background: white;
+  bottom: -10px;
+  transform: translate(50%, 100%);
+`;
+
+interface Props {
+  element: ConceptInlineElement;
+  locale: string;
+  editor: Editor;
+  attributes: RenderElementProps['attributes'];
+  concept?: IConcept;
+  id: string;
+  handleRemove: () => void;
+  children: ReactNode;
+}
+
+const SlateNotion = ({
+  children,
+  element,
+  locale,
+  editor,
+  attributes,
+  id,
+  concept,
+  handleRemove,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const selected = useSelected();
+  const { t } = useTranslation();
+
+  const onToggleOpen = () => {
+    setOpen(prev => !prev);
+  };
+
+  useEffect(() => {
+    if (!selected && open) {
+      setOpen(false);
+    }
+  }, [selected, open]);
+  return (
+    <>
+      <span css={NotionCSS} {...attributes} onClick={onToggleOpen}>
+        <div contentEditable={false} css={afterCSS} />
+        {open && (
+          <SlateNotionModal>
+            <NotionDialogStyledWrapper className="visible" contentEditable={false}>
+              <NotionHeader title={concept?.title.title || ''}>
+                <div
+                  css={css`
+                    display: flex;
+                    flex: 1;
+                    flex-direction: inherit;
+                  `}>
+                  {(concept?.status.current === PUBLISHED ||
+                    concept?.status.other.includes(PUBLISHED)) && (
+                    <Tooltip
+                      tooltip={t('form.workflow.published')}
+                      css={css`
+                        margin-right: auto;
+                      `}>
+                      <StyledCheckIcon />
+                    </Tooltip>
+                  )}
+                  {concept?.status.current !== PUBLISHED && (
+                    <Tooltip
+                      tooltip={t('form.workflow.currentStatus', {
+                        status: t(`form.status.${concept?.status.current.toLowerCase()}`),
+                      })}>
+                      <StyledWarnIcon />
+                    </Tooltip>
+                  )}
+                </div>
+              </NotionHeader>
+              <NotionBody>
+                {concept && (
+                  <SlateConceptPreview
+                    concept={concept}
+                    handleRemove={handleRemove}
+                    id={concept.id}
+                  />
+                )}
+              </NotionBody>
+            </NotionDialogStyledWrapper>
+          </SlateNotionModal>
+        )}
+        {children}
+      </span>
+    </>
+  );
+};
+
+export default SlateNotion;

--- a/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
@@ -3,19 +3,16 @@ import styled from '@emotion/styled';
 import { colors, spacing } from '@ndla/core';
 import { NotionDialog } from '@ndla/notion';
 import { IConcept } from '@ndla/types-concept-api';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode } from 'react';
 import { Editor } from 'slate';
-import { RenderElementProps, useSelected } from 'slate-react';
-import { ConceptInlineElement } from './interfaces';
-import { Portal } from '../../../../Portal';
-import Tooltip from '@ndla/tooltip';
-import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
+import { RenderElementProps } from 'slate-react';
 import { useTranslation } from 'react-i18next';
+import Tooltip from '@ndla/tooltip';
 import { AlertCircle, Check } from '@ndla/icons/lib/editor';
+import { ConceptInlineElement } from './interfaces';
 import SlateConceptPreview from '../SlateConceptPreview';
-import { NotionDialogStyledWrapper } from '@ndla/notion/lib/NotionDialog';
-import NotionHeader from '@ndla/notion/lib/NotionHeader';
-import NotionBody from '@ndla/notion/lib/NotionBody';
+import { Portal } from '../../../../Portal';
+import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
 
 const StyledCheckIcon = styled(Check)`
   margin-left: 10px;

--- a/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
@@ -70,15 +70,6 @@ const NotionCSS = css`
   }
 `;
 
-const SlateNotionModal = styled.div`
-  position: absolute;
-  z-index: 1;
-  min-width: 600px;
-  background: white;
-  bottom: -10px;
-  transform: translate(50%, 100%);
-`;
-
 interface Props {
   element: ConceptInlineElement;
   locale: string;
@@ -100,68 +91,53 @@ const SlateNotion = ({
   concept,
   handleRemove,
 }: Props) => {
-  const [open, setOpen] = useState(false);
-  const selected = useSelected();
   const { t } = useTranslation();
 
-  const onToggleOpen = () => {
-    setOpen(prev => !prev);
-  };
-
-  useEffect(() => {
-    if (!selected && open) {
-      setOpen(false);
-    }
-  }, [selected, open]);
   return (
-    <>
-      <span css={NotionCSS} {...attributes} onClick={onToggleOpen}>
+    <span data-notion id={id}>
+      <span css={NotionCSS} data-notion-link {...attributes}>
         <div contentEditable={false} css={afterCSS} />
-        {open && (
-          <SlateNotionModal>
-            <NotionDialogStyledWrapper className="visible" contentEditable={false}>
-              <NotionHeader title={concept?.title.title || ''}>
-                <div
-                  css={css`
-                    display: flex;
-                    flex: 1;
-                    flex-direction: inherit;
-                  `}>
-                  {(concept?.status.current === PUBLISHED ||
-                    concept?.status.other.includes(PUBLISHED)) && (
-                    <Tooltip
-                      tooltip={t('form.workflow.published')}
-                      css={css`
-                        margin-right: auto;
-                      `}>
-                      <StyledCheckIcon />
-                    </Tooltip>
-                  )}
-                  {concept?.status.current !== PUBLISHED && (
-                    <Tooltip
-                      tooltip={t('form.workflow.currentStatus', {
-                        status: t(`form.status.${concept?.status.current.toLowerCase()}`),
-                      })}>
-                      <StyledWarnIcon />
-                    </Tooltip>
-                  )}
-                </div>
-              </NotionHeader>
-              <NotionBody>
-                {concept && (
-                  <SlateConceptPreview
-                    concept={concept}
-                    handleRemove={handleRemove}
-                    id={concept.id}
-                  />
+        <Portal isOpened>
+          <NotionDialog
+            title={concept?.title.title ?? ''}
+            subTitle={t('conceptform.title')}
+            id={id}
+            customCSS={''}
+            headerContent={
+              <div
+                css={css`
+                  display: flex;
+                  flex: 1;
+                  flex-direction: inherit;
+                `}>
+                {(concept?.status.current === PUBLISHED ||
+                  concept?.status.other.includes(PUBLISHED)) && (
+                  <Tooltip
+                    tooltip={t('form.workflow.published')}
+                    css={css`
+                      margin-right: auto;
+                    `}>
+                    <StyledCheckIcon />
+                  </Tooltip>
                 )}
-              </NotionBody>
-            </NotionDialogStyledWrapper>
-          </SlateNotionModal>
-        )}
+                {concept?.status.current !== PUBLISHED && (
+                  <Tooltip
+                    tooltip={t('form.workflow.currentStatus', {
+                      status: t(`form.status.${concept?.status.current.toLowerCase()}`),
+                    })}>
+                    <StyledWarnIcon />
+                  </Tooltip>
+                )}
+              </div>
+            }>
+            {concept && (
+              <SlateConceptPreview concept={concept} handleRemove={handleRemove} id={concept.id} />
+            )}
+          </NotionDialog>
+        </Portal>
         {children}
       </span>
-    </>
+    </span>
   );
 };
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2965

Navigering med piltaster i Notion har vært veldig buggy til nå. Grunnen er at Slate har problemer med å håndtere tekst i `<button>`-elementer. Derfor har jeg laget en Slate-variant av Notion som ikke bruker `<button>`.

Hvordan teste:
1. Åpne en artikkel som har flere inline-forklaringer (settes inn fra toolbar ved markering av tekst eller ctrl+alt+c). Bruk gjerne /nn/subject-matter/learning-resource/31329/edit/nb
2. Naviger gjennom forklaringene med piltaster, spesielt trykk på opp/ned når du har markøren inni forklaringen.
3. Sjekk også at åpning av modal og fjern-knapp i modal fungerer som før.