### PR TITLE
New query keys for resource types

### DIFF
--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -50,7 +50,7 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
   });
 
   const { data: resourceTypes } = useAllResourceTypes(
-    { locale, taxonomyVersion },
+    { language: locale, taxonomyVersion },
     {
       select: resourceTypes => flattenResourceTypesAndAddContextTypes(resourceTypes, t),
       placeholderData: [],

--- a/src/containers/StructurePageBeta/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/StructureResources.tsx
@@ -70,7 +70,7 @@ const StructureResources = ({ currentChildNode, resourceRef, onCurrentNodeChange
   );
 
   const { data: resourceTypes } = useAllResourceTypes(
-    { locale: i18n.language, taxonomyVersion },
+    { language: i18n.language, taxonomyVersion },
     {
       select: resourceTypes => resourceTypes.concat(getMissingResourceType(t)),
       onError: e => handleError(e),

--- a/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
+++ b/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
@@ -16,27 +16,28 @@ interface UseResourceTypeParams extends WithTaxonomyVersion {
   id: string;
   language: string;
 }
-
+export const resourceTypeQueryKey = (params?: Partial<UseResourceTypeParams>) => [
+  RESOURCE_TYPE,
+  params,
+];
 export const useResourceType = (
-  { id, language, taxonomyVersion }: UseResourceTypeParams,
+  params: UseResourceTypeParams,
   options?: UseQueryOptions<ResourceType>,
-) =>
-  useQuery<ResourceType>(
-    [RESOURCE_TYPE, id, language, taxonomyVersion],
-    () => fetchResourceType({ id, language, taxonomyVersion }),
-    options,
-  );
+) => useQuery<ResourceType>(resourceTypeQueryKey(params), () => fetchResourceType(params), options);
 
 interface UseAllResourceTypesParams extends WithTaxonomyVersion {
-  locale: string;
+  language: string;
 }
-
+export const resourceTypesQueryKey = (params?: Partial<UseAllResourceTypesParams>) => [
+  RESOURCE_TYPES,
+  params,
+];
 export const useAllResourceTypes = <ReturnType>(
-  { locale, taxonomyVersion }: UseAllResourceTypesParams,
+  params: UseAllResourceTypesParams,
   options?: UseQueryOptions<ResourceType[], unknown, ReturnType>,
 ) =>
   useQuery<ResourceType[], unknown, ReturnType>(
-    [RESOURCE_TYPES, locale, taxonomyVersion],
-    () => fetchAllResourceTypes({ language: locale, taxonomyVersion }),
+    resourceTypesQueryKey(params),
+    () => fetchAllResourceTypes(params),
     options,
   );


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/editorial-frontend/pull/1442
I samme stil som https://github.com/NDLANO/editorial-frontend/pull/1442

Sjekk at ressurstyper fungerer på lagrede søk, på søkesiden og på ressursvisningen i struktur-beta. Gjøres ingen invalidering på dette direkte, så burde være greit.