### PR TITLE
Move c-inline__code to Styled Component

### DIFF
--- a/src/components/SlateEditor/plugins/mark/index.tsx
+++ b/src/components/SlateEditor/plugins/mark/index.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import styled from '@emotion/styled';
 import { ReactElement } from 'react';
 import { Descendant, Editor, Text, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
@@ -35,6 +36,13 @@ const marks: { [key: string]: string } = {
   sup: 'sup',
   sub: 'sub',
 };
+
+const StyledCode = styled.code`
+  display: inline;
+  padding: 0;
+  margin: 0;
+  background-color: #eee;
+`;
 
 export const markSerializer: SlateSerializer = {
   deserialize(el: HTMLElement, children: Descendant[]) {
@@ -100,11 +108,7 @@ export const markPlugin = (editor: Editor) => {
       ret = <u {...attributes}>{ret || children}</u>;
     }
     if (leaf.code) {
-      ret = (
-        <code className="c-inline__code" {...attributes}>
-          {ret || children}
-        </code>
-      );
+      ret = <StyledCode {...attributes}>{ret || children}</StyledCode>;
     }
     if (ret) {
       return ret;

--- a/src/style/code.css
+++ b/src/style/code.css
@@ -1,6 +1,0 @@
-.c-inline__code {
-  display: inline;
-  padding: 0;
-  margin: 0;
-  background-color: #eee;
-}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -14,7 +14,6 @@
 @import './alert.css';
 @import './article-form.css';
 @import './content-block.css';
-@import './code.css';
 @import './dropdown-menu.css';
 @import './fields.css';
 @import './form.css';


### PR DESCRIPTION
Med mindre Slate finner på noe lurt ser jeg ingen grunn til at dette ikke skal være likt. 