### PR TITLE
Slate blockpicker in root

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -28,6 +28,8 @@ import withPlugins from './utils/withPlugins';
 import Spinner from '../Spinner';
 import { ArticleFormType } from '../../containers/FormikForm/articleFormHooks';
 import { FormikStatus } from '../../interfaces';
+import SlateBlockPicker from './plugins/blockPicker/SlateBlockPicker';
+import { BlockPickerOptions, createBlockpickerOptions } from './plugins/blockPicker/options';
 
 export const classes = new BEMHelper({
   name: 'editor',
@@ -45,9 +47,20 @@ interface Props {
   placeholder?: string;
   plugins?: SlatePlugin[];
   submitted: boolean;
+  language: string;
+  blockpickerOptions?: Partial<BlockPickerOptions>;
 }
 
-const RichTextEditor = ({ className, placeholder, plugins, value, onChange, submitted }: Props) => {
+const RichTextEditor = ({
+  className,
+  placeholder,
+  plugins,
+  value,
+  onChange,
+  submitted,
+  language,
+  blockpickerOptions = {},
+}: Props) => {
   const editor = useMemo(
     () => withReact(withHistory(withPlugins(createEditor(), plugins))),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -179,6 +192,11 @@ const RichTextEditor = ({ className, placeholder, plugins, value, onChange, subm
             ) : (
               <>
                 <SlateToolbar editor={editor} />
+                <SlateBlockPicker
+                  editor={editor}
+                  articleLanguage={language}
+                  {...createBlockpickerOptions(blockpickerOptions)}
+                />
                 <Editable
                   decorate={decorations}
                   // @ts-ignore is-hotkey and editor.onKeyDown does not have matching types

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -75,7 +75,9 @@ const SlateBlockPicker = ({
   const portalRef = createRef<HTMLDivElement>();
 
   useEffect(() => {
-    updateMenu();
+    setTimeout(() => {
+      updateMenu();
+    }, 0);
   });
 
   const updateMenu = () => {
@@ -93,11 +95,9 @@ const SlateBlockPicker = ({
       return;
     }
 
-    menu.style.display = 'block';
     const domElement = ReactEditor.toDOMNode(editor, selectedParagraph);
     const rect = domElement.getBoundingClientRect();
 
-    menu.style.opacity = '1';
     const left = rect.left + window.scrollX - (isListItem ? 110 : 78);
     menu.style.top = `${rect.top + window.scrollY - 14}px`;
     menu.style.left = `${left}px`;

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -8,11 +8,11 @@
 
 import { createRef, useEffect, useState } from 'react';
 import { Editor, Element, Node, Location, Range, Path, Transforms } from 'slate';
-import { Portal } from '../../../Portal';
 import { useTranslation } from 'react-i18next';
 import { ReactEditor } from 'slate-react';
 import { SlateBlockMenu } from '@ndla/editor';
 import styled from '@emotion/styled';
+import { Portal } from '../../../Portal';
 import SlateVisualElementPicker from './SlateVisualElementPicker';
 import actions, { ActionData } from './actions';
 import { defaultAsideBlock } from '../aside/utils';

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -40,8 +40,6 @@ interface Props {
 const StyledBlockPickerWrapper = styled.div`
   position: absolute;
 `;
-/* left: ${props => (props.isList ? -110 : -78)}px;
-  top: -14px; */
 
 const SlateBlockPicker = ({
   editor,

--- a/src/components/SlateEditor/plugins/blockPicker/options.ts
+++ b/src/components/SlateEditor/plugins/blockPicker/options.ts
@@ -17,10 +17,10 @@ const defaultOptions: BlockPickerOptions = {
   actionsToShowInAreas: {},
 };
 
-const options = (opts: Partial<BlockPickerOptions>): BlockPickerOptions => ({
+export const createBlockpickerOptions = (
+  opts: Partial<BlockPickerOptions>,
+): BlockPickerOptions => ({
   allowedPickAreas: opts.allowedPickAreas || defaultOptions.allowedPickAreas,
   illegalAreas: opts.illegalAreas || defaultOptions.illegalAreas,
   actionsToShowInAreas: opts.actionsToShowInAreas || defaultOptions.actionsToShowInAreas,
 });
-
-export default options;

--- a/src/components/SlateEditor/plugins/paragraph/Paragraph.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/Paragraph.tsx
@@ -1,11 +1,9 @@
 import styled from '@emotion/styled';
-import { isObject } from 'lodash';
 import { ReactNode } from 'react';
-import { Editor, Node, Path } from 'slate';
-import { ReactEditor, RenderElementProps, useSelected } from 'slate-react';
+import { Editor } from 'slate';
+import { RenderElementProps } from 'slate-react';
 import { ParagraphElement } from '.';
 import { BlockPickerOptions } from '../blockPicker/options';
-import SlateBlockPicker from '../blockPicker/SlateBlockPicker';
 
 interface Props {
   attributes: RenderElementProps['attributes'];
@@ -20,36 +18,12 @@ const StyledParagraph = styled.p`
   position: relative;
 `;
 
-const Paragraph = ({
-  attributes,
-  children,
-  element,
-  editor,
-  language,
-  blockpickerOptions,
-}: Props) => {
-  const isSelected = useSelected();
-
-  const path = ReactEditor.findPath(editor, element);
-  const anchorInParagraph =
-    !!editor.selection && Path.isDescendant(editor.selection?.anchor.path, path);
-  const isEmpty = Node.string(element).length === 0;
-
+const Paragraph = ({ attributes, children, element }: Props) => {
   return (
     <StyledParagraph
       className={element.data?.align === 'center' ? 'u-text-center' : ''}
       {...attributes}>
       {children}
-
-      {language && isObject(blockpickerOptions) && (
-        <SlateBlockPicker
-          editor={editor}
-          articleLanguage={language}
-          {...blockpickerOptions}
-          selectedParagraphPath={path}
-          show={isEmpty && anchorInParagraph && isSelected}
-        />
-      )}
     </StyledParagraph>
   );
 };

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -55,7 +55,6 @@ import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
 import { LocaleType } from '../../../../interfaces';
 import { LearningResourceFormType } from '../../../FormikForm/articleFormHooks';
 import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
-import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import { SessionProps } from '../../../Session/SessionProvider';
 import withSession from '../../../Session/withSession';
@@ -104,12 +103,7 @@ export const plugins = (
     sectionPlugin,
     spanPlugin,
     divPlugin,
-    paragraphPlugin(
-      articleLanguage,
-      options({
-        actionsToShowInAreas,
-      }),
-    ),
+    paragraphPlugin(articleLanguage),
     footnotePlugin,
     embedPlugin(articleLanguage, locale),
     bodyboxPlugin,
@@ -207,6 +201,10 @@ const LearningResourceContent = ({
               )}
             </FieldHeader>
             <RichTextEditor
+              language={articleLanguage}
+              blockpickerOptions={{
+                actionsToShowInAreas,
+              }}
               placeholder={t('form.content.placeholder')}
               value={value}
               submitted={isSubmitting}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -43,7 +43,6 @@ import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
 import { TopicArticleFormType } from '../../../FormikForm/articleFormHooks';
 import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
-import options from '../../../../components/SlateEditor/plugins/blockPicker/options';
 import { useSession } from '../../../Session/SessionProvider';
 import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
 
@@ -60,26 +59,13 @@ const IconContainer = styled.div`
   width: 64px;
 `;
 
-const actions = ['table', 'embed', 'code-block', 'file', 'h5p'];
-const actionsToShowInAreas = {
-  details: actions,
-  aside: actions,
-  bodybox: actions,
-  summary: actions,
-};
-
 const createPlugins = (language: string, handleSubmitRef: RefObject<() => void>): SlatePlugin[] => {
   // Plugins are checked from last to first
   return [
     sectionPlugin,
     spanPlugin,
     divPlugin,
-    paragraphPlugin(
-      language,
-      options({
-        actionsToShowInAreas,
-      }),
-    ),
+    paragraphPlugin(language),
     noEmbedPlugin,
     linkPlugin(language),
     headingPlugin,
@@ -158,6 +144,7 @@ const TopicArticleContent = (props: Props) => {
               )}
             </FieldHeader>
             <RichTextEditor
+              language={language}
               placeholder={t('form.content.placeholder')}
               value={value}
               submitted={isSubmitting}


### PR DESCRIPTION
Ble nødvendig å skrive om pluss-menyen i Slate til å plasseres absolutt i en Portal i stedet for som en del av paragrafer. Pluss-menyen skal nå være tilgjengelig i tabeller og siden tabeller har overflow: hidden fungerer ikke nåværende løsning lenger. Litt synd, for portaler og manuell oppdatering av position skaper flere bugs 🤷 Uansett, det ser ut som at dette fungerer bra, men måtte bruke en setTimeout på 0ms for å unngå rare posisjoner på menyen. Visning i tabell kommer i en senere PR.

Hvordan teste:
1. Åpne en artikkel.
2. Forsøk diverse innsettinger fra menyen, åpning, lukking og trykk på diverse annet i editoren. Målet er at alt skal fungere likt som før.