### PR TITLE
Fikset avkuttet forklaringsmodal

### DIFF
--- a/src/containers/PreviewDraftPage/PreviewDraftPage.tsx
+++ b/src/containers/PreviewDraftPage/PreviewDraftPage.tsx
@@ -6,21 +6,20 @@
  *
  */
 
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { Hero, OneColumn } from '@ndla/ui';
-import { css } from '@emotion/core';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import * as draftApi from '../../modules/draft/draftApi';
-import * as articleApi from '../../modules/article/articleApi';
 import PreviewDraft from '../../components/PreviewDraft/PreviewDraft';
-import { queryResources } from '../../modules/taxonomy';
-import { getContentTypeFromResourceTypes } from '../../util/resourceHelpers';
-import LanguageSelector from './LanguageSelector';
+import * as articleApi from '../../modules/article/articleApi';
 import { ArticleConverterApiType } from '../../modules/article/articleApiInterfaces';
+import * as draftApi from '../../modules/draft/draftApi';
+import { queryResources } from '../../modules/taxonomy';
 import { Resource } from '../../modules/taxonomy/taxonomyApiInterfaces';
+import { getContentTypeFromResourceTypes } from '../../util/resourceHelpers';
 import { useTaxonomyVersion } from '../StructureVersion/TaxonomyVersionProvider';
+import LanguageSelector from './LanguageSelector';
 
 const PreviewDraftPage = () => {
   const params = useParams<'draftId' | 'language'>();
@@ -53,7 +52,7 @@ const PreviewDraftPage = () => {
   if (!draft) {
     return null;
   }
-  
+
   const hasResourceTypes = resources.length > 0;
   const contentTypeFromResourceType = hasResourceTypes
     ? getContentTypeFromResourceTypes(resources[0].resourceTypes)
@@ -64,23 +63,13 @@ const PreviewDraftPage = () => {
 
   return (
     <>
-      <div
-        css={css`
-          overflow: visible;
-        `}>
-        <Hero contentType={contentType}>
-          <LanguageSelector supportedLanguages={draft.supportedLanguages} />
-        </Hero>
-        <HelmetWithTracker title={`${draft.title} ${t('htmlTitles.titleTemplate')}`} />
-        <OneColumn>
-          <PreviewDraft
-            article={draft}
-            contentType={contentType}
-            language={language}
-            label={label}
-          />
-        </OneColumn>
-      </div>
+      <Hero contentType={contentType}>
+        <LanguageSelector supportedLanguages={draft.supportedLanguages} />
+      </Hero>
+      <HelmetWithTracker title={`${draft.title} ${t('htmlTitles.titleTemplate')}`} />
+      <OneColumn>
+        <PreviewDraft article={draft} contentType={contentType} language={language} label={label} />
+      </OneColumn>
     </>
   );
 };

--- a/src/containers/PreviewDraftPage/PreviewDraftPage.tsx
+++ b/src/containers/PreviewDraftPage/PreviewDraftPage.tsx
@@ -53,7 +53,7 @@ const PreviewDraftPage = () => {
   if (!draft) {
     return null;
   }
-
+  
   const hasResourceTypes = resources.length > 0;
   const contentTypeFromResourceType = hasResourceTypes
     ? getContentTypeFromResourceTypes(resources[0].resourceTypes)
@@ -66,7 +66,7 @@ const PreviewDraftPage = () => {
     <>
       <div
         css={css`
-          overflow: auto;
+          overflow: visible;
         `}>
         <Hero contentType={contentType}>
           <LanguageSelector supportedLanguages={draft.supportedLanguages} />


### PR DESCRIPTION
Var et enkelt overflow problem.

*For å gjenskape:* 
I innhold, klikk på ordet som har forklaring

*Her fungerer det ikke:*
https://ed.test.ndla.no/preview/31480/nb

*Her fungerer det:*
https://editorial-frontend-pr-1514.ndla.sh/preview/31480/nb

Closes NDLANO/Issues#3090