### PR TITLE
Sletter emneartikler dersom ingen emner bruker artikkelen.

### DIFF
--- a/src/containers/StructurePage/folderComponents/menuOptions/DeleteTopic.tsx
+++ b/src/containers/StructurePage/folderComponents/menuOptions/DeleteTopic.tsx
@@ -104,7 +104,7 @@ class DeleteTopic extends PureComponent<Props, State> {
     let articleId = Number(article.contentUri.split(':')[2]);
     const topics = await queryTopics({ contentId: articleId, language: locale, taxonomyVersion });
     // Only topics with paths are relevant here.
-    if (topics.filter(t => t.path).length === 1) {
+    if (topics.filter(t => t.path).length === 0) {
       await updateStatusDraft(articleId, ARCHIVED);
     }
   }


### PR DESCRIPTION
Fixes NDLANO/Issues#3184

Det var en logisk brist i koden. Fordi sletting av emner først er sletting av koblingsobjekt, så vil emnet du sletter faktisk bli filtrert ut fordi path er borte. Så det er kun når lengda på emner uten path er 0 at du faktisk kan arkivere artikkelen.