### PR TITLE
Convert SlateRightAside ED css to emotion. 

### DIFF
--- a/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
+++ b/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
@@ -6,23 +6,17 @@
  *
  */
 
-import PropTypes from 'prop-types';
+import { ReactNode } from 'react';
+import { RenderElementProps } from 'slate-react';
 import Button from '@ndla/button';
 import { useTranslation } from 'react-i18next';
-import BEMHelper from 'react-bem-helper';
+import styled from '@emotion/styled';
 import { colors } from '@ndla/core';
 import { ChevronLeft } from '@ndla/icons/common';
-import { css } from '@emotion/core';
 import darken from 'polished/lib/color/darken';
 import DeleteButton from '../../../DeleteButton';
-import { AttributesShape } from '../../../../shapes';
 
-const classes = new BEMHelper({
-  name: 'editor',
-  prefix: 'c-',
-});
-
-const moveContentButtonStyle = css`
+const MoveAsideButton = styled(Button)`
   position: absolute;
   top: 0.1rem;
   right: 1.2rem;
@@ -33,39 +27,50 @@ const moveContentButtonStyle = css`
   }
 `;
 
-const SlateRightAside = props => {
+const StyledAsideType = styled.div`
+  background-color: #444;
+  color: white;
+  position: absolute;
+  width: 100%;
+  padding: 3.2px;
+`;
+
+const StyledAsideContent = styled.div`
+  padding-top: 60px;
+`;
+
+interface Props {
+  onRemoveClick: () => void;
+  children: ReactNode;
+  onMoveContent: () => void;
+  attributes: RenderElementProps['attributes'];
+}
+
+const SlateRightAside = ({ children, onRemoveClick, onMoveContent, attributes }: Props) => {
   const { t } = useTranslation();
-  const { children, onRemoveClick, onMoveContent, attributes } = props;
 
   return (
-    <aside {...classes('right-aside', '', 'c-aside expanded')} {...attributes}>
-      <div {...classes('aside-type')} contentEditable={false}>
+    <aside className="c-aside" {...attributes}>
+      <StyledAsideType contentEditable={false}>
         {t('learningResourceForm.fields.rightAside.title')}
-      </div>
-      <div className="c-aside__content">{children}</div>
+      </StyledAsideType>
+      <StyledAsideContent className="c-aside__content">{children}</StyledAsideContent>
       <DeleteButton
         title={t('learningResourceForm.fields.rightAside.delete')}
         stripped
         onMouseDown={onRemoveClick}
         tabIndex="-1"
       />
-      <Button
+      <MoveAsideButton
         contentEditable={false}
-        css={moveContentButtonStyle}
         title={t('learningResourceForm.fields.rightAside.moveContent')}
         stripped
         onMouseDown={onMoveContent}>
         <ChevronLeft />
         ??
-      </Button>
+      </MoveAsideButton>
     </aside>
   );
-};
-
-SlateRightAside.propTypes = {
-  attributes: AttributesShape,
-  onRemoveClick: PropTypes.func.isRequired,
-  onMoveContent: PropTypes.func.isRequired,
 };
 
 export default SlateRightAside;

--- a/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
+++ b/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
@@ -67,7 +67,6 @@ const SlateRightAside = ({ children, onRemoveClick, onMoveContent, attributes }:
         stripped
         onMouseDown={onMoveContent}>
         <ChevronLeft />
-        ??
       </MoveAsideButton>
     </aside>
   );


### PR DESCRIPTION
Keep classNames to get css from ndla-ui.
Denne er verken pen eller vakker, men sikkert greit å støtte den uansett. 
Kan sammenligne utseendet på https://ed.test.ndla.no/subject-matter/learning-resource/31473/edit/nb med PR-instans for å teste.