### PR TITLE
Separate previews for inline and block concept

### DIFF
--- a/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
@@ -14,11 +14,11 @@ import { Dictionary } from 'lodash';
 import styled from '@emotion/styled';
 import { IConcept } from '@ndla/types-concept-api';
 import ConceptModal from '../ConceptModal';
-import SlateConceptPreview from '../SlateConceptPreview';
 import { useFetchConceptData } from '../../../../../containers/FormikForm/formikConceptHooks';
 import mergeLastUndos from '../../../utils/mergeLastUndos';
 import { TYPE_CONCEPT_BLOCK } from './types';
 import { ConceptBlockElement } from './interfaces';
+import BlockConceptPreview from './BlockConceptPreview';
 
 const getConceptDataAttributes = ({ id }: Dictionary<any>) => ({
   type: TYPE_CONCEPT_BLOCK,
@@ -117,7 +117,7 @@ const BlockConcept = ({ element, locale, editor, attributes, children }: Props) 
     <StyledWrapper {...attributes} tabIndex={1} isSelected={isSelected} draggable={true}>
       {concept && (
         <div contentEditable={false}>
-          <SlateConceptPreview
+          <BlockConceptPreview
             concept={concept}
             handleRemove={handleRemove}
             id={concept.id}

--- a/src/components/SlateEditor/plugins/concept/block/BlockConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockConceptPreview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2022-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,11 +18,11 @@ import { IConcept } from '@ndla/types-concept-api';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { addShowConceptDefinitionClickListeners } from '@ndla/article-scripts';
-import IconButton from '../../../IconButton';
-import { getYoutubeEmbedUrl } from '../../../../util/videoUtil';
-import { parseEmbedTag } from '../../../../util/embedTagHelpers';
-import config from '../../../../config';
-import { Embed } from '../../../../interfaces';
+import IconButton from '../../../../IconButton';
+import { getYoutubeEmbedUrl } from '../../../../../util/videoUtil';
+import { parseEmbedTag } from '../../../../../util/embedTagHelpers';
+import config from '../../../../../config';
+import { Embed } from '../../../../../interfaces';
 
 const StyledFigureButtons = styled('span')<{ isBlockView?: boolean }>`
   position: absolute;
@@ -44,7 +44,7 @@ interface Props {
   id: number | string;
 }
 
-const SlateConceptPreview = ({ concept, handleRemove, id, isBlockView }: Props) => {
+const BlockConceptPreview = ({ concept, handleRemove, id, isBlockView }: Props) => {
   const { t, i18n } = useTranslation();
   useEffect(() => {
     addShowConceptDefinitionClickListeners();
@@ -133,4 +133,4 @@ const SlateConceptPreview = ({ concept, handleRemove, id, isBlockView }: Props) 
   );
 };
 
-export default SlateConceptPreview;
+export default BlockConceptPreview;

--- a/src/components/SlateEditor/plugins/concept/block/BlockConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockConceptPreview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-present, NDLA.
+ * Copyright (c) 2021-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConceptPreview.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2022-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConceptPreview.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConceptPreview.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactNode, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Remarkable } from 'remarkable';
+import styled from '@emotion/styled';
+import { spacing } from '@ndla/core';
+import { DeleteForever } from '@ndla/icons/editor';
+import { Link as LinkIcon } from '@ndla/icons/common';
+import { ImageLink } from '@ndla/ui';
+import { useTranslation } from 'react-i18next';
+import { IConcept } from '@ndla/types-concept-api';
+import { NotionDialogContent, NotionDialogText, NotionDialogLicenses } from '@ndla/notion';
+import Tooltip from '@ndla/tooltip';
+import { addShowConceptDefinitionClickListeners } from '@ndla/article-scripts';
+import IconButton from '../../../../IconButton';
+import { getSrcSets } from '../../../../../util/imageEditorUtil';
+import { getYoutubeEmbedUrl } from '../../../../../util/videoUtil';
+import { parseEmbedTag } from '../../../../../util/embedTagHelpers';
+import config from '../../../../../config';
+import { Embed } from '../../../../../interfaces';
+
+const StyledFigureButtons = styled('span')<{ isBlockView?: boolean }>`
+  position: absolute;
+  top: 0;
+  z-index: 1;
+  right: 0;
+  ${p => (p.isBlockView ? 'transform: translateX(100%);' : '')}
+  margin-top: ${spacing.xsmall};
+  > * {
+    margin-bottom: ${spacing.xsmall};
+  }
+`;
+
+interface Props {
+  concept: IConcept;
+  isBlockView?: boolean;
+  handleRemove: () => void;
+  id: number | string;
+}
+interface ImageWrapperProps {
+  children: ReactNode;
+  url?: string;
+}
+
+const ImageWrapper = ({ children, url }: ImageWrapperProps) =>
+  url ? <ImageLink src={url}>{children}</ImageLink> : <>{children}</>;
+
+const SlateConceptPreview = ({ concept, handleRemove, id, isBlockView }: Props) => {
+  const { t } = useTranslation();
+  useEffect(() => {
+    addShowConceptDefinitionClickListeners();
+  }, []);
+
+  const markdown = new Remarkable({ breaks: true });
+  markdown.inline.ruler.enable(['sub', 'sup']);
+
+  const visualElement = useMemo(() => {
+    const visualElement: Embed | undefined = parseEmbedTag(concept.visualElement?.visualElement);
+    if (!visualElement) return null;
+    switch (visualElement?.resource) {
+      case 'image':
+        const wrapperUrl = `${config.ndlaApiUrl}/image-api/raw/id/${visualElement.resource_id}`;
+        const srcSet = getSrcSets(visualElement.resource_id, visualElement);
+        return (
+          <ImageWrapper url={wrapperUrl}>
+            <img alt={visualElement?.alt} src={visualElement?.url} srcSet={srcSet} />
+          </ImageWrapper>
+        );
+      case 'external':
+        return (
+          <iframe
+            title={visualElement?.title}
+            src={
+              visualElement?.url?.includes('youtube')
+                ? getYoutubeEmbedUrl(visualElement?.url)
+                : visualElement?.url
+            }
+            frameBorder="0"
+            scrolling="no"
+            height={400}
+          />
+        );
+      case 'brightcove':
+        return (
+          <iframe
+            title={visualElement?.title}
+            src={`https://players.brightcove.net/${config.brightCoveAccountId}/${config.brightcovePlayerId}_default/index.html?videoId=${visualElement?.videoid}`}
+            frameBorder="0"
+            scrolling="no"
+            height={400}
+          />
+        );
+      case 'video':
+      case 'h5p':
+        return (
+          <iframe
+            title={visualElement?.title}
+            src={visualElement?.url}
+            frameBorder="0"
+            scrolling="no"
+            height={400}
+          />
+        );
+      default:
+        return null;
+    }
+  }, [concept.visualElement]);
+
+  return (
+    <>
+      <NotionDialogContent>
+        {visualElement}
+        <NotionDialogText>
+          <span
+            dangerouslySetInnerHTML={{
+              __html: markdown.render(concept.content?.content),
+            }}
+          />
+        </NotionDialogText>
+      </NotionDialogContent>
+      <NotionDialogLicenses
+        license={concept.copyright?.license?.license}
+        source={
+          <span
+            dangerouslySetInnerHTML={{
+              __html: markdown.render(concept.source),
+            }}
+          />
+        }
+        authors={concept.copyright?.creators.map(creator => creator.name)}
+      />
+
+      <StyledFigureButtons isBlockView={isBlockView}>
+        <Tooltip tooltip={t('form.concept.removeConcept')} align="right">
+          <IconButton color="red" type="button" onClick={handleRemove} tabIndex={-1}>
+            <DeleteForever />
+          </IconButton>
+        </Tooltip>
+        <Tooltip tooltip={t('form.concept.edit')} align="right">
+          <IconButton
+            as={Link}
+            to={`/concept/${id}/edit/${concept.content?.language}`}
+            target="_blank"
+            title={t('form.concept.edit')}
+            tabIndex={-1}>
+            <LinkIcon />
+          </IconButton>
+        </Tooltip>
+      </StyledFigureButtons>
+    </>
+  );
+};
+
+export default SlateConceptPreview;

--- a/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/SlateNotion.tsx
@@ -8,9 +8,9 @@ import { RenderElementProps } from 'slate-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { AlertCircle, Check } from '@ndla/icons/lib/editor';
-import SlateConceptPreview from '../SlateConceptPreview';
 import { Portal } from '../../../../Portal';
 import { PUBLISHED } from '../../../../../util/constants/ConceptStatus';
+import InlineConceptPreview from './InlineConceptPreview';
 
 const StyledCheckIcon = styled(Check)`
   margin-left: 10px;
@@ -110,7 +110,7 @@ const SlateNotion = ({ children, attributes, id, concept, handleRemove }: Props)
               </div>
             }>
             {concept && (
-              <SlateConceptPreview concept={concept} handleRemove={handleRemove} id={concept.id} />
+              <InlineConceptPreview concept={concept} handleRemove={handleRemove} id={concept.id} />
             )}
           </NotionDialog>
         </Portal>


### PR DESCRIPTION
Inline-forklaring i slate fikk feil visning i modal etter feilrettinger jeg gjorde tidligere. Den fikk det nye blokk-visningsformatet, men skal fortsatt vises som tidligere. Har rettet dette opp ved å lage to separate preview-types, en for inline og en for blokk-visning.

Hvordan teste:
1. Åpne en artikkel.
2. Sett inn en forklaring
3. Modalen som åpnes skal ha "gammel" visning med visuelt element på toppen og tekst under.