### PR TITLE
Added query key functions to search and single-resource query functions

### DIFF
--- a/src/components/ResourcePage.tsx
+++ b/src/components/ResourcePage.tsx
@@ -29,7 +29,10 @@ interface BaseResource {
 interface Props<T extends BaseResource> {
   CreateComponent: ComponentType;
   EditComponent: ComponentType<ResourceComponentProps>;
-  useHook: (id: number, language?: string, options?: UseQueryOptions<T>) => UseQueryResult<T>;
+  useHook: (
+    params: { id: number; language?: string },
+    options?: UseQueryOptions<T>,
+  ) => UseQueryResult<T>;
   createUrl: string;
   titleTranslationKey?: string;
 }
@@ -69,7 +72,10 @@ const ResourcePage = <T extends BaseResource>({
 
 interface EditResourceRedirectProps<T extends BaseResource> {
   isNewlyCreated: boolean;
-  useHook: (id: number, language?: string, options?: UseQueryOptions<T>) => UseQueryResult<T>;
+  useHook: (
+    params: { id: number; language?: string },
+    options?: UseQueryOptions<T>,
+  ) => UseQueryResult<T>;
   Component: ComponentType<ResourceComponentProps>;
 }
 
@@ -83,7 +89,10 @@ const EditResourceRedirect = <T extends BaseResource>({
   const locale = i18n.language;
   const { id } = useParams<'id'>();
   const parsedId = Number(id);
-  const { data, error, isLoading } = useHook(parsedId, undefined, { enabled: !!parsedId });
+  const { data, error, isLoading } = useHook(
+    { id: parsedId, language: undefined },
+    { enabled: !!parsedId },
+  );
   if (isLoading) return <Spinner />;
   if (error || !data || !parsedId) return <NotFoundPage />;
   const supportedLanguage =

--- a/src/containers/App/SubjectMatterPage.tsx
+++ b/src/containers/App/SubjectMatterPage.tsx
@@ -33,9 +33,7 @@ const SubjectMatterPage = () => (
 
 const GenericArticleRedirect = () => {
   const parsedId = Number(useParams<'id'>().id);
-  const { data: article, error, isLoading } = useDraft(parsedId, undefined, {
-    enabled: !!parsedId,
-  });
+  const { data: article, error, isLoading } = useDraft({ id: parsedId }, { enabled: !!parsedId });
   if (isLoading) return <Spinner />;
   if (error || !article || !parsedId) return <NotFoundPage />;
 

--- a/src/containers/StructurePageBeta/resourceComponents/GrepCodesModal.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/GrepCodesModal.tsx
@@ -11,8 +11,7 @@ import { useQueryClient } from 'react-query';
 import Spinner from '../../../components/Spinner';
 import TaxonomyLightbox from '../../../components/Taxonomy/TaxonomyLightbox';
 import { useUpdateDraftMutation } from '../../../modules/draft/draftMutations';
-import { useDraft } from '../../../modules/draft/draftQueries';
-import { DRAFT } from '../../../queryKeys';
+import { draftQueryKey, useDraft } from '../../../modules/draft/draftQueries';
 import { getIdFromUrn } from '../../../util/taxonomyHelpers';
 import GrepCodesForm from './GrepCodesForm';
 
@@ -23,7 +22,10 @@ interface Props {
 const GrepCodesModal = ({ contentUri, onClose }: Props) => {
   const { t, i18n } = useTranslation();
   const draftId = getIdFromUrn(contentUri);
-  const { data, isLoading } = useDraft(draftId!, i18n.language, { enabled: !!draftId });
+  const { data, isLoading } = useDraft(
+    { id: draftId!, language: i18n.language },
+    { enabled: !!draftId },
+  );
   const updateDraft = useUpdateDraftMutation();
   const qc = useQueryClient();
 
@@ -36,10 +38,10 @@ const GrepCodesModal = ({ contentUri, onClose }: Props) => {
       { id: draftId, body: { grepCodes: newCodes, revision: data.revision } },
       {
         onSuccess: data => {
-          const key = [DRAFT, draftId!, i18n.language];
+          const key = draftQueryKey({ id: draftId!, language: i18n.language! });
           qc.cancelQueries(key);
           qc.setQueryData(key, data);
-          qc.invalidateQueries([DRAFT, draftId!, i18n.language]);
+          qc.invalidateQueries(key);
         },
       },
     );

--- a/src/containers/WelcomePage/components/LastUsedContent.tsx
+++ b/src/containers/WelcomePage/components/LastUsedContent.tsx
@@ -26,7 +26,7 @@ const LastUsedContent = ({ articleId }: Props) => {
   const locale = i18n.language;
   const { userPermissions } = useSession();
 
-  const { data: article } = useDraft(articleId, locale);
+  const { data: article } = useDraft({ id: articleId, language: locale });
 
   return (
     <div {...classes('result')}>

--- a/src/modules/audio/audioQueries.ts
+++ b/src/modules/audio/audioQueries.ts
@@ -7,7 +7,6 @@
  */
 
 import { useQuery, UseQueryOptions } from 'react-query';
-import queryString from 'query-string';
 import {
   IAudioMetaInformation,
   IAudioSummarySearchResult,
@@ -15,38 +14,54 @@ import {
   ISeries,
 } from '@ndla/types-audio-api';
 import { AUDIO, PODCAST_SERIES, SEARCH_AUDIO, SEARCH_SERIES } from '../../queryKeys';
-import { SeriesSearchParams } from './audioApiInterfaces';
+import { AudioSearchParams, SeriesSearchParams } from './audioApiInterfaces';
 import { fetchAudio, fetchSeries, searchAudio, searchSeries } from './audioApi';
 
-export const useAudio = (
-  id: number,
-  language: string | undefined,
-  options?: UseQueryOptions<IAudioMetaInformation>,
-) =>
-  useQuery<IAudioMetaInformation>([AUDIO, id, language], () => fetchAudio(id, language), options);
+export interface UseAudio {
+  id: number;
+  language?: string;
+}
 
-export const useSeries = (
-  id: number,
-  language: string | undefined,
-  options?: UseQueryOptions<ISeries>,
-) => useQuery<ISeries>([PODCAST_SERIES, id, language], () => fetchSeries(id, language), options);
+export const audioQueryKeys = (params?: Partial<UseAudio>) => [AUDIO, params];
 
+export const useAudio = (params: UseAudio, options?: UseQueryOptions<IAudioMetaInformation>) =>
+  useQuery<IAudioMetaInformation>(
+    audioQueryKeys(params),
+    () => fetchAudio(params.id, params.language),
+    options,
+  );
+
+export interface UseSeries {
+  id: number;
+  language?: string;
+}
+
+export const seriesQueryKey = (params?: Partial<UseSeries>) => [PODCAST_SERIES, params];
+
+export const useSeries = (params: UseSeries, options?: UseQueryOptions<ISeries>) =>
+  useQuery<ISeries>(seriesQueryKey(params), () => fetchSeries(params.id, params.language), options);
+
+export const searchSeriesQueryKey = (params?: Partial<SeriesSearchParams>) => [
+  SEARCH_SERIES,
+  params,
+];
 export const useSearchSeries = (
   query: SeriesSearchParams,
   options?: UseQueryOptions<ISeriesSummarySearchResult>,
 ) =>
   useQuery<ISeriesSummarySearchResult>(
-    [SEARCH_SERIES, queryString.stringify(query)],
+    searchSeriesQueryKey(query),
     () => searchSeries(query),
     options,
   );
 
+export const searchAudioQueryKey = (params?: Partial<AudioSearchParams>) => [SEARCH_AUDIO, params];
 export const useSearchAudio = (
-  query: object,
+  query: AudioSearchParams,
   options?: UseQueryOptions<IAudioSummarySearchResult>,
 ) =>
   useQuery<IAudioSummarySearchResult>(
-    [SEARCH_AUDIO, queryString.stringify(query)],
+    searchAudioQueryKey(query),
     () => searchAudio(query),
     options,
   );

--- a/src/modules/concept/conceptQueries.ts
+++ b/src/modules/concept/conceptQueries.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import queryString from 'query-string';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { IConcept, IConceptSearchResult } from '@ndla/types-concept-api';
 import { CONCEPT, CONCEPT_STATE_MACHINE, SEARCH_CONCEPTS } from '../../queryKeys';
@@ -14,28 +13,40 @@ import { fetchConcept, fetchStatusStateMachine, searchConcepts } from './concept
 import { ConceptQuery } from './conceptApiInterfaces';
 import { ConceptStatusStateMachineType } from '../../interfaces';
 
-export const useConcept = (
-  id: string | number,
-  language?: string,
-  options?: UseQueryOptions<IConcept>,
-) => {
-  return useQuery<IConcept>([CONCEPT, id, language], () => fetchConcept(id, language), options);
+export interface UseConcept {
+  id: number;
+  language?: string;
+}
+
+export const conceptQueryKey = (params?: Partial<UseConcept>) => [CONCEPT, params];
+
+export const useConcept = (params: UseConcept, options?: UseQueryOptions<IConcept>) => {
+  return useQuery<IConcept>(
+    conceptQueryKey(params),
+    () => fetchConcept(params.id, params.language),
+    options,
+  );
 };
+
+export const searchConceptsQueryKey = (params?: Partial<ConceptQuery>) => [SEARCH_CONCEPTS, params];
+
 export const useSearchConcepts = (
   query: ConceptQuery,
   options?: UseQueryOptions<IConceptSearchResult>,
 ) =>
   useQuery<IConceptSearchResult>(
-    [SEARCH_CONCEPTS, queryString.stringify(query)],
+    searchConceptsQueryKey(query),
     () => searchConcepts(query),
     options,
   );
+
+export const conceptStateMachineQueryKey = () => [CONCEPT_STATE_MACHINE];
 
 export const useConceptStateMachine = (
   options?: UseQueryOptions<ConceptStatusStateMachineType>,
 ) => {
   return useQuery<ConceptStatusStateMachineType>(
-    [CONCEPT_STATE_MACHINE],
+    conceptStateMachineQueryKey(),
     () => fetchStatusStateMachine(),
     options,
   );

--- a/src/modules/image/imageQueries.ts
+++ b/src/modules/image/imageQueries.ts
@@ -7,21 +7,24 @@
  */
 
 import { ISearchResult, ISearchParams, IImageMetaInformationV2 } from '@ndla/types-image-api';
-import queryString from 'query-string';
 import { useQuery, UseQueryOptions } from 'react-query';
 import { IMAGE, SEARCH_IMAGES } from '../../queryKeys';
 import { fetchImage, searchImages } from './imageApi';
 
-export const useImage = (
-  id: string | number,
-  language: string | undefined,
-  options?: UseQueryOptions<IImageMetaInformationV2>,
-) =>
-  useQuery<IImageMetaInformationV2>([IMAGE, id, language], () => fetchImage(id, language), options);
+export interface UseImage {
+  id: number;
+  language?: string;
+}
 
-export const useSearchImages = (query: ISearchParams, options?: UseQueryOptions<ISearchResult>) =>
-  useQuery<ISearchResult>(
-    [SEARCH_IMAGES, queryString.stringify(query)],
-    () => searchImages(query),
+export const imageQueryKey = (params?: Partial<UseImage>) => [IMAGE, params];
+export const useImage = (params: UseImage, options?: UseQueryOptions<IImageMetaInformationV2>) =>
+  useQuery<IImageMetaInformationV2>(
+    imageQueryKey(params),
+    () => fetchImage(params.id, params.language),
     options,
   );
+
+export const searchImagesQueryKey = (params?: Partial<ISearchParams>) => [SEARCH_IMAGES, params];
+
+export const useSearchImages = (query: ISearchParams, options?: UseQueryOptions<ISearchResult>) =>
+  useQuery<ISearchResult>(searchImagesQueryKey(query), () => searchImages(query), options);


### PR DESCRIPTION
Måtte ta dette sammen for å unngå feil. Dette går i all hovedsak på søkesidene og form-sidene. Kan derfor testes ved å sjekke at søk og navigering til alle ressurser fungerer som før. Sjekk også forsiden, da den tar i bruk draft-queries.