### PR TITLE
Use separate playerid for copyrighted videos.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -168,6 +168,7 @@ export type ConfigType = {
   zendeskWidgetKey: string | undefined;
   brightcovePlayerId: string | undefined;
   brightcove360PlayerId: string | undefined;
+  brightcoveCopyrightPlayerId: string | undefined;
   disableCSP: string | undefined;
   usernamePasswordEnabled: boolean;
 };
@@ -197,6 +198,7 @@ const config: ConfigType = {
   brightCoveAccountId: getEnvironmentVariabel('BRIGHTCOVE_ACCOUNT_ID', '123456789'),
   brightcovePlayerId: getEnvironmentVariabel('BRIGHTCOVE_PLAYER_ID', 'Ab1234'),
   brightcove360PlayerId: getEnvironmentVariabel('BRIGHTCOVE_PLAYER_360_ID', 'Ab1234'),
+  brightcoveCopyrightPlayerId: getEnvironmentVariabel('BRIGHTCOVE_PLAYER_COPYRIGHT_ID', 'Ab1234'),
   brightcoveApiUrl: 'https://cms.api.brightcove.com',
   brightcoveUrl: 'https://studio.brightcove.com/products/videocloud/home',
   h5pApiUrl: getEnvironmentVariabel('H5P_API_URL', h5pApiUrl()),

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -148,6 +148,8 @@ const VisualElementSearch = ({
                   player:
                     video.projection === 'equirectangular'
                       ? config.brightcove360PlayerId!
+                      : video.custom_fields['license'] === 'Opphavsrett'
+                      ? config.brightcoveCopyrightPlayerId!
                       : config.brightcovePlayerId!,
                   metaData: video,
                   title: video.name,


### PR DESCRIPTION
Fixes NDLANO/Issues#3194

Test:
* Sett inn video med opphavsrett og sjekk at videoid wWQ015NyI lagres. (Vercel og deploy er oppdatert med ny variabel)