### PR TITLE
Bugfix mathml

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,9 +184,9 @@
     "react-transition-group": "^4.2.2",
     "remarkable": "^2.0.0",
     "serialize-javascript": "^3.1.0",
-    "slate": "0.78.0",
+    "slate": "0.77.0",
     "slate-history": "^0.66.0",
-    "slate-react": "0.77.1",
+    "slate-react": "0.77.0",
     "slate-hyperscript": "^0.77.0",
     "source-map-support": "^0.5.13",
     "yup": "^0.32.9"

--- a/package.json
+++ b/package.json
@@ -184,10 +184,10 @@
     "react-transition-group": "^4.2.2",
     "remarkable": "^2.0.0",
     "serialize-javascript": "^3.1.0",
-    "slate": "0.77.2",
+    "slate": "0.72.0",
     "slate-history": "^0.66.0",
-    "slate-react": "0.77.3",
-    "slate-hyperscript": "^0.77.0",
+    "slate-react": "0.72.1",
+    "slate-hyperscript": "^0.67.0",
     "source-map-support": "^0.5.13",
     "yup": "^0.32.9"
   },

--- a/package.json
+++ b/package.json
@@ -184,10 +184,10 @@
     "react-transition-group": "^4.2.2",
     "remarkable": "^2.0.0",
     "serialize-javascript": "^3.1.0",
-    "slate": "0.72.0",
+    "slate": "0.78.0",
     "slate-history": "^0.66.0",
-    "slate-react": "0.72.1",
-    "slate-hyperscript": "^0.67.0",
+    "slate-react": "0.77.1",
+    "slate-hyperscript": "^0.77.0",
     "source-map-support": "^0.5.13",
     "yup": "^0.32.9"
   },

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -82,11 +82,13 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       handleRemove();
     } else {
       const nextPath = Path.next(elementPath);
-      ReactEditor.focus(editor);
-      Transforms.select(editor, {
-        anchor: { path: nextPath, offset: 0 },
-        focus: { path: nextPath, offset: 0 },
-      });
+      setTimeout(() => {
+        ReactEditor.focus(editor);
+        Transforms.select(editor, {
+          anchor: { path: nextPath, offset: 0 },
+          focus: { path: nextPath, offset: 0 },
+        });
+      }, 0);
       setEditMode(false);
       setShowMenu(false);
     }

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -122,16 +122,17 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
         match: node => node === element,
       });
     }
-
-    ReactEditor.focus(editor);
-    Transforms.select(editor, {
-      anchor: { path: leafPath, offset: 0 },
-      focus: { path: leafPath, offset: 0 },
-    });
-
     setIsFirstEdit(false);
     setEditMode(false);
     setShowMenu(false);
+
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, {
+        anchor: { path: leafPath, offset: 0 },
+        focus: { path: leafPath, offset: 0 },
+      });
+    }, 0);
   };
 
   const handleRemove = () => {

--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -156,6 +156,7 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       role="button"
       tabIndex={0}
       onClick={toggleMenu}
+      contentEditable={false}
       style={{ boxShadow: selected && focused ? `0 0 0 1px ${colors.brand.tertiary}` : 'none' }}
       {...attributes}>
       <MathML model={nodeInfo.model} editor={editor} element={element} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -14423,10 +14423,10 @@ slate-hyperscript@^0.77.0:
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-react@0.77.1:
-  version "0.77.1"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.77.1.tgz#4e298915d43198b732c0249bf8b04abc75c81b07"
-  integrity sha512-xTy9ZiuecVv+zjsqoiyN8g9ICwM6USQHT6dkloiBA6rvA68aUmaFvoFyvROedvhuRgNEjcH6/CtJS/3KK7XszA==
+slate-react@0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.77.0.tgz#4df9d55448767c73ace1689c2d297be9896a2248"
+  integrity sha512-rBhEkJNOhPqPzaxo5YMf2NukZ4pP8CTx5/okWm40S/oL59ZcNTxddM3gX7UIPUHtID7B1WH/BVUg0sFUzzfqZQ==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -14437,10 +14437,10 @@ slate-react@0.77.1:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@0.78.0:
-  version "0.78.0"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.78.0.tgz#cd0328d22b0a99c543987d2a2dd30903bb950ee9"
-  integrity sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==
+slate@0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.77.0.tgz#a83425cb1499ebd3d4a85a7bbbeaf9faefb29769"
+  integrity sha512-1yg8h4wX3WjTecvTTqfg1+a1cM1wXzmQ4MCWwd+KSJBJCtAvjgRDDQq2ThhWhx2uviznQemRzdls/BI0c/KvYQ==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14416,17 +14416,17 @@ slate-history@^0.66.0:
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-hyperscript@^0.67.0:
-  version "0.67.0"
-  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.67.0.tgz#b066febf10a5176106fe1fcdcdc76460f3eb721b"
-  integrity sha512-3c+d2ePTUk5J7wMjs2CZIJPhb1/VnTltel+qnQarOWlXtJng7oRc8BNaYbNfkl2ecT9W5bpxpsy1r6x5ICXucQ==
+slate-hyperscript@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.77.0.tgz#72c1c0fbd54dc6b6210ecd81d020c8d3d0ab8eae"
+  integrity sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-react@0.72.1:
-  version "0.72.1"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.72.1.tgz#a18917625fa9ec87ae137b6f78bb36d04cdb732b"
-  integrity sha512-H7bCem0xE0PHfaoWOcz18cQ0SZ/oTljAiEH4ygqaeYUjPOid6kAEJ8n28Psbp5g4njIgHTnHfVJGuPiTcKtKeA==
+slate-react@0.77.1:
+  version "0.77.1"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.77.1.tgz#4e298915d43198b732c0249bf8b04abc75c81b07"
+  integrity sha512-xTy9ZiuecVv+zjsqoiyN8g9ICwM6USQHT6dkloiBA6rvA68aUmaFvoFyvROedvhuRgNEjcH6/CtJS/3KK7XszA==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -14437,10 +14437,10 @@ slate-react@0.72.1:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@0.72.0:
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.72.0.tgz#509b4fd06a13eab6c19ea28aa4f1848064e4c61b"
-  integrity sha512-PdyMSxsv6ZOeoPp/tKb3mCfn7jWdtnavKzzuVrTYbydOIubYq60N9D3kJRcvR7Z86kxIOzu1ZXB8vsUzy30/vg==
+slate@0.78.0:
+  version "0.78.0"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.78.0.tgz#cd0328d22b0a99c543987d2a2dd30903bb950ee9"
+  integrity sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14416,17 +14416,17 @@ slate-history@^0.66.0:
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-hyperscript@^0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.77.0.tgz#72c1c0fbd54dc6b6210ecd81d020c8d3d0ab8eae"
-  integrity sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==
+slate-hyperscript@^0.67.0:
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.67.0.tgz#b066febf10a5176106fe1fcdcdc76460f3eb721b"
+  integrity sha512-3c+d2ePTUk5J7wMjs2CZIJPhb1/VnTltel+qnQarOWlXtJng7oRc8BNaYbNfkl2ecT9W5bpxpsy1r6x5ICXucQ==
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-react@0.77.3:
-  version "0.77.3"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.77.3.tgz#6882bc22f501d503f90015925bcbdce3f7462a16"
-  integrity sha512-j7DeGHJMwePT6OeCX/nqkTXcrbo0599UyBQsP+knoqlrW/SRLuyCrj4rgOo6hbahOLlTR6wvKshW9p6KAs+uJA==
+slate-react@0.72.1:
+  version "0.72.1"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.72.1.tgz#a18917625fa9ec87ae137b6f78bb36d04cdb732b"
+  integrity sha512-H7bCem0xE0PHfaoWOcz18cQ0SZ/oTljAiEH4ygqaeYUjPOid6kAEJ8n28Psbp5g4njIgHTnHfVJGuPiTcKtKeA==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -14437,10 +14437,10 @@ slate-react@0.77.3:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@0.77.2:
-  version "0.77.2"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.77.2.tgz#ba66ac32d96f5e6f6793a53727930248ec2279fc"
-  integrity sha512-raG/eyYyRDThz+r/opUD+wxWxwXQi4fH0ViZh41x8qBu8uOPMTBYl10RA7KsF8IK48DS207uPrvWGGBsnMCLwg==
+slate@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.72.0.tgz#509b4fd06a13eab6c19ea28aa4f1848064e4c61b"
+  integrity sha512-PdyMSxsv6ZOeoPp/tKb3mCfn7jWdtnavKzzuVrTYbydOIubYq60N9D3kJRcvR7Z86kxIOzu1ZXB8vsUzy30/vg==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
Fant ikke ut nøyaktig når dette har brukket, for det så ut som fokus etter lukking av modal har vært trøblete en stund. Uansett: problemet med fokus er løst (som alltid når Slate er vrang) med setTimeout på 0ms. 
Oppdaget samtidig at Slate har en bug introdusert med versjon 0.77.2 relatert til inline-voids plassert på slutten av en linje. Gjør det umulig å bruke piltast til å plassere markøren etter feks Mathml. Bruker derfor versjon 0.77.0 inntil videre og har subscribed til issue på github.

Hvordan teste:
1. Opprett mathml og lagre. Markøren skal plasseres rett etter mathml.
2. Åpne eksisterende mathml og avbryt. Markøren skal her også plasseres rett etter mathml.
3. Marker en mathml som er i slutten av en paragraf. Sjekk at pil til høyre plasserer markør til høyre for mathml. Samme for pil ned.