### PR TITLE
Update page number in pager

### DIFF
--- a/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
@@ -170,7 +170,7 @@ const ConceptModal = ({
                         />
                         <Pager
                           query={searchObject}
-                          page={searchObject.page ?? 1}
+                          page={results.page ?? 1}
                           pathname=""
                           lastPage={Math.ceil(results.totalCount / results.pageSize)}
                           onClick={searchConcept}


### PR DESCRIPTION
Closes https://github.com/NDLANO/Issues/issues/3168

_Det som var feil:_ Dersom man skulle bla gjennom flere sider av forklaringer i forklaringsmodal, ble innholdet på siden oppdatert, men ikke sidetallet. Da kunne man ikke bla bakover fordi uansett hvilken side man var på så stod sidetallet som 1. 

Nå funker det å navigere seg gjennom sidene og sidetallet oppdateres riktig.
