### PR TITLE
Prevent pipes in mathml for disappearing

### DIFF
--- a/src/components/SlateEditor/plugins/mathml/MathML.tsx
+++ b/src/components/SlateEditor/plugins/mathml/MathML.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import styled from '@emotion/styled';
 import { useState, useEffect, useRef } from 'react';
 import { Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
@@ -19,6 +20,12 @@ interface Props {
   editor: Editor;
   element: MathmlElement;
 }
+
+const StyledSpan = styled.span`
+  mjx-stretchy-v > mjx-ext > mjx-c {
+    transform: scaleY(200) translateY(0.075em);
+  }
+`;
 
 const clearMathjax = (editor: Editor, element: MathmlElement) => {
   const { MathJax } = window;
@@ -74,7 +81,7 @@ const MathML = ({ model, element, editor }: Props) => {
   }
 
   return (
-    <span data-cy="math">
+    <StyledSpan data-cy="math">
       {/* @ts-ignore math does not exist in JSX, but this hack works by setting innerHTML manually. */}
       <math
         xlmns={model.xlmns}
@@ -82,7 +89,7 @@ const MathML = ({ model, element, editor }: Props) => {
           __html: model.innerHTML,
         }}
       />
-    </span>
+    </StyledSpan>
   );
 };
 


### PR DESCRIPTION
Dette er en feil som er fikset i ndla frontend og forhåndsvisning av artikkel i ed. Absoluttverdi-wrapping i mathml forsvinner i en del tilfeller.

Legger på samme styling i matte i slate.

Hvordan teste:
- Åpne /subject-matter/learning-resource/31044/edit/nb (skal være mathml der nå)
- Endre skalering på nettsiden større/mindre og se at absoluttverdi-wrapping forblir der hele tiden.