### PR TITLE
Always set focus after mathml when editing

### DIFF
--- a/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathEditor.tsx
@@ -99,40 +99,41 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
       data: { innerHTML: mathML },
     };
     const path = ReactEditor.findPath(editor, element);
-    const leafPath = Path.next(path);
 
-    if (isFirstEdit) {
-      Transforms.setNodes(editor, properties, {
-        at: path,
-        voids: true,
-        match: node => node === element,
-      });
+    const nextPath = Path.next(path);
 
-      const mathAsString = new DOMParser().parseFromString(mathML, 'text/xml').firstChild
-        ?.textContent;
-
-      Transforms.insertText(editor, mathAsString || '', {
-        at: path,
-        voids: true,
-      });
-
-      mergeLastUndos(editor);
-    } else {
-      Transforms.setNodes(editor, properties, {
-        at: path,
-        voids: true,
-        match: node => node === element,
-      });
-    }
     setIsFirstEdit(false);
     setEditMode(false);
     setShowMenu(false);
 
     setTimeout(() => {
       ReactEditor.focus(editor);
+      if (isFirstEdit) {
+        Transforms.setNodes(editor, properties, {
+          at: path,
+          voids: true,
+          match: node => node === element,
+        });
+
+        const mathAsString = new DOMParser().parseFromString(mathML, 'text/xml').firstChild
+          ?.textContent;
+
+        Transforms.insertText(editor, mathAsString || '', {
+          at: path,
+          voids: true,
+        });
+
+        mergeLastUndos(editor);
+      } else {
+        Transforms.setNodes(editor, properties, {
+          at: path,
+          voids: true,
+          match: node => node === element,
+        });
+      }
       Transforms.select(editor, {
-        anchor: { path: leafPath, offset: 0 },
-        focus: { path: leafPath, offset: 0 },
+        anchor: { path: nextPath, offset: 0 },
+        focus: { path: nextPath, offset: 0 },
       });
     }, 0);
   };
@@ -150,6 +151,11 @@ const MathEditor = ({ element, children, attributes, editor }: Props & RenderEle
   };
 
   const { top, left } = getMenuPosition();
+
+  useEffect(() => {
+    ReactEditor.blur(editor);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <span


### PR DESCRIPTION
Et par feilrettinger på mathml i slate. I alle disse tilfellene skal markør plasseres etter matte:
- Innsetting av matte ved markering av tekst
- Innsetting av matte ved umarkert tekst og trykk på ctrl+m 
- Lagring av eksisterende matte

Forklaring av kodeendringene: Vet ikke. Fokus er weird. Virker likevel som om dette er litt mindre forutsigbart enn andre ting i Slate da mathml også re-rendrer seg asynkront.