### PR TITLE
Do not send status with update

### DIFF
--- a/src/containers/ConceptPage/conceptTransformers.ts
+++ b/src/containers/ConceptPage/conceptTransformers.ts
@@ -85,7 +85,6 @@ export const getUpdatedConceptType = (
 ): IUpdatedConcept => ({
   ...getNewConceptType(values, licenses),
   metaImage: metaImageFromForm(values) ?? null,
-  status: values.status?.current,
 });
 
 export const conceptFormTypeToApiType = (


### PR DESCRIPTION
Fixes NDLANO/Issues#3086

Det går ikkje an å lagre forklaringer med status PUBLISHED fordi endring av status fungerer ikkje når du sender inn gjeldende status med update. Kunne sikkert løst dette i concept-api også men dette var en raskere fiks.

Test:
* Sjekk at det går an å lagre forklaringer som er publiserte og at status endres til kladd.