### PR TITLE
Skjuler revisjoner så lenge det ikkje er eksplisitt skrudd på.

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -232,7 +232,7 @@ const HeaderStatusInformation = ({
         {articleConnections}
         {conceptConnecions}
         {learningpathConnections}
-        {revisionDateExpiration}
+        {config.revisiondateEnabled === 'true' && revisionDateExpiration}
         {published &&
           (taxonomyPaths && taxonomyPaths?.length > 0 ? publishedIconLink : publishedIcon)}
         {multipleTaxonomyIcon}

--- a/src/config.ts
+++ b/src/config.ts
@@ -151,6 +151,7 @@ export type ConfigType = {
   googleSearchEngineId: string | undefined;
   isNdlaProdEnvironment: boolean;
   versioningEnabled: string;
+  revisiondateEnabled: string;
   ndlaEnvironment: string;
   learningpathFrontendDomain: string;
   googleSearchApiKey: string | undefined;
@@ -182,6 +183,7 @@ const config: ConfigType = {
   logglyApiKey: getEnvironmentVariabel('LOGGLY_API_KEY'),
   isNdlaProdEnvironment: ndlaEnvironment === 'prod',
   versioningEnabled: getEnvironmentVariabel('ENABLE_VERSIONING', 'true'),
+  revisiondateEnabled: getEnvironmentVariabel('ENABLE_REVISIONDATE', 'false'),
   ndlaApiUrl: getEnvironmentVariabel('NDLA_API_URL', getNdlaApiUrl(ndlaEnvironment)),
   ndlaBaseUrl: ndlaBaseUrl(),
   ndlaFrontendDomain: getEnvironmentVariabel('FRONTEND_DOMAIN', ndlaFrontendDomain()),

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -110,13 +110,15 @@ const LearningResourcePanels = ({
           <RelatedContentFieldGroup />
         </AccordionSection>
       )}
-      <AccordionSection
-        id={'learning-resource-revisions'}
-        title={t('form.name.revisions')}
-        className={'u-6/6'}
-        hasError={!!errors.revisionMeta}>
-        <RevisionNotes />
-      </AccordionSection>
+      {config.revisiondateEnabled === 'true' && (
+        <AccordionSection
+          id={'learning-resource-revisions'}
+          title={t('form.name.revisions')}
+          className={'u-6/6'}
+          hasError={!!errors.revisionMeta}>
+          <RevisionNotes />
+        </AccordionSection>
+      )}
       {article && (
         <AccordionSection
           id={'learning-resource-workflow'}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -98,13 +98,15 @@ const TopicArticleAccordionPanels = ({
           <RelatedContentFieldGroup />
         </AccordionSection>
       )}
-      <AccordionSection
-        id={'topic-article-revisions'}
-        title={t('form.name.revisions')}
-        className={'u-6/6'}
-        hasError={!!errors.revisionMeta}>
-        <RevisionNotes />
-      </AccordionSection>
+      {config.revisiondateEnabled === 'true' && (
+        <AccordionSection
+          id={'topic-article-revisions'}
+          title={t('form.name.revisions')}
+          className={'u-6/6'}
+          hasError={!!errors.revisionMeta}>
+          <RevisionNotes />
+        </AccordionSection>
+      )}
       {article && (
         <AccordionSection
           id={'topic-article-workflow'}

--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -15,6 +15,7 @@ import { getTagName } from '../../../../util/formHelper';
 import ArticleStatuses from '../../../../util/constants/index';
 import { SearchParams } from './SearchForm';
 import { DRAFT_WRITE_SCOPE } from '../../../../constants';
+import config from '../../../../config';
 import { SubjectType } from '../../../../modules/taxonomy/taxonomyApiInterfaces';
 import { useAuth0Editors } from '../../../../modules/auth0/auth0Queries';
 import { useAllResourceTypes } from '../../../../modules/taxonomy/resourcetypes/resourceTypesQueries';
@@ -155,19 +156,24 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
       width: 25,
       options: getResourceLanguages(t),
     },
-    {
-      name: search['revision-date-from'],
-      type: 'revision-date-from',
-      width: 25,
-      options: [],
-    },
-    {
-      name: search['revision-date-to'],
-      type: 'revision-date-to',
-      width: 25,
-      options: [],
-    },
   ];
+
+  if (config.revisiondateEnabled === 'true') {
+    selectors.push(
+      {
+        name: search['revision-date-from'],
+        type: 'revision-date-from',
+        width: 25,
+        options: [],
+      },
+      {
+        name: search['revision-date-to'],
+        type: 'revision-date-to',
+        width: 25,
+        options: [],
+      },
+    );
+  }
 
   return (
     <GenericSearchForm

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -113,7 +113,7 @@ const SettingsMenuDropdownType = ({
             <ToNodeDiff node={node} />
           </>
         )}
-        <CopyRevisionDate node={node} editModeHandler={editModeHandler} />
+        {config.revisiondateEnabled === 'true' && (<CopyRevisionDate node={node} editModeHandler={editModeHandler} />)}
         <DeleteNode
           node={node}
           nodeChildren={nodeChildren}

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -113,7 +113,9 @@ const SettingsMenuDropdownType = ({
             <ToNodeDiff node={node} />
           </>
         )}
-        {config.revisiondateEnabled === 'true' && (<CopyRevisionDate node={node} editModeHandler={editModeHandler} />)}
+        {config.revisiondateEnabled === 'true' && (
+          <CopyRevisionDate node={node} editModeHandler={editModeHandler} />
+        )}
         <DeleteNode
           node={node}
           nodeChildren={nodeChildren}


### PR DESCRIPTION
NDLA trenger litt meir tid for å lande revisjoner. Legger til miljøvariabel for å skru på enn så lenge.

I denne pr-installasjonen er verdien ikkje satt, så derfor er det nok å sjekke at Revisjoner er borte fra artikkel, at klokke-ikon ikkje vises i artikkel/søkeresultat, og at valg for å sette revisjonsdato på barn i struktur er borte.