### PR TITLE
Add feed-icon to series page.

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -9,6 +9,7 @@ import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import SafeLink from '@ndla/safelink';
 import { colors, fonts, spacing } from '@ndla/core';
+import { RssFeed } from '@ndla/icons/common';
 import { Check, AlertCircle } from '@ndla/icons/editor';
 import Tooltip from '@ndla/tooltip';
 import { IConceptSummary } from '@ndla/types-concept-api';
@@ -115,6 +116,12 @@ const HeaderStatusInformation = ({
     fill: ${colors.support.yellow};
   `;
 
+  const StyledRssIcon = styled(RssFeed)`
+    height: ${spacing.normal};
+    width: ${spacing.normal};
+    fill: ${colors.support.green};
+  `;
+
   const StyledLink = styled(SafeLink)`
     box-shadow: inset 0 0;
   `;
@@ -134,6 +141,12 @@ const HeaderStatusInformation = ({
   const publishedIconLink = (
     <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}${taxonomyPaths?.[0]}`}>
       {publishedIcon}
+    </StyledLink>
+  );
+
+  const rssLink = type === 'podcast-series' && id !== undefined && (
+    <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/podkast/${id}/feed.xml`}>
+      <StyledRssIcon title={t('podcastSeriesForm.rss')} />
     </StyledLink>
   );
 
@@ -203,6 +216,8 @@ const HeaderStatusInformation = ({
     return <StyledStatusWrapper>{imageConnections}</StyledStatusWrapper>;
   } else if (type === 'audio' || type === 'podcast') {
     return <StyledStatusWrapper>{audioConnections}</StyledStatusWrapper>;
+  } else if (type === 'podcast-series') {
+    return <StyledStatusWrapper>{rssLink}</StyledStatusWrapper>;
   }
   return null;
 };

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -435,6 +435,7 @@ const phrases = {
     title: 'Podcast series',
     alreadyPartOfSeries: 'Part of another series',
     description: 'Description',
+    rss: 'Rss feed',
   },
   podcastForm: {
     title: 'Podcast episode',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -436,6 +436,7 @@ const phrases = {
     title: 'Podkastserie',
     alreadyPartOfSeries: 'Del av en annen serie',
     description: 'Beskrivelse',
+    rss: 'Rss-feed',
   },
   podcastForm: {
     title: 'Podkastepisode',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -436,6 +436,7 @@ const phrases = {
     title: 'Podkastserie',
     alreadyPartOfSeries: 'Del av ein anna serie',
     description: 'Beskrivelse',
+    rss: 'Rss-feed',
   },
   podcastForm: {
     title: 'Podkastepisode',


### PR DESCRIPTION
Viser feed-ikon i header på podkastserie.

Test:
* Sjekk at det vises url til feed i header på serier. 