### PR TITLE
Added options for deleting nodes in structure beta

### DIFF
--- a/src/containers/StructurePageBeta/NodeItem.tsx
+++ b/src/containers/StructurePageBeta/NodeItem.tsx
@@ -134,6 +134,7 @@ const NodeItem = ({
             structure={allRootNodes}
             onCurrentNodeChanged={node => (isChildNode(node) ? onChildNodeSelected(node) : null)}
             jumpToResources={() => resourceSectionRef?.current?.scrollIntoView()}
+            nodeChildren={nodes ?? []}
           />
         )}
         {isLoading && (

--- a/src/containers/StructurePageBeta/folderComponents/FolderItem.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/FolderItem.tsx
@@ -34,6 +34,7 @@ interface Props {
   resourcesLoading?: boolean;
   rootNodeId: string;
   onCurrentNodeChanged: (node: NodeType) => void;
+  nodeChildren: NodeType[];
 }
 
 const FolderItem = ({
@@ -44,6 +45,7 @@ const FolderItem = ({
   rootNodeId,
   structure,
   onCurrentNodeChanged,
+  nodeChildren,
 }: Props) => {
   const { t } = useTranslation();
   const showJumpToResources = isMainActive && node.id.includes('topic');
@@ -56,6 +58,7 @@ const FolderItem = ({
           rootNodeId={rootNodeId}
           structure={structure}
           onCurrentNodeChanged={onCurrentNodeChanged}
+          nodeChildren={nodeChildren}
         />
       )}
       {showJumpToResources && (

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenu.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenu.tsx
@@ -33,10 +33,17 @@ interface Props {
   node: NodeType;
   rootNodeId: string;
   structure: NodeType[];
+  nodeChildren: NodeType[];
   onCurrentNodeChanged: (node: NodeType) => void;
 }
 
-const SettingsMenu = ({ node, rootNodeId, structure, onCurrentNodeChanged }: Props) => {
+const SettingsMenu = ({
+  node,
+  rootNodeId,
+  structure,
+  onCurrentNodeChanged,
+  nodeChildren,
+}: Props) => {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
   const nodeType = getNodeTypeFromNodeId(node.id);
@@ -68,6 +75,7 @@ const SettingsMenu = ({ node, rootNodeId, structure, onCurrentNodeChanged }: Pro
               rootNodeId={rootNodeId}
               structure={structure}
               onCurrentNodeChanged={onCurrentNodeChanged}
+              nodeChildren={nodeChildren}
             />
           </StyledDivWrapper>
         </>

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -12,6 +12,7 @@ import { EditMode } from '../../../interfaces';
 import { NodeType, SUBJECT_NODE, TOPIC_NODE } from '../../../modules/nodes/nodeApiTypes';
 import { getNodeTypeFromNodeId } from '../../../modules/nodes/nodeUtil';
 import { useSession } from '../../Session/SessionProvider';
+import DeleteNode from './sharedMenuOptions/DeleteNode';
 import EditCustomFields from './sharedMenuOptions/EditCustomFields';
 import EditGrepCodes from './sharedMenuOptions/EditGrepCodes';
 import ToggleVisibility from './sharedMenuOptions/ToggleVisibility';
@@ -24,6 +25,7 @@ interface Props {
   node: NodeType;
   onClose: () => void;
   structure: NodeType[];
+  nodeChildren: NodeType[];
   onCurrentNodeChanged: (node: NodeType) => void;
 }
 
@@ -38,6 +40,7 @@ const SettingsMenuDropdownType = ({
   onClose,
   structure,
   onCurrentNodeChanged,
+  nodeChildren,
 }: Props) => {
   const { userPermissions } = useSession();
   const [editMode, setEditMode] = useState<EditMode>('');
@@ -70,7 +73,12 @@ const SettingsMenuDropdownType = ({
         <EditGrepCodes node={node} editModeHandler={editModeHandler} />
         <EditSubjectpageOption node={node} />
         <ToNodeDiff node={node} />
-        {/* <DeleteNode node={node} editModeHandler={editModeHandler} /> */}
+        <DeleteNode
+          node={node}
+          nodeChildren={nodeChildren}
+          editModeHandler={editModeHandler}
+          rootNodeId={rootNodeId}
+        />
       </>
     );
   } else if (nodeType === TOPIC_NODE) {
@@ -94,6 +102,12 @@ const SettingsMenuDropdownType = ({
         <ToggleVisibility node={node} editModeHandler={editModeHandler} rootNodeId={rootNodeId} />
         <EditGrepCodes node={node} editModeHandler={editModeHandler} />
         <ToNodeDiff node={node} />
+        <DeleteNode
+          node={node}
+          nodeChildren={nodeChildren}
+          editModeHandler={editModeHandler}
+          rootNodeId={rootNodeId}
+        />
         {/* <CopyResources toNode={node} structure={structure} onClose={onClose} /> */}
       </>
     );

--- a/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/DeleteNode.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/sharedMenuOptions/DeleteNode.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeleteForever } from '@ndla/icons/editor';
+import AlertModal from '../../../../components/AlertModal';
+import RoundIcon from '../../../../components/RoundIcon';
+import { updateStatusDraft } from '../../../../modules/draft/draftApi';
+import { ChildNodeType, NodeType } from '../../../../modules/nodes/nodeApiTypes';
+import {
+  useDeleteNodeConnectionMutation,
+  useDeleteNodeMutation,
+} from '../../../../modules/nodes/nodeMutations';
+import { queryTopics } from '../../../../modules/taxonomy';
+import { ARCHIVED } from '../../../../util/constants/ArticleStatus';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
+import { EditModeHandler } from '../SettingsMenuDropdownType';
+import MenuItemButton from './components/MenuItemButton';
+import Spinner from '../../../../components/Spinner';
+import Overlay from '../../../../components/Overlay';
+import { StyledErrorMessage } from '../styles';
+
+interface Props {
+  node: NodeType | ChildNodeType;
+  nodeChildren: NodeType[];
+  editModeHandler: EditModeHandler;
+  rootNodeId?: string;
+}
+
+const DeleteNode = ({
+  node,
+  nodeChildren,
+  editModeHandler: { editMode, toggleEditMode },
+  rootNodeId,
+}: Props) => {
+  const { t, i18n } = useTranslation();
+  const { taxonomyVersion } = useTaxonomyVersion();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const disabled = nodeChildren && nodeChildren.length !== 0;
+
+  const deleteNodeConnectionMutation = useDeleteNodeConnectionMutation();
+  const deleteNodeMutation = useDeleteNodeMutation();
+
+  const toggleDelete = () => toggleEditMode('deleteNode');
+
+  const onDelete = async (): Promise<void> => {
+    setLoading(true);
+    setError(undefined);
+    toggleDelete();
+    try {
+      if ('parent' in node) {
+        await deleteNodeConnectionMutation.mutateAsync({ id: node.connectionId, taxonomyVersion });
+      }
+      const articleId = Number(node.contentUri?.split(':')[2]);
+      if ('parent' in node && articleId) {
+        const topicPlacements = await queryTopics({
+          contentId: articleId,
+          language: i18n.language,
+          taxonomyVersion,
+        });
+        if (topicPlacements.length === 1) {
+          await updateStatusDraft(articleId, ARCHIVED);
+        }
+      }
+
+      await deleteNodeMutation.mutateAsync(
+        {
+          id: node.id,
+          taxonomyVersion,
+          rootId: 'parent' in node ? rootNodeId : undefined,
+        },
+        { onSuccess: () => setLoading(false) },
+      );
+    } catch (e) {
+      setError(`${t('taxonomy.errorMessage')}${e.message ? `:${e.message}` : ''}`);
+      setLoading(false);
+    }
+  };
+  return (
+    <>
+      <MenuItemButton stripped data-testid="deleteNode" disabled={disabled} onClick={toggleDelete}>
+        <RoundIcon small icon={<DeleteForever />} />
+        {t('taxonomy.deleteNode')}
+      </MenuItemButton>
+      <AlertModal
+        show={editMode === 'deleteNode'}
+        actions={[
+          {
+            text: t('form.abort'),
+            onClick: toggleDelete,
+          },
+          {
+            text: t('alertModal.delete'),
+            onClick: onDelete,
+          },
+        ]}
+        onCancel={toggleDelete}
+        text={t('taxonomy.confirmDelete')}
+      />
+      {loading && <Spinner appearance="absolute" />}
+      {loading && <Overlay modifiers={['absolute', 'white-opacity', 'zIndex']} />}
+      {error && (
+        <StyledErrorMessage data-testid="inlineEditErrorMessage">{error}</StyledErrorMessage>
+      )}
+    </>
+  );
+};
+
+export default DeleteNode;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,6 +37,7 @@ export type EditMode =
   | 'addExistingTopic'
   | 'addTopic'
   | 'deleteSubject'
+  | 'deleteNode'
   | '';
 
 export interface SearchResultBase<T> {

--- a/src/modules/nodes/nodeApi.ts
+++ b/src/modules/nodes/nodeApi.ts
@@ -87,7 +87,11 @@ interface NodeDeleteParams extends WithTaxonomyVersion {
   id: string;
 }
 export const deleteNode = ({ id, taxonomyVersion }: NodeDeleteParams): Promise<void> =>
-  deleteAndResolve({ url: `${baseUrl}/${id}`, taxonomyVersion });
+  deleteAndResolve({
+    url: `${baseUrl}/${id}`,
+    taxonomyVersion,
+    alternateResolve: resolveVoidOrRejectWithError,
+  });
 
 interface NodeMetadataPutParams extends WithTaxonomyVersion {
   id: string;

--- a/src/modules/nodes/nodeMutations.ts
+++ b/src/modules/nodes/nodeMutations.ts
@@ -103,20 +103,30 @@ export const useUpdateNodeMetadataMutation = () => {
 
 interface UseDeleteNodeMutation extends WithTaxonomyVersion {
   id: string;
+  rootId?: string;
 }
 
 export const useDeleteNodeMutation = () => {
   const qc = useQueryClient();
+  const { i18n } = useTranslation();
   return useMutation<void, unknown, UseDeleteNodeMutation>(
     ({ id, taxonomyVersion }) => deleteNode({ id, taxonomyVersion }),
     {
-      onMutate: async ({ id }) => {
-        await qc.cancelQueries(NODES);
-        const prevNodes = qc.getQueryData<NodeType[]>(NODES) ?? [];
+      onMutate: async ({ id, rootId, taxonomyVersion }) => {
+        const key = rootId
+          ? [CHILD_NODES_WITH_ARTICLE_TYPE, taxonomyVersion, rootId, i18n.language]
+          : NODES;
+        await qc.cancelQueries(key);
+        const prevNodes = qc.getQueryData<NodeType[]>(key) ?? [];
         const withoutDeleted = prevNodes.filter(s => s.id !== id);
-        qc.setQueryData<NodeType[]>(NODES, withoutDeleted);
+        qc.setQueryData<NodeType[]>(key, withoutDeleted);
       },
-      onSettled: () => qc.invalidateQueries(NODES),
+      onSettled: (_, __, { rootId, taxonomyVersion }) => {
+        const key = rootId
+          ? [CHILD_NODES_WITH_ARTICLE_TYPE, taxonomyVersion, rootId, i18n.language]
+          : NODES;
+        qc.invalidateQueries(key);
+      },
     },
   );
 };

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1182,6 +1182,8 @@ const phrases = {
     errorMessage: 'An error occurred',
     addTopic: 'Add topic',
     currentVersion: 'Current version',
+    deleteNode: 'Delete',
+    confirmDelete: 'Are you sure you want to delete this node?',
     changeName: {
       loadError: 'Could not fetch translations',
       updateError: 'Could not update translations',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1183,6 +1183,8 @@ const phrases = {
     subjectSettings: 'Faginnstillinger',
     topicSettings: 'Emneinnstillinger',
     currentVersion: 'Nåværende versjon',
+    deleteNode: 'Slett',
+    confirmDelete: 'Er du sikker på at du vil slette denne noden?',
     changeName: {
       loadError: 'Klarte ikke hente oversettelser',
       updateError: 'Klarte ikke oppdatere oversettelser',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1183,6 +1183,8 @@ const phrases = {
     subjectSettings: 'Faginnstillinger',
     topicSettings: 'Emneinnstillinger',
     currentVersion: 'Noverande versjon',
+    deleteNode: 'Slett',
+    confirmDelete: 'Er du sikker på at du vil slette denne noden?',
     changeName: {
       loadError: 'Klarte ikkje hente omsetjingar',
       updateError: 'Klarte ikkje oppdatere omsetjingar',


### PR DESCRIPTION
Legger inn støtte for å slette noder i struktur-beta. I tidligere versjon måtte man behandle subject, subject-topic og topic-subtopic forskjellig. I denne versjonen differensierer man kun mellom rotnode og barnenode. Hvis en barnenode slettes vil også connection slettes, samt at emnebeskrivelsen slettes hvis den kun brukes her. 

Kan testes ved å legge til en ny rotnode, for deretter å legge minst to nivåer med barn inn under den. Slett deretter hele treet fra blad-nivå og oppover. 