### PR TITLE
3145 hide clone revisions

### DIFF
--- a/src/containers/FormikForm/AddRevisionDateField.tsx
+++ b/src/containers/FormikForm/AddRevisionDateField.tsx
@@ -85,7 +85,9 @@ const AddRevisionDateField = ({ formikField, showError }: Props) => {
       ...formikField.value,
       {
         note: '',
-        revisionDate: formatDateForBackend(new Date()),
+        revisionDate: formatDateForBackend(
+          new Date(new Date().setFullYear(new Date().getFullYear() + 5)),
+        ),
         status: 'needs-revision',
         new: true,
       },

--- a/src/containers/FormikForm/AddRevisionDateField.tsx
+++ b/src/containers/FormikForm/AddRevisionDateField.tsx
@@ -7,6 +7,7 @@
  */
 
 import { FormEvent } from 'react';
+import addYears from 'date-fns/addYears';
 import Button from '@ndla/button';
 import { Input, FieldRemoveButton } from '@ndla/forms';
 import { useTranslation } from 'react-i18next';
@@ -85,9 +86,7 @@ const AddRevisionDateField = ({ formikField, showError }: Props) => {
       ...formikField.value,
       {
         note: '',
-        revisionDate: formatDateForBackend(
-          new Date(new Date().setFullYear(new Date().getFullYear() + 5)),
-        ),
+        revisionDate: formatDateForBackend(addYears(new Date(), 5)),
         status: 'needs-revision',
         new: true,
       },

--- a/src/containers/NodeDiff/DiffOptions.tsx
+++ b/src/containers/NodeDiff/DiffOptions.tsx
@@ -146,7 +146,7 @@ const DiffOptions = ({ originalHash, otherHash }: Props) => {
           />
         </StyledDiffOption>
         <StyledDiffOption>
-          <strong>{t('diff.options.originalHashLabel')}</strong>
+          <strong>{t('diff.options.otherHashLabel')}</strong>
           <OptGroupVersionSelector
             versions={taxonomyVersions.data ?? []}
             currentVersion={otherVersion}

--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -126,7 +126,7 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
     {
       name: getTagName(search.subjects, subjects),
       type: 'subjects',
-      width: 50,
+      width: config.revisiondateEnabled === 'true' ? 50 : 25,
       options: subjects.sort(sortByProperty('name')),
     },
     {
@@ -147,7 +147,7 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
     {
       name: getTagName(search.users, users),
       type: 'users',
-      width: 50,
+      width: 25,
       options: users!.sort(sortByProperty('name')),
     },
     {

--- a/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePageBeta/folderComponents/SettingsMenuDropdownType.tsx
@@ -113,9 +113,7 @@ const SettingsMenuDropdownType = ({
             <ToNodeDiff node={node} />
           </>
         )}
-        {config.revisiondateEnabled === 'true' && (
-          <CopyRevisionDate node={node} editModeHandler={editModeHandler} />
-        )}
+        {false && <CopyRevisionDate node={node} editModeHandler={editModeHandler} />}
         <DeleteNode
           node={node}
           nodeChildren={nodeChildren}

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1136,7 +1136,7 @@ const phrases = {
       add: 'New revision',
       remove: 'Remove revision',
       description:
-        'Revisions requires a description and an expiration date for the article. The switch decides whether a revision is performed or not. Saved revisions can not be deleted, just updated.',
+        'Revisions requires a description and an expiration date for the article. The switch marks whether a revision is performed or not. Remember that a revised article must be republished.',
       datePickerTooltip: 'The date the article expires if the revision is not marked as revised.',
       switchTooltip: 'Whether the article is revised or not.',
       inputPlaceholder: 'Description of the revision',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1137,7 +1137,7 @@ const phrases = {
       add: 'Ny revisjon',
       remove: 'Fjern revisjon',
       description:
-        'Revisjoner krever en beskrivelse og en dato artikkelen utløper på. Bryteren bestemmer hvorvidt en revisjon er utført eller ikke. Lagrede revisjoner kan ikke slettes, bare oppdateres.',
+        'Revisjoner krever en beskrivelse og en dato artikkelen utløper på. Bryteren markerer hvorvidt en revisjon er utført eller ikke. Husk at en revidert artikkel må republiseres.',
       datePickerTooltip:
         'Dato artikkelen utløper dersom revisjonen ikke blir markert som revidert.',
       switchTooltip: 'Hvorvidt artikkelen er revidert eller ikke.',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1137,7 +1137,7 @@ const phrases = {
       add: 'Ny revisjon',
       remove: 'Fjern revisjon',
       description:
-        'Revisjonar krev ei skildring og ein dato artikkelen går ut på. Bryteren bestemmer i kva grad ein revisjon er utført eller ikkje. Lagra revisjonar kan ikkje slettast, berre oppdaterast.',
+        'Revisjonar krev ei skildring og ein dato artikkelen går ut på. Bryteren markerar i kva grad ein revisjon er utført eller ikkje. Hugs at ein revidert artikkel må republiserast.',
       datePickerTooltip:
         'Dato artikkelen går ut dersom revisjonen ikkje blir markert som revidert.',
       switchTooltip: 'I kva grad artikkelen er revidert eller ikkje.',


### PR DESCRIPTION
Fixes NDLANO/Issues#3145

Menyvalg for å kopiere revisjonsdato skjules. Funksjonaliteten blir liggende i apiet, så sletter ikkje komponenten i tilfelle den skal inn igjen.
Endrer størrelse på et par søkefelt for å få litt bedre flyt for dersom revisjonsdato er skrudd av. Dette vil fjernes etter kvart.
Fikser en feil label i diff-visning av nodetrær.