### PR TITLE
Remove unneeded BEM classes for audio content and audio meta

### DIFF
--- a/src/containers/AudioUploader/components/AudioContent.tsx
+++ b/src/containers/AudioUploader/components/AudioContent.tsx
@@ -10,7 +10,6 @@ import { FormEvent } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { connect, FormikContextType } from 'formik';
-import BEMHelper from 'react-bem-helper';
 import { UploadDropZone, FieldHeader } from '@ndla/forms';
 import styled from '@emotion/styled';
 import Tooltip from '@ndla/tooltip';
@@ -23,9 +22,7 @@ import { TitleField } from '../../FormikForm';
 import AudioCopyInfo from './AudioCopyInfo';
 import AudioFileInfoModal from './AudioFileInfoModal';
 
-interface BaseProps {
-  classes: BEMHelper<BEMHelper.ReturnObject>;
-}
+interface BaseProps {}
 
 interface Props extends BaseProps {
   formik: FormikContextType<AudioFormikType>;

--- a/src/containers/AudioUploader/components/AudioForm.tsx
+++ b/src/containers/AudioUploader/components/AudioForm.tsx
@@ -218,7 +218,7 @@ const AudioForm = ({
                   title={t('form.contentSection')}
                   hasError={hasError(['title', 'audioFile'])}
                   startOpen>
-                  <AudioContent classes={formClasses} />
+                  <AudioContent />
                 </AccordionSection>
                 <AccordionSection
                   id="podcast-upload-podcastmanus"
@@ -238,7 +238,7 @@ const AudioForm = ({
                     'processors',
                     'license',
                   ])}>
-                  <AudioMetaData classes={formClasses} />
+                  <AudioMetaData />
                 </AccordionSection>
               </Accordions>
             )}

--- a/src/containers/AudioUploader/components/AudioMetaData.tsx
+++ b/src/containers/AudioUploader/components/AudioMetaData.tsx
@@ -6,10 +6,7 @@
  *
  */
 
-import PropTypes from 'prop-types';
-
 import { useTranslation } from 'react-i18next';
-import BEMHelper from 'react-bem-helper';
 import { FieldProps, useFormikContext } from 'formik';
 import { fetchSearchTags } from '../../../modules/audio/audioApi';
 import { LicenseField, ContributorsField } from '../../FormikForm';
@@ -19,11 +16,7 @@ import { AudioFormikType } from './AudioForm';
 
 const contributorTypes = ['creators', 'rightsholders', 'processors'];
 
-interface Props {
-  classes: BEMHelper<BEMHelper.ReturnObject>;
-}
-
-const AudioMetaData = (props: Props) => {
+const AudioMetaData = () => {
   const {
     values: { language, tags },
   } = useFormikContext<AudioFormikType>();
@@ -50,11 +43,6 @@ const AudioMetaData = (props: Props) => {
       <ContributorsField contributorTypes={contributorTypes} />
     </>
   );
-};
-
-AudioMetaData.propTypes = {
-  classes: PropTypes.func.isRequired,
-  values: PropTypes.object,
 };
 
 export default AudioMetaData;

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -256,7 +256,7 @@ const PodcastForm = ({
                   className="u-4/6@desktop u-push-1/6@desktop"
                   hasError={['title', 'audioFile'].some(field => field in errors)}
                   startOpen>
-                  <AudioContent classes={formClasses} />
+                  <AudioContent />
                 </AccordionSection>
                 <AccordionSection
                   id="podcast-upload-podcastmanus"
@@ -291,7 +291,7 @@ const PodcastForm = ({
                   hasError={['tags', 'creators', 'rightsholders', 'processors', 'license'].some(
                     field => field in errors,
                   )}>
-                  <AudioMetaData classes={formClasses} />
+                  <AudioMetaData />
                 </AccordionSection>
               </Accordions>
             )}


### PR DESCRIPTION
Dette gjelder AudioMeta og AudioContent i lyd- og podkast-skjemaer. Klassene passeres inn, men brukes ikke til noe.