### PR TITLE
Add copy and clone resources functionality for structure beta

### DIFF
--- a/src/containers/StructurePage/folderComponents/menuOptions/CopyResources.tsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/CopyResources.tsx
@@ -250,7 +250,7 @@ const CopyResources = ({
             setShowCloneSearch(false);
           }}>
           <RoundIcon small smallIcon icon={<Copy css={iconCss} />} />
-          {t('taxonomy.copyResources')}
+          {t('taxonomy.copyResources.info')}
         </MenuItemButton>
       ) : (
         <MenuItemDropdown
@@ -271,7 +271,7 @@ const CopyResources = ({
             setShowCloneSearch(true);
           }}>
           <RoundIcon small smallIcon icon={<Copy css={iconCss} />} />
-          {t('taxonomy.copyAndCloneResources')}
+          {t('taxonomy.cloneResources.info')}
         </MenuItemButton>
       ) : (
         <MenuItemDropdown

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -23,6 +23,7 @@ import AddExistingToNode from './sharedMenuOptions/AddExistingToNode';
 import ChangeNodeName from './subjectMenuOptions/ChangeNodeName';
 import EditSubjectpageOption from './subjectMenuOptions/EditSubjectpageOption';
 import PublishChildNodeResources from './topicMenuOptions/PublishChildNodeResources';
+import CopyNodeResources from './topicMenuOptions/CopyNodeResources';
 
 interface Props {
   rootNodeId: string;
@@ -117,7 +118,16 @@ const SettingsMenuDropdownType = ({
           editModeHandler={editModeHandler}
           rootNodeId={rootNodeId}
         />
-        {/* <CopyResources toNode={node} structure={structure} onClose={onClose} /> */}
+        <CopyNodeResources
+          currentNode={node}
+          editModeHandler={editModeHandler}
+          type="copyResources"
+        />
+        <CopyNodeResources
+          currentNode={node}
+          editModeHandler={editModeHandler}
+          type="cloneResources"
+        />
       </>
     );
   } else return null;

--- a/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/CopyNodeResources.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/topicMenuOptions/CopyNodeResources.tsx
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { Copy } from '@ndla/icons/action';
+import { spacing, colors } from '@ndla/core';
+import { Spinner } from '@ndla/editor';
+import { Done } from '@ndla/icons/editor';
+import RoundIcon from '../../../../components/RoundIcon';
+import { NodeType, ResourceWithNodeConnection } from '../../../../modules/nodes/nodeApiTypes';
+import { EditModeHandler } from '../SettingsMenuDropdownType';
+import MenuItemButton from '../sharedMenuOptions/components/MenuItemButton';
+import NodeSearchDropdown from '../sharedMenuOptions/components/NodeSearchDropdown';
+import { fetchNodeResources, postResourceForNode } from '../../../../modules/nodes/nodeApi';
+import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
+import { cloneDraft } from '../../../../modules/draft/draftApi';
+import { cloneResource } from '../../../../modules/taxonomy/resources';
+import { learningpathCopy } from '../../../../modules/learningpath/learningpathApi';
+import { EditMode } from '../../../../interfaces';
+import AlertModal from '../../../../components/AlertModal';
+import ResourceItemLink from '../../resourceComponents/ResourceItemLink';
+import { resourcesWithNodeConnectionQueryKey } from '../../../../modules/nodes/nodeQueries';
+
+type ActionType = Extract<EditMode, 'copyResources' | 'cloneResources'>;
+interface Props {
+  currentNode: NodeType;
+  editModeHandler: EditModeHandler;
+  type: ActionType;
+}
+
+const iconCss = css`
+  width: 8px;
+  height: 8px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin: calc(${spacing.small} / 2);
+`;
+
+const LinkWrapper = styled.div`
+  a {
+    color: ${colors.white};
+    &:hover {
+      color: ${colors.white};
+    }
+  }
+  margin-top: 0.5em;
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: ${spacing.normal};
+`;
+
+const StyledDone = styled(Done)`
+  margin: 0px 4px;
+  color: green;
+`;
+
+const CopyNodeResources = ({
+  editModeHandler: { editMode, toggleEditMode },
+  currentNode,
+  type,
+}: Props) => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
+  const { taxonomyVersion } = useTaxonomyVersion();
+  const qc = useQueryClient();
+  const [totalAmount, setTotalAmount] = useState<number>(0);
+  const [count, setCount] = useState<number>(0);
+  const [failedResources, setFailedResources] = useState<ResourceWithNodeConnection[]>([]);
+  const [showDisplay, setShowDisplay] = useState(false);
+  const [done, setDone] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+
+  useEffect(() => {
+    setShowAlert(failedResources.length !== 0 && done);
+  }, [failedResources, done]);
+
+  const toggleEditModeFunc = () => toggleEditMode(type);
+
+  const prepareForAction = () => {
+    setFailedResources([]);
+    setDone(false);
+    setCount(0);
+    setTotalAmount(0);
+    setShowDisplay(true);
+    toggleEditModeFunc();
+  };
+
+  const cloneOrCopyResources = async (node: NodeType, type: ActionType) => {
+    prepareForAction();
+    const resources = await fetchNodeResources({ id: node.id, taxonomyVersion, language });
+    setTotalAmount(resources.length);
+    const action = type === 'cloneResources' ? clone : copy;
+    await Promise.all(resources.map(async res => await doAction(res, action)));
+    setDone(true);
+    qc.invalidateQueries(
+      resourcesWithNodeConnectionQueryKey({ id: currentNode.id, taxonomyVersion }),
+    );
+  };
+
+  const doAction = async (
+    res: ResourceWithNodeConnection,
+    action: (res: ResourceWithNodeConnection) => Promise<string>,
+  ) => {
+    try {
+      const result = await action(res);
+      setCount(count => count + 1);
+      return result;
+    } catch (e) {
+      setFailedResources(prev => prev.concat(res));
+      return e;
+    }
+  };
+
+  const copy = async ({ primary, id, rank }: ResourceWithNodeConnection): Promise<string> =>
+    await postResourceForNode({
+      taxonomyVersion,
+      body: { primary, rank, resourceId: id, nodeId: currentNode.id },
+    });
+
+  const clone = async (resource: ResourceWithNodeConnection): Promise<string> => {
+    const newLocation = await _clone(resource);
+    return await copy({ ...resource, id: newLocation.replace('/v1/resources/', '') });
+  };
+
+  const _clone = async (resource: ResourceWithNodeConnection): Promise<string> => {
+    const [, resourceType, idString] = resource.contentUri?.split(':')[1] ?? [];
+    const id = Number(idString);
+    if (resourceType === 'article' && id) {
+      const clonedArticle = await cloneDraft(id, undefined, false);
+      const body = { contentUri: `urn:article:${clonedArticle.id}`, name: resource.name };
+      return await cloneResource({ id: resource.id, taxonomyVersion, body });
+    } else if (resourceType === 'learningpath' && id) {
+      const lpBody = { title: resource.name, language };
+      const clonedLp = await learningpathCopy(id, lpBody);
+      const body = { contentUri: `urn:learningpath:${clonedLp.id}`, name: resource.name };
+      return await cloneResource({ id: resource.id, taxonomyVersion, body });
+    } else {
+      return await cloneResource({
+        id: resource.id,
+        taxonomyVersion,
+        body: { name: resource.name },
+      });
+    }
+  };
+
+  if (editMode === type) {
+    return (
+      <Wrapper>
+        <RoundIcon open small smallIcon icon={<Copy />} />
+        <NodeSearchDropdown
+          placeholder={t('taxonomy.existingTopic')}
+          onChange={node => cloneOrCopyResources(node, type)}
+          searchNodeType={'TOPIC'}
+          filter={node => {
+            return (
+              !!node.path &&
+              !node.paths?.some(p => {
+                const split = p.replace('/', '').split('/');
+                return split[split.length - 2] === currentNode.id.replace('urn:', '');
+              })
+            );
+          }}
+        />
+      </Wrapper>
+    );
+  }
+
+  const prefixText = t(`taxonomy.${type}.${done ? 'done' : 'waiting'}`);
+
+  return (
+    <>
+      <MenuItemButton stripped onClick={toggleEditModeFunc}>
+        <RoundIcon small icon={<Copy css={iconCss} />} />
+        {t(`taxonomy.${type}.info`)}
+      </MenuItemButton>
+      {showDisplay && (
+        <StyledDiv>
+          {done ? <StyledDone /> : <Spinner size="normal" margin="0px 4px" />}
+          {`${prefixText} (${count}/${totalAmount})`}
+        </StyledDiv>
+      )}
+      <AlertModal
+        show={showAlert}
+        onCancel={() => setShowAlert(false)}
+        text={t(`taxonomy.${type}.error`)}
+        component={failedResources.map(res => (
+          <LinkWrapper>
+            <ResourceItemLink
+              contentType={
+                res.contentUri?.split(':')[1] === 'article' ? 'article' : 'learning-resource'
+              }
+              contentUri={res.contentUri}
+              name={res.name}
+            />
+          </LinkWrapper>
+        ))}
+      />
+    </>
+  );
+};
+
+export default CopyNodeResources;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,6 +39,8 @@ export type EditMode =
   | 'deleteSubject'
   | 'requestPublish'
   | 'deleteNode'
+  | 'copyResources'
+  | 'cloneResources'
   | '';
 
 export interface SearchResultBase<T> {

--- a/src/modules/nodes/nodeApi.ts
+++ b/src/modules/nodes/nodeApi.ts
@@ -234,11 +234,11 @@ interface NodeResourcePostParams extends WithTaxonomyVersion {
 export const postResourceForNode = ({
   body,
   taxonomyVersion,
-}: NodeResourcePostParams): Promise<void> =>
+}: NodeResourcePostParams): Promise<string> =>
   postAndResolve({
     url: resUrl,
     body: JSON.stringify(body),
-    alternateResolve: resolveVoidOrRejectWithError,
+    alternateResolve: resolveLocation,
     taxonomyVersion,
   });
 

--- a/src/modules/nodes/nodeMutations.ts
+++ b/src/modules/nodes/nodeMutations.ts
@@ -218,9 +218,9 @@ interface UsePostResourceForNodeMutation extends WithTaxonomyVersion {
 }
 
 export const usePostResourceForNodeMutation = (
-  options?: UseMutationOptions<void, unknown, UsePostResourceForNodeMutation>,
+  options?: UseMutationOptions<string, unknown, UsePostResourceForNodeMutation>,
 ) => {
-  return useMutation<void, unknown, UsePostResourceForNodeMutation>(
+  return useMutation<string, unknown, UsePostResourceForNodeMutation>(
     ({ body, taxonomyVersion }) => postResourceForNode({ body, taxonomyVersion }),
     options,
   );

--- a/src/modules/taxonomy/resources/index.ts
+++ b/src/modules/taxonomy/resources/index.ts
@@ -246,3 +246,25 @@ export const setResourceTranslation = ({
     alternateResolve: resolveVoidOrRejectWithError,
   });
 };
+
+interface CloneResourceParams extends WithTaxonomyVersion {
+  id: string;
+  body: {
+    contentUri?: string;
+    name: string;
+    id?: string;
+  };
+}
+
+export const cloneResource = ({
+  id,
+  body,
+  taxonomyVersion,
+}: CloneResourceParams): Promise<string> => {
+  return postAndResolve({
+    url: `${resourcesUrl}/${id}/clone`,
+    taxonomyVersion,
+    body: JSON.stringify(body),
+    alternateResolve: resolveLocation,
+  });
+};

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1222,8 +1222,18 @@ const phrases = {
     confirmSetPrimary: 'Do you want to make this the main location?',
     removeLink: 'Remove link',
     jumpToResources: 'Jump to resources',
-    copyResources: 'Reuse resources from topic',
-    copyAndCloneResources: 'Copy and clone resources from topic',
+    copyResources: {
+      error: 'Something went wrong during copying',
+      info: 'Reuse resources from topic',
+      done: 'Resources copied',
+      waiting: 'Copying resources',
+    },
+    cloneResources: {
+      error: 'Something went wrong during cloning',
+      info: 'Copy and clone resources from topic',
+      done: 'Resources cloned',
+      waiting: 'Cloning resources',
+    },
     favorites: 'Show favorites',
     publish: {
       button: 'Publish all resources',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1223,8 +1223,18 @@ const phrases = {
     addTopicDescription: 'Endre emnebeskrivelse',
     confirmSetPrimary: 'Vil du gjøre dette til hovedplassering?',
     jumpToResources: 'Hopp til ressurser',
-    copyResources: 'Gjenbruk ressurser fra emne',
-    copyAndCloneResources: 'Kopier og klon ressurser fra emne',
+    copyResources: {
+      info: 'Gjenbruk ressurser fra emne',
+      done: 'Ressurser ferdigkopiert!',
+      waiting: 'Kopierer ressurser',
+      error: 'Noe gikk galt under kopiering',
+    },
+    cloneResources: {
+      info: 'Kopier og klon ressurser fra emne',
+      done: 'Ressurser ferdigklonet!',
+      waiting: 'Kloner ressurser',
+      error: 'Noe gikk galt under kloning',
+    },
     favorites: 'Vis favoritter',
     publish: {
       button: 'Publiser alle ressurser',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1223,8 +1223,18 @@ const phrases = {
     addTopicDescription: 'Endre emnebeskrivelse',
     confirmSetPrimary: 'Vil du gjere dette til hovedplassering?',
     jumpToResources: 'Hopp til ressurser',
-    copyResources: 'Gjenbruk ressurser fra emne',
-    copyAndCloneResources: 'Kopier og klon ressurser fra emne',
+    copyResources: {
+      error: 'Noko gjekk feil med kopiering',
+      info: 'Gjenbruk ressurser fra emne',
+      done: 'Ressurser ferdigkopiert!',
+      waiting: 'Kopierer ressurser',
+    },
+    cloneResources: {
+      error: 'Noko gjekk feil med kloning',
+      info: 'Kopier og klon ressurser fra emne',
+      done: 'Ressurser ferdigklonet!',
+      waiting: 'Kloner ressurser',
+    },
     favorites: 'Vis favorittar',
     publish: {
       button: 'Publiser alle ressursar',


### PR DESCRIPTION
Med denne PR'en merget inn er struktur-beta feature-complete!!
Jeg er litt usikker på hvordan man skal få testet feilhåndtering her; Har inntil videre ikke kommet på en god måte å fremprovosere feil på, annet enn å endre på URL'en man treffer. 

Happy-pathen kan testes ved å få oversikt over hvilke ressurser som eksisterer på et emne. Etter at man har navigert seg til et annet emne kan man deretter sjekke at `kopier`-knappen legger ressursene under den nyvalgte noden. Det samme kan også gjøres for kloning, men da er det også greit å sjekke at det er har blitt opprettet nye versjoner av selve ressursene også.