### PR TITLE
Litt hårete, men støtter nynorskoversettelse av nøkkeord.

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.tsx
@@ -41,6 +41,7 @@ const EditLearningResource = ({ isNewlyCreated }: Props) => {
     'metaDescription.metaDescription',
     'introduction.introduction',
     'content.content',
+    'tags.tags',
   ]);
 
   if (loading || !article || !article.id) {

--- a/src/containers/ArticlePage/TopicArticlePage/EditTopicArticle.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/EditTopicArticle.tsx
@@ -40,6 +40,7 @@ const EditTopicArticle = ({ isNewlyCreated }: Props) => {
     'metaDescription.metaDescription',
     'introduction.introduction',
     'content.content',
+    'tags.tags',
   ]);
 
   if (loading || !article || !article.id) {

--- a/src/containers/AudioUploader/EditAudio.tsx
+++ b/src/containers/AudioUploader/EditAudio.tsx
@@ -27,7 +27,7 @@ const EditAudio = ({ isNewlyCreated }: Props) => {
   const { translating, translateToNN } = useTranslateApi(
     audio,
     (audio: IAudioMetaInformation) => setAudio(audio),
-    ['id', 'manuscript.manuscript', 'title.title'],
+    ['id', 'manuscript.manuscript', 'title.title', 'tags.tags'],
   );
   const audioId = Number(params.id) || undefined;
   const audioLanguage = params.selectedLanguage!;

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -41,6 +41,7 @@ const EditConcept = ({ isNewlyCreated }: Props) => {
     'id',
     'title.title',
     'content.content',
+    'tags.tags',
   ]);
 
   if (loading || translating) {

--- a/src/containers/FormikForm/translateFormHooks.ts
+++ b/src/containers/FormikForm/translateFormHooks.ts
@@ -17,7 +17,13 @@ import { fetchNnTranslation } from '../../modules/translate/translateApi';
  * to transform 'podcastMeta.manuscript' to podcastMeta: { manuscript }.
  * Lodash.merge is used to avoid nested translated fields to shadow nested
  * fields in original domain object.
+ * Arrays are not supported by the service, so these are converted to strings
+ * and then unwrapped after translation.
  */
+
+// Values _most likely_ not used in translated values
+const arrayIdent = 'ARRAY:';
+const separator = '~~';
 
 export function useTranslateApi(
   element: any,
@@ -26,14 +32,30 @@ export function useTranslateApi(
 ) {
   const [translating, setTranslating] = useState(false);
 
+  const pick = (field: string, element: any) => {
+    const picked = dot.pick(field, element);
+    if (Array.isArray(picked)) {
+      return `${arrayIdent}${picked.join(separator)}`;
+    }
+    return picked;
+  };
+
+  const unwrap = (document: JSON) => {
+    const doc = JSON.parse(JSON.stringify(document), function(key: string, value: string) {
+      if (typeof value === 'string' && value.startsWith(arrayIdent)) {
+        return value.slice(arrayIdent.length).split(separator);
+      }
+      return value;
+    });
+
+    return doc;
+  };
+
   const translateToNN = async () => {
     setTranslating(true);
-    const payload = fields.reduce(
-      (acc, field) => ({ ...acc, [field]: dot.pick(field, element) }),
-      {},
-    );
+    const payload = fields.reduce((acc, field) => ({ ...acc, [field]: pick(field, element) }), {});
     const translated = await fetchNnTranslation(payload);
-    const document = dot.object(translated.document);
+    const document = dot.object(unwrap(translated.document));
     setElement({
       ...merge(element, document),
       language: 'nn',

--- a/src/containers/Podcast/EditPodcast.tsx
+++ b/src/containers/Podcast/EditPodcast.tsx
@@ -42,6 +42,7 @@ const EditPodcast = ({ isNewlyCreated }: Props) => {
       'title.title',
       'podcastMeta.introduction',
       'podcastMeta.coverPhoto.altText',
+      'tags.tags',
     ],
   );
 


### PR DESCRIPTION
Som ønska på https://trello.com/c/G01BVAuK/1422-metadata-om-listeoppf%C3%B8ring-nynorsk-bokm%C3%A5l-p%C3%A5-forklaring-m%C3%A5-samkj%C3%B8res

Støtter oversettelse av nøkkelord.

Test:
* Lag artikkel og legg inn nøkkelord som vil være forskjellig på bokmål og nynorsk
* Oversett artikkel til nn og sjekk at nøkkelord også er oversatt.