### PR TITLE
Remove stored subjectpage when switching languages to fix bug with PlainTextEditor

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -183,7 +183,7 @@ const config: ConfigType = {
   logglyApiKey: getEnvironmentVariabel('LOGGLY_API_KEY'),
   isNdlaProdEnvironment: ndlaEnvironment === 'prod',
   versioningEnabled: getEnvironmentVariabel('ENABLE_VERSIONING', 'true'),
-  revisiondateEnabled: getEnvironmentVariabel('ENABLE_REVISIONDATE', 'false'),
+  revisiondateEnabled: getEnvironmentVariabel('ENABLE_REVISIONDATE', 'true'),
   ndlaApiUrl: getEnvironmentVariabel('NDLA_API_URL', getNdlaApiUrl(ndlaEnvironment)),
   ndlaBaseUrl: ndlaBaseUrl(),
   ndlaFrontendDomain: getEnvironmentVariabel('FRONTEND_DOMAIN', ndlaFrontendDomain()),

--- a/src/containers/FormikForm/formikSubjectpageHooks.ts
+++ b/src/containers/FormikForm/formikSubjectpageHooks.ts
@@ -84,6 +84,7 @@ export function useFetchSubjectpageData(
   useEffect(() => {
     (async () => {
       setLoading(true);
+      setSubjectpage(undefined);
       if (subjectpageId) {
         try {
           const subjectpage = await frontpageApi.fetchSubjectpage(subjectpageId, selectedLanguage);


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3181
Kan testes ved å navigere mellom forskjellige språkversjoner av en fagforside der innholdet varierer basert på språket man er på. Kan også testes ved å lagre og bytte språkversjon flere ganger.