### PR TITLE
Add a more sustainable way to invalidate queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "react-helmet": "^5.2.1",
     "react-i18next": "11.11.4",
     "react-image-crop": "^6.0.18",
-    "react-query": "^3.25.1",
+    "react-query": "^3.38.1",
     "react-router-dom": "^6.0.2",
     "react-tabs": "^3.0.0",
     "react-transition-group": "^4.2.2",

--- a/src/containers/TaxonomyVersions/components/Version.tsx
+++ b/src/containers/TaxonomyVersions/components/Version.tsx
@@ -21,11 +21,11 @@ import { VersionStatusType, VersionType } from '../../../modules/taxonomy/versio
 import IconButton from '../../../components/IconButton';
 import VersionForm from './VersionForm';
 import { useDeleteVersionMutation } from '../../../modules/taxonomy/versions/versionMutations';
-import { VERSIONS } from '../../../queryKeys';
 import AlertModal from '../../../components/AlertModal';
 import { StyledErrorMessage } from '../../StructurePage/folderComponents/styles';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 import config from '../../../config';
+import { versionsQueryKey } from '../../../modules/taxonomy/versions/versionQueries';
 
 interface Props {
   version: VersionType;
@@ -110,16 +110,17 @@ const Version = ({ version }: Props) => {
   const [error, setError] = useState<string | undefined>(undefined);
   const [isEditing, setIsEditing] = useState(false);
   const qc = useQueryClient();
+  const key = versionsQueryKey({ taxonomyVersion: 'default' });
 
   const deleteVersionMutation = useDeleteVersionMutation({
     onMutate: async ({ id }) => {
       setError(undefined);
-      await qc.cancelQueries([VERSIONS]);
-      const existingVersions = qc.getQueryData<VersionType[]>([VERSIONS]) ?? [];
+      await qc.cancelQueries(key);
+      const existingVersions = qc.getQueryData<VersionType[]>(key) ?? [];
       const withoutDeleted = existingVersions.filter(version => version.id !== id);
-      qc.setQueryData<VersionType[]>([VERSIONS], withoutDeleted);
+      qc.setQueryData<VersionType[]>(key, withoutDeleted);
     },
-    onSuccess: () => qc.invalidateQueries([VERSIONS]),
+    onSuccess: () => qc.invalidateQueries(key),
     onError: () => setError(t('taxonomyVersions.deleteError')),
   });
 

--- a/src/modules/taxonomy/versions/versionQueries.ts
+++ b/src/modules/taxonomy/versions/versionQueries.ts
@@ -13,13 +13,14 @@ import { fetchVersion, fetchVersions } from './versionApi';
 import { GetVersionsParams, VersionType } from './versionApiTypes';
 
 interface UseVersionsParams extends WithTaxonomyVersion, GetVersionsParams {}
+export const versionsQueryKey = (params?: Partial<UseVersionParams>) => [VERSIONS, params];
 export const useVersions = (
-  { taxonomyVersion, ...params }: UseVersionsParams,
+  params: UseVersionsParams,
   options?: UseQueryOptions<VersionType[]>,
 ) => {
   return useQuery<VersionType[]>(
-    [VERSIONS, params],
-    () => fetchVersions({ ...params, taxonomyVersion }),
+    versionsQueryKey(params),
+    () => fetchVersions({ ...params }),
     options,
   );
 };
@@ -27,7 +28,7 @@ export const useVersions = (
 interface UseVersionParams extends WithTaxonomyVersion {
   id: string;
 }
-
+export const versionQueryKey = (params?: Partial<UseVersionParams>) => [VERSION, params];
 export const useVersion = (
   { id, taxonomyVersion }: UseVersionParams,
   options?: UseQueryOptions<VersionType>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13182,10 +13182,10 @@ react-property@1.0.1:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-1.0.1.tgz#4ae4211557d0a0ae050a71aa8ad288c074bea4e6"
   integrity sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ==
 
-react-query@^3.25.1:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.25.1.tgz#221ff17406518a7689378dcbbdc986b0ba2c3919"
-  integrity sha512-tGZkap921d9dJD2F8+NpEu3djLRP+tpZKHKhQvqUMYMfWT5R18iRtGAG5ZeUMlRKuhzNaZx3cHiYj3DsyZ1SWw==
+react-query@^3.38.1:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.38.1.tgz#4892304dae7eca7fa0ab5c8ae3e9748f0fca2df9"
+  integrity sha512-CM9hsz6oib17hsBguGaMJr+a0swMzou2gvNHHjAusnXvkfTx6CTzx0Iwuplox1jI2j3WiY91BGrcIN6bp1n1Iw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/Issues/issues/3076.

Prøver å splitte denne opp, og dette virket som et greit sted å starte.

Denne PR'en inneholder to endringer, der den første ikke har noe med issuet å gjøre. Jeg bumpet react-query for å fikse query key-tekstfargen slik at det ikke lenger er hvit tekst på hvit bakgrunn.

Den andre, og store endringen er at jeg har laget et nytt system for hvordan man oppretter en query key. En query key er en nøkkel som forbindes med en spesifikk API-spørring. Dersom man spør etter data fra samme query key to ganger på rad vil react-query bruke cache og returnere umiddelbart, før den eventuelt returnerer oppdatert data fra API'et. Vår gamle løsning baserte seg på at utvikleren hadde en grei kunnskap om hvordan en spesifikk nøkkel var bygget opp i den nåværende konteksten. Ettersom query keys vokste ble dette mer uhåndterbart. Inntil videre er det vel for det meste jeg som har jobbet med query keys, og hvis jeg synes det blir vanskelig vil jeg anta at de som kommer inn senere vil anse det som nærmest umulig. 

I den nye løsningen har man en query key-funksjon som følger med enhver query. I dette tilfellet vil `useVersions` ha en query key-funksjon som heter `versionsQueryKey`. I den gamle versjonen kunne man invalidere cachen ved å skrive `invalidateQueries([VERSIONS, 'default'])`, da versions-queryet tok hensyn til taksonomiversjon. Hvis man passerte inn `invalidateQueries([VERSIONS, 'ae9f'])` ville ingenting blitt invalidert. I dette tilfellet ga det egentlig mer mening å invalidere alle `VERSIONS`-queries. I den nye versjonen kan man derfor bare passere inn `invalidateQueries(versionsQueryKey())`, og oppnå akkurat dette. Hvis man ønsker å kun invalidere `VERSIONS`-queries for en spesifikk taksonomi-versjon kan man passere inn `invalidateQueries({taxonomyVersion: 'default'})`. Typesikkert, og mye enklere å forstå seg på. 