### PR TITLE
Slate image editor always have full width

### DIFF
--- a/src/components/SlateEditor/plugins/embed/EditImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditImage.tsx
@@ -16,6 +16,7 @@ import ImageEditor from '../../../../containers/ImageEditor/ImageEditor';
 import { Portal } from '../../../Portal';
 import Overlay from '../../../Overlay';
 import { ImageEmbed } from '../../../../interfaces';
+import { placeholder } from 'lodash/fp';
 
 const editorContentCSS = css`
   box-shadow: ${shadows.levitate1};
@@ -74,15 +75,15 @@ const EditImage = ({ embed, saveEmbedUpdates, setEditModus }: Props) => {
 
   useEffect(() => {
     const bodyRect = document.body.getBoundingClientRect();
-    // Use contenteditable as reference to fetch embed size when previewing.
+
+    const editorRect = placeholderElement.closest('.c-editor').getBoundingClientRect();
+
     const placeholderRect = placeholderElement.closest('div.c-figure').getBoundingClientRect();
 
     embedElement.style.position = 'absolute';
     embedElement.style.top = `${placeholderRect.top - bodyRect.top}px`;
-    embedElement.style.left = `${placeholderRect.left +
-      spacingUnit -
-      placeholderRect.width * (0.333 / 2)}px`;
-    embedElement.style.width = `${placeholderRect.width * 1.333 - spacingUnit * 2}px`;
+    embedElement.style.left = `${editorRect.left + spacingUnit - editorRect.width * (0.333 / 2)}px`;
+    embedElement.style.width = `${editorRect.width * 1.333 - spacingUnit * 2}px`;
   }, [embedElement, placeholderElement]);
 
   const onUpdatedImageSettings = (transformedData: NonNullable<StateProps['imageUpdates']>) => {

--- a/src/components/SlateEditor/plugins/embed/EditImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/EditImage.tsx
@@ -16,7 +16,6 @@ import ImageEditor from '../../../../containers/ImageEditor/ImageEditor';
 import { Portal } from '../../../Portal';
 import Overlay from '../../../Overlay';
 import { ImageEmbed } from '../../../../interfaces';
-import { placeholder } from 'lodash/fp';
 
 const editorContentCSS = css`
   box-shadow: ${shadows.levitate1};


### PR DESCRIPTION
Oppdaget et problem med bilder av små størrelse der bilderedigerings-modal ble veldig smal og dermed gjøre det vanskelig å redigere bilde. Feilen kan framprovoseres i test ved å sette inn et bilde av størrelse "frimerke" (må høyre eller venstrestilles først) og deretter trykke på det igjen for å åpne editoren.

Dette er nå løst ved at modalen alltid har samme bredde som slate-editoren.

Hvordan teste:
1. Åpne artikkel.
2. Sett inn bilde og trykk på det etterpå.
3. Høyre eller venstre-juster og sett størrelse til frimerke. Lagre bilde.
4. Trykk på bildet igjen. Bredden på editoren skal fortsatt være stor.