### PR TITLE
Fix article width bug

### DIFF
--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -113,6 +113,7 @@ export const StyledCross = styled(Cross)<{ severity?: string }>`
 const ChildWrapper = styled.div`
   display: flex;
   height: 100%;
+  width: 100%;
 `;
 
 interface State {

--- a/src/containers/Messages/__tests__/__snapshots__/Messages-test.tsx.snap
+++ b/src/containers/Messages/__tests__/__snapshots__/Messages-test.tsx.snap
@@ -138,6 +138,7 @@ exports[`Messages A message is removed if the modal is closed 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
 }
 
 .emotion-11 {
@@ -435,6 +436,7 @@ exports[`Messages A single message renders correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
 }
 
 .emotion-11 {
@@ -712,6 +714,7 @@ exports[`Messages Several messages renders correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
 }
 
 .emotion-11 {
@@ -1066,6 +1069,7 @@ exports[`Messages auth0 messages provides a cancel button 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
 }
 
 .emotion-15 {

--- a/src/containers/StructurePage/__tests__/__snapshots__/AddResourceModal-test.tsx.snap
+++ b/src/containers/StructurePage/__tests__/__snapshots__/AddResourceModal-test.tsx.snap
@@ -516,6 +516,7 @@ exports[`Can paste a valid url and add it to topic 1`] = `
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
 }
 
 .emotion-33 {


### PR DESCRIPTION
Super kjapp fix av bredde-problem på sammenlikning av språkversjoner. Er ikke veldig kjent med hvor komponenten brukes utover her, så hadde vært fint om noen kunne peke meg i riktig retning dersom dette brekker design på andre steder.

**Eksempel:**
> Klikk på sammenlign språkversjoner

**Før:** https://ed.test.ndla.no/subject-matter/learning-resource/31469/edit/nb

**Etter:** https://editorial-frontend-pr-1521.ndla.sh/subject-matter/learning-resource/31469/edit/nb

---

Closes NDLANO/Issues#3125
