### PR TITLE
Use content language to fetch image.

### DIFF
--- a/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
@@ -250,6 +250,7 @@ const ConceptForm = ({
                   fetchTags={fetchConceptTags}
                   subjects={subjects}
                   inModal={inModal}
+                  language={language}
                 />
               </AccordionSection>
               <AccordionSection

--- a/src/containers/ConceptPage/components/ConceptMetaData.tsx
+++ b/src/containers/ConceptPage/components/ConceptMetaData.tsx
@@ -22,9 +22,10 @@ interface Props {
   subjects: SubjectType[];
   fetchTags: (input: string, language: string) => Promise<ITagsSearchResult>;
   inModal: boolean;
+  language?: string;
 }
 
-const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
+const ConceptMetaData = ({ subjects, fetchTags, inModal, language }: Props) => {
   const { t } = useTranslation();
   const formikContext = useFormikContext<ConceptFormValues>();
   const { values } = formikContext;
@@ -42,6 +43,7 @@ const ConceptMetaData = ({ subjects, fetchTags, inModal }: Props) => {
               showRemoveButton
               showCheckbox={true}
               checkboxAction={image => onSaveAsVisualElement(image, formikContext)}
+              language={language}
               {...field}
             />
           )}

--- a/src/containers/FormikForm/MetaDataField.tsx
+++ b/src/containers/FormikForm/MetaDataField.tsx
@@ -75,6 +75,7 @@ const MetaDataField = ({ articleLanguage, showCheckbox, checkboxAction }: Props)
             showRemoveButton={false}
             showCheckbox={showCheckbox}
             checkboxAction={checkboxAction}
+            language={articleLanguage}
             {...field}
           />
         )}

--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -57,11 +57,11 @@ const MetaImageSearch = ({
 
   useEffect(() => {
     if (metaImageId) {
-      fetchImage(parseInt(metaImageId), locale).then(image => setImage(image));
+      fetchImage(parseInt(metaImageId), language).then(image => setImage(image));
     } else {
       setImage(undefined);
     }
-  }, [metaImageId, locale]);
+  }, [metaImageId, language]);
 
   const onChangeFormik = (id: string | null) => {
     onChange({
@@ -138,7 +138,7 @@ const MetaImageSearch = ({
                 locale={locale}
                 language={language}
                 closeModal={onImageSelectClose}
-                fetchImage={id => fetchImage(id, locale)}
+                fetchImage={id => fetchImage(id, language)}
                 searchImages={searchImages}
                 onError={onError}
                 updateImage={onImageUpdate}

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -272,6 +272,7 @@ const PodcastForm = ({
                     field => field in errors,
                   )}>
                   <PodcastMetaData
+                    language={language}
                     onImageLoad={el => {
                       size.current = [
                         el.currentTarget.naturalWidth,

--- a/src/containers/Podcast/components/PodcastMetaData.tsx
+++ b/src/containers/Podcast/components/PodcastMetaData.tsx
@@ -15,12 +15,13 @@ import { textTransformPlugin } from '../../../components/SlateEditor/plugins/tex
 import { MetaImageSearch } from '../../FormikForm';
 
 interface Props {
+  language?: string;
   onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
 }
 
 const plugins = [textTransformPlugin];
 
-const PodcastMetaData = ({ onImageLoad }: Props) => {
+const PodcastMetaData = ({ language, onImageLoad }: Props) => {
   const { t } = useTranslation();
 
   return (
@@ -48,6 +49,7 @@ const PodcastMetaData = ({ onImageLoad }: Props) => {
               setFieldTouched={form.setFieldTouched}
               showRemoveButton
               onImageLoad={onImageLoad}
+              language={language}
               {...field}
             />
           );

--- a/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
@@ -171,6 +171,7 @@ const PodcastSeriesForm = ({
                 className="u-4/6@desktop u-push-1/6@desktop"
                 hasError={['title', 'coverPhotoId', 'metaImageAlt'].some(field => field in errors)}>
                 <PodcastSeriesMetaData
+                  language={language}
                   onImageLoad={el => {
                     size.current = [el.currentTarget.naturalWidth, el.currentTarget.naturalHeight];
                     validateForm();

--- a/src/containers/PodcastSeries/components/PodcastSeriesMetaData.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesMetaData.tsx
@@ -17,10 +17,11 @@ import PlainTextEditor from '../../../components/SlateEditor/PlainTextEditor';
 import { textTransformPlugin } from '../../../components/SlateEditor/plugins/textTransform';
 
 interface Props {
+  language?: string;
   onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
 }
 
-const PodcastSeriesMetadata = ({ onImageLoad }: Props) => {
+const PodcastSeriesMetaData = ({ language, onImageLoad }: Props) => {
   const { t } = useTranslation();
   const formikContext = useFormikContext<PodcastSeriesFormikType>();
   const { submitForm } = formikContext;
@@ -47,6 +48,7 @@ const PodcastSeriesMetadata = ({ onImageLoad }: Props) => {
             metaImageId={field.value}
             setFieldTouched={form.setFieldTouched}
             showRemoveButton
+            language={language}
             {...field}
           />
         )}
@@ -55,4 +57,4 @@ const PodcastSeriesMetadata = ({ onImageLoad }: Props) => {
   );
 };
 
-export default PodcastSeriesMetadata;
+export default PodcastSeriesMetaData;

--- a/src/containers/SearchPage/components/results/SearchConcept/SearchConcept.tsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/SearchConcept.tsx
@@ -73,7 +73,7 @@ const SearchConcept = ({ concept, locale, subjects, editingState }: Props) => {
     <StyledSearchResult>
       <StyledSearchImageContainer>
         {metaImageSrc ? (
-          <img src={`${metaImageSrc}?width=200`} alt={metaImageAlt} />
+          <img src={`${metaImageSrc}?width=200&language=${locale}`} alt={metaImageAlt} />
         ) : (
           <Concept className="c-icon--large" />
         )}

--- a/src/containers/SearchPage/components/results/SearchContent.tsx
+++ b/src/containers/SearchPage/components/results/SearchContent.tsx
@@ -71,7 +71,7 @@ const SearchContent = ({ content, locale }: Props) => {
   const { userPermissions } = useSession();
   const { contexts, metaImage } = content;
   const { url, alt } = metaImage || {};
-  const imageUrl = url ? `${url}?width=200` : '/placeholder.png';
+  const imageUrl = url ? `${url}?width=200&language=${locale}` : '/placeholder.png';
   let resourceType: ContentType | undefined;
   if ((contexts[0]?.resourceTypes?.length ?? 0) > 0) {
     resourceType = getContentTypeFromResourceTypes(contexts[0].resourceTypes);


### PR DESCRIPTION
Fixes NDLANO/Issues#3171

Bruker innholdsspråk for å vise metabilde.

Test:
* Endre metabilde for innhold med språkvariant nn og nb og bruk bildeid 54599
* Alle plasser der dette bildet brukes skal forskjellig variant vises.