### PR TITLE
Add choice to publish node resources to structure beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@ndla/types-article-api": "^0.0.5",
     "@ndla/types-audio-api": "^0.0.10",
     "@ndla/types-concept-api": "^0.0.10",
-    "@ndla/types-draft-api": "^0.0.21",
+    "@ndla/types-draft-api": "^0.0.23",
     "@ndla/types-frontpage-api": "^0.0.3",
     "@ndla/types-image-api": "^0.0.4",
     "@ndla/types-learningpath-api": "^0.0.2",

--- a/src/containers/ArticlePage/articleTransformers.ts
+++ b/src/containers/ArticlePage/articleTransformers.ts
@@ -223,5 +223,6 @@ export const updatedDraftApiTypeToDraftApiType = (
     conceptIds: article.conceptIds ?? [],
     availability: article.availability ?? 'everyone',
     relatedContent: article.relatedContent ?? [],
+    revisions: article.revisionMeta ?? [],
   };
 };

--- a/src/containers/FormikForm/VersionAndNotesPanel.tsx
+++ b/src/containers/FormikForm/VersionAndNotesPanel.tsx
@@ -104,6 +104,7 @@ const VersionAndNotesPanel = ({ article, getArticle, type, currentLanguage }: Pr
           editorLabels: [],
           relatedContent: [],
           status: { current: 'PUBLISHED', other: [] },
+          revisions: [],
         };
       }
       const transform =

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -21,6 +21,7 @@ import ToggleVisibility from './sharedMenuOptions/ToggleVisibility';
 import ToNodeDiff from './sharedMenuOptions/ToNodeDiff';
 import ChangeNodeName from './subjectMenuOptions/ChangeNodeName';
 import EditSubjectpageOption from './subjectMenuOptions/EditSubjectpageOption';
+import PublishChildNodeResources from './topicMenuOptions/PublishChildNodeResources';
 
 interface Props {
   rootNodeId: string;
@@ -95,7 +96,7 @@ const SettingsMenuDropdownType = ({
   } else if (nodeType === TOPIC_NODE) {
     return (
       <>
-        {/* <PublishChildNode node={node} /> */}
+        <PublishChildNodeResources node={node} />
         <EditCustomFields
           toggleEditMode={toggleEditMode}
           editMode={editMode}

--- a/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import styled from '@emotion/styled';
+import { colors } from '@ndla/core';
+import { Spinner } from '@ndla/editor';
+import { Done } from '@ndla/icons/lib/editor';
+import { ISearchResult } from '@ndla/types-draft-api';
+import { ISearchResultV2 } from '@ndla/types-learningpath-api';
+import { partition } from 'lodash';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
+import AlertModal from '../../../../components/AlertModal';
+import RoundIcon from '../../../../components/RoundIcon';
+import { searchDrafts, updateStatusDraft } from '../../../../modules/draft/draftApi';
+import {
+  learningpathSearch,
+  updateStatusLearningpath,
+} from '../../../../modules/learningpath/learningpathApi';
+import { fetchNodeResources } from '../../../../modules/nodes/nodeApi';
+import { NodeType } from '../../../../modules/nodes/nodeApiTypes';
+import { RESOURCE_META } from '../../../../queryKeys';
+import { PUBLISHED } from '../../../../util/constants/ArticleStatus';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
+import ResourceItemLink from '../../resourceComponents/ResourceItemLink';
+import MenuItemButton from '../sharedMenuOptions/components/MenuItemButton';
+
+interface Props {
+  node: NodeType;
+}
+const StyledDiv = styled.div`
+  display: flex;
+  align-items: center;
+  padding-left: 1.2em;
+`;
+
+const LinkWrapper = styled.div`
+  a {
+    color: ${colors.white};
+    &:hover {
+      color: ${colors.white};
+    }
+  }
+  margin-top: 0.5em;
+`;
+
+const StyledDone = styled(Done)`
+  margin: 0px 4px;
+  color: green;
+`;
+
+interface BaseResource {
+  name: string;
+  contentUri?: string | undefined;
+}
+
+const PublishChildNodeResources = ({ node }: Props) => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
+  const { taxonomyVersion } = useTaxonomyVersion();
+  const [showDisplay, setShowDisplay] = useState(false);
+  const [failedResources, setFailedResources] = useState<BaseResource[]>([]);
+  const [publishedCount, setPublishedCount] = useState(0);
+  const [publishableCount, setPublishableCount] = useState(0);
+  const [done, setDone] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    setShowAlert(failedResources.length !== 0 && done);
+  }, [failedResources, done]);
+
+  const publishResources = async () => {
+    setFailedResources([]);
+    setDone(false);
+    setPublishableCount(0);
+    setPublishedCount(0);
+    const nodeResources = await fetchNodeResources({ id: node.id, language, taxonomyVersion });
+    const allResources = [{ name: node.name, contentUri: node.contentUri }, ...nodeResources];
+    const withContentUri = allResources.filter(res => !!res.contentUri);
+    setPublishableCount(allResources.length);
+    setShowDisplay(true);
+    const [draftResources, learningpathResources] = partition(withContentUri, res => {
+      const [, resourceType] = res.contentUri!.split(':');
+      return resourceType === 'article';
+    });
+    const draftIds = draftResources.map(res => Number(res.contentUri!.split(':')[2]));
+    const learningpathIds = learningpathResources.map(res => Number(res.contentUri!.split(':')[2]));
+    const [drafts, learningpaths]: [ISearchResult, ISearchResultV2] = await Promise.all([
+      searchDrafts({ idList: draftIds }),
+      learningpathSearch({ ids: learningpathIds }),
+    ]);
+    const unpublishedDrafts = drafts.results.filter(draft => draft.status.current !== PUBLISHED);
+    const unpublishedLearningpaths = learningpaths.results.filter(lp => lp.status !== PUBLISHED);
+
+    const draftPromises = unpublishedDrafts.map(draft =>
+      updateStatusDraft(draft.id, PUBLISHED)
+        .then(_ => setPublishedCount(c => c + 1))
+        .catch(_ =>
+          setFailedResources(prev =>
+            prev.concat({ name: draft.title.title, contentUri: `url:article:${draft.id}` }),
+          ),
+        ),
+    );
+    const learningpathPromises = unpublishedLearningpaths.map(lp =>
+      updateStatusLearningpath(lp.id, PUBLISHED)
+        .then(_ => setPublishedCount(c => c + 1))
+        .catch(_ =>
+          setFailedResources(prev =>
+            prev.concat({ name: lp.title.title, contentUri: `url:learningpath:${lp.id}` }),
+          ),
+        ),
+    );
+    await Promise.all([...draftPromises, ...learningpathPromises]);
+    await qc.invalidateQueries([RESOURCE_META, {}]);
+    setDone(true);
+  };
+
+  const publishText = t(`taxonomy.publish.${done ? 'done' : 'waiting'}`);
+
+  return (
+    <>
+      <MenuItemButton stripped onClick={() => setShowConfirmation(true)}>
+        <RoundIcon small icon={<Done />} />
+        {t('taxonomy.publish.button')}
+      </MenuItemButton>
+      {showDisplay && (
+        <StyledDiv>
+          {done ? <StyledDone /> : <Spinner size="normal" margin="0px 4px" />}
+          {`${publishText} (${publishedCount}/${publishableCount})`}
+        </StyledDiv>
+      )}
+      <AlertModal
+        show={showAlert}
+        onCancel={() => setShowAlert(false)}
+        text={t('taxonomy.publish.error')}
+        component={failedResources.map(res => (
+          <LinkWrapper>
+            <ResourceItemLink
+              contentType={
+                res.contentUri?.split(':')[1] === 'article' ? 'article' : 'learning-resource'
+              }
+              contentUri={res.contentUri}
+              name={res.name}
+            />
+          </LinkWrapper>
+        ))}
+      />
+      <AlertModal
+        show={showConfirmation}
+        actions={[
+          {
+            text: t('form.abort'),
+            onClick: () => setShowConfirmation(false),
+          },
+          {
+            text: t('taxonomy.publish.button'),
+            onClick: () => {
+              setShowConfirmation(false);
+              publishResources();
+            },
+          },
+        ]}
+        onCancel={() => setShowConfirmation(false)}
+        text={t('taxonomy.publish.info')}
+      />
+    </>
+  );
+};
+
+export default PublishChildNodeResources;

--- a/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePageBeta/resourceComponents/Resource.tsx
@@ -167,7 +167,7 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
   };
 
   const resourceMetaQuery = useQuery<ResourceMeta>(
-    [RESOURCE_META, resource.id],
+    [RESOURCE_META, { id: resource.id }],
     () => getArticleMeta(resource),
     { retry: false, initialData: {} },
   );

--- a/src/modules/learningpath/learningpathApi.ts
+++ b/src/modules/learningpath/learningpathApi.ts
@@ -49,11 +49,23 @@ export const updateLearningPathTaxonomy = (
     method: 'POST',
   }).then(r => resolveJsonOrRejectWithError<ILearningPathV2>(r));
 
-export const learningpathSearch = (query: SearchBody): Promise<ISearchResultV2> =>
-  fetchAuthorized(`${baseUrl}/search/`, {
+export const learningpathSearch = async (
+  query: SearchBody & { ids?: number[] },
+): Promise<ISearchResultV2> => {
+  if (query.ids && query.ids.length === 0) {
+    return {
+      totalCount: 0,
+      page: 1,
+      pageSize: 0,
+      language: 'nb',
+      results: [],
+    };
+  }
+  return fetchAuthorized(`${baseUrl}/search/`, {
     method: 'POST',
     body: JSON.stringify(query),
   }).then(r => resolveJsonOrRejectWithError<ISearchResultV2>(r));
+};
 
 export const learningpathCopy = (
   id: number,

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1226,6 +1226,7 @@ const phrases = {
     publish: {
       button: 'Publish all',
       waiting: 'Publishing resourses',
+      info: 'Are you sure you want to publish all resources associated with this node?',
       done: 'Resources published',
       error: 'The following resources were not published:',
     },

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1227,6 +1227,8 @@ const phrases = {
     publish: {
       button: 'Publiser alt',
       waiting: 'Publiserer ressurser',
+      info:
+        'Er du sikker på at du ønsker å publisere alle ressurser som er knyttet til denne noden?',
       done: 'Ressurser er publisert',
       error: 'Følgende ressurser ble ikke publisert:',
     },

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1227,6 +1227,8 @@ const phrases = {
     publish: {
       button: 'Publiser alt',
       waiting: 'Publiserar ressurser',
+      info:
+        'Er du sikker på at du ønskjar å publisere alle ressursane som er knytta til denne noden?',
       done: 'Ressurser er publisert',
       error: 'Følgande ressurser blei ikkje publisert:',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,10 +2175,10 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-concept-api/-/types-concept-api-0.0.10.tgz#43bd9dcfede1c1680e52bdc0f1ffa31246fbca9c"
   integrity sha512-btJNLpUuSaQXH1RYAhF4867Ka8dYLFo1gAbwcXQj3uQdo6BWJfPKMHoRHGXJ9Qww+MuZArlLgWc+YEh2Hd0aJg==
 
-"@ndla/types-draft-api@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@ndla/types-draft-api/-/types-draft-api-0.0.21.tgz#7c8591b2e639171a270d5092ef6158f130705063"
-  integrity sha512-QNxLDdD2g1Xzd9pL4ow0NZeXa6QflqwfSbfIL9742vuXNhAw6rSruH92jCb0MooTu9Fx+r49T/Onzrk8r/DXzA==
+"@ndla/types-draft-api@^0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@ndla/types-draft-api/-/types-draft-api-0.0.23.tgz#36dd0a460af680f085d4458170ff81625403fdd8"
+  integrity sha512-XMdnh59BihPiCDJ4BB/mD6WxgRfKmkWgmTSKuhBialN1YgF674B+pieMfRyn9hAlD0YP7SWWkhxlYd9voPZOpQ==
 
 "@ndla/types-frontpage-api@^0.0.3":
   version "0.0.3"


### PR DESCRIPTION
Kan testes ved å lage en ny rotnode og koble et emne til den. Opprett deretter flere ressurser og koble de til emnet. Sørg for at hvertfall en av nodene er ugyldige. Publiser deretter alle ressursene. Du skal få opp en varsel med noden som har feilet, mens resten skal ha gått gjennom. Sjekk også at ressurs-cachen oppdateres, slik at 'publisert'-statusen vises umiddelbart.