### PR TITLE
Using different img sizes based on if image is in slate table or not.…

### DIFF
--- a/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
@@ -85,7 +85,8 @@ const SlateFigure = ({ attributes, editor, element, language, locale = 'nb', chi
           saveEmbedUpdates={saveEmbedUpdates}
           visualElement={false}
           active={isActive()}
-          isSelectedForCopy={isSelected}>
+          isSelectedForCopy={isSelected}
+          element={element}>
           {children}
         </SlateImage>
       );

--- a/src/components/SlateEditor/plugins/embed/SlateImage.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateImage.tsx
@@ -9,15 +9,18 @@
 import { ReactNode, useState, MouseEvent } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { RenderElementProps } from 'slate-react';
+import { ReactEditor, RenderElementProps, useSlateStatic } from 'slate-react';
 import Button from '@ndla/button';
 import { useTranslation } from 'react-i18next';
-//@ts-ignore
 import { parseMarkdown } from '@ndla/util';
+import { Editor } from 'slate';
 import { getSrcSets } from '../../../../util/imageEditorUtil';
 import FigureButtons from './FigureButtons';
 import EditImage from './EditImage';
 import { ImageEmbed } from '../../../../interfaces';
+
+import { EmbedElement } from './index';
+import { isTable } from '../table/helpers';
 
 const buttonStyle = css`
   min-width: -webkit-fill-available;
@@ -38,6 +41,7 @@ interface Props {
   saveEmbedUpdates: (change: { [x: string]: string }) => void;
   visualElement: boolean;
   children: ReactNode;
+  element: EmbedElement;
 }
 
 const StyledDiv = styled.div<{ embed: ImageEmbed }>`
@@ -55,10 +59,19 @@ const SlateImage = ({
   saveEmbedUpdates,
   visualElement,
   children,
+  element,
 }: Props) => {
   const { t } = useTranslation();
   const [editMode, setEditMode] = useState(false);
   const showCopyOutline = isSelectedForCopy && (!editMode || !active);
+  const editor = useSlateStatic();
+
+  const imagePath = ReactEditor.findPath(editor, element);
+  const [parentTable] = Editor.nodes(editor, {
+    at: imagePath,
+    match: node => isTable(node),
+  });
+  const inTable = !!parentTable;
 
   const constructFigureClassName = () => {
     const isFullWidth = embed.align === 'center';
@@ -110,7 +123,16 @@ const SlateImage = ({
           <figure {...figureClass}>
             <img
               alt={embed.alt}
-              sizes="(min-width: 1024px) 180px, (min-width: 768px) 180px, 100vw"
+              sizes={
+                inTable
+                  ? '(min-width: 1024px) 180px, (min-width: 768px) 180px, 100vw'
+                  : '(min-width: 1280px) 1440px,' +
+                    '(min-width: 1024px) 1000px,' +
+                    '(min-width: 768px) 800px,' +
+                    '(min-width: 500px) 480px,' +
+                    '(min-width: 350px) 320px,' +
+                    '100vw'
+              }
               srcSet={getSrcSets(embed.resource_id, transformData())}
               css={css`
                 box-shadow: ${showCopyOutline ? 'rgb(32, 88, 143) 0 0 0 2px' : 'none'};


### PR DESCRIPTION
… This ensures that images in tables have low quality because they are small in size, while normal images retain high quality.

Fixes https://github.com/NDLANO/Issues/issues/3172

Kan testes ved å sette et bilde i en slate tabell og sette et bilde på en venlig måte i artikkelen og se at `?width` parameteret inneholder forskjellige verdier i network tab. Bildet utenfor slate tabellen skal alltid komme med høyre width verdi. (Det gjenspeiler høyre kvalitet)

Kan sjekker f.eks på denne artikkelen: `/subject-matter/learning-resource/31493/edit/en`

### ED:
![image](https://user-images.githubusercontent.com/10486712/177490562-3ed01830-75a5-42b6-8e88-920b08a6522c.png)

### PR:
![image](https://user-images.githubusercontent.com/10486712/177490471-47e2210c-f0e5-4715-875e-c0906d044cae.png)
