### PR TITLE
Legger til mulighet for å sende inn artikkelspråk til bildesøk.

### DIFF
--- a/cypress/integration/Editor/slate_block_picker_spec.js
+++ b/cypress/integration/Editor/slate_block_picker_spec.js
@@ -54,7 +54,7 @@ describe('can enter both element types SlateBlockPicker and SlateVisualElementPi
   });
 
   it('opens and closes image', () => {
-    cy.apiroute('GET', '/image-api/v2/images/?page=1&page-size=16', 'editor/images/imageList');
+    cy.apiroute('GET', '/image-api/v2/images/?language=nb&page=1&page-size=16', 'editor/images/imageList');
     cy.get('[data-cy=create-image]').click();
     cy.get('[data-cy="modal-header"]').should('exist');
     cy.get('[data-cy="modal-body"]').should('exist');
@@ -63,7 +63,7 @@ describe('can enter both element types SlateBlockPicker and SlateVisualElementPi
   });
 
   it('adds and removes image', () => {
-    cy.apiroute('GET', '/image-api/v2/images/?page=1&page-size=16', 'editor/images/imageList');
+    cy.apiroute('GET', '/image-api/v2/images/?language=nb&page=1&page-size=16', 'editor/images/imageList');
     cy.apiroute('GET', '**/images/*?language=nb', 'editor/images/image');
     cy.get('[data-cy=create-image]').click();
     cy.apiwait('@editor/images/imageList');

--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -31,6 +31,7 @@ const StyledTitleDiv = styled.div`
 interface Props {
   onImageSelect: (image: IImageMetaInformationV2) => void;
   locale: string;
+  language?: string;
   closeModal: () => void;
   onError: (err: Error & Response) => void;
   searchImages: (queryObject: ImageSearchQuery) => Promise<ISearchResult>;
@@ -52,6 +53,7 @@ const ImageSearchAndUploader = ({
   onImageSelect,
   closeModal,
   locale,
+  language,
   fetchImage,
   searchImages,
   onError,
@@ -63,7 +65,7 @@ const ImageSearchAndUploader = ({
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const { data: licenses } = useLicenses({ placeholderData: [] });
   const searchImagesWithParameters = (query?: string, page?: number) => {
-    return searchImages({ query, page, 'page-size': 16 });
+    return searchImages({ query, page, 'page-size': 16, language });
   };
   const imageLicenses = draftLicensesToImageLicenses(licenses ?? []);
 

--- a/src/components/ImageSearchAndUploader.tsx
+++ b/src/components/ImageSearchAndUploader.tsx
@@ -25,6 +25,7 @@ interface Props {
   onImageSelect: (image: IImageMetaInformationV2) => void;
   inModal?: boolean;
   locale: string;
+  language?: string;
   closeModal: () => void;
   onError: (err: any) => void;
   searchImages: (query: ImageSearchQuery) => Promise<ISearchResult>;
@@ -36,6 +37,7 @@ interface Props {
 const ImageSearchAndUploader = ({
   onImageSelect,
   locale,
+  language,
   inModal,
   closeModal,
   onError,
@@ -48,7 +50,7 @@ const ImageSearchAndUploader = ({
   const { t } = useTranslation();
 
   const searchImagesWithParameters = (query?: string, page?: number) => {
-    return searchImages({ query, page, 'page-size': 16 });
+    return searchImages({ query, page, 'page-size': 16, language });
   };
 
   return (

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -35,6 +35,7 @@ interface Props {
   showRemoveButton: boolean;
   showCheckbox: boolean;
   checkboxAction: (image: IImageMetaInformationV2) => void;
+  language?: string;
 }
 
 const MetaImageSearch = ({
@@ -46,6 +47,7 @@ const MetaImageSearch = ({
   onImageLoad,
   showCheckbox,
   checkboxAction,
+  language,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const { setFieldValue } = useFormikContext();
@@ -131,6 +133,7 @@ const MetaImageSearch = ({
                 inModal={true}
                 onImageSelect={onImageSet}
                 locale={locale}
+                language={language}
                 closeModal={onImageSelectClose}
                 fetchImage={id => fetchImage(id, locale)}
                 searchImages={searchImages}

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -93,6 +93,7 @@ const VisualElementSearch = ({
         <ImageSearchAndUploader
           inModal={true}
           locale={locale}
+          language={articleLanguage}
           closeModal={closeModal}
           fetchImage={id => fetchImage(id, articleLanguage)}
           searchImages={searchImages}

--- a/src/containers/VisualElement/VisualElementUrlPreview.tsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.tsx
@@ -439,6 +439,7 @@ const VisualElementUrlPreview = ({
               <ImageSearchAndUploader
                 inModal={true}
                 locale={language}
+                language={language}
                 closeModal={() => {}}
                 fetchImage={id => fetchImage(id, articleLanguage)}
                 searchImages={searchImages}


### PR DESCRIPTION
Legger til ekstra parameter language i tillegg til locale for bildesøk, slik at det går an å sende inn artikkelspråk for å få korrekt bildetreff. Det hadde ikkje holdt å bruke locale for då vil du få samme visning uavhengig av artikkelspråket.

Test:
* Lag en artikkel med både bokmål og nynorskversjon. 
* Sett inn bilde i artikkel og søk på 54559. Du skal få forskjellig bilde avhengig av språk fordi denne id-en har forskjellige bildefiler for nynorsk og bokmål.