### PR TITLE
Ignore whitespaces when inserting inline concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,10 +185,10 @@
     "react-tabs": "^3.0.0",
     "remarkable": "^2.0.0",
     "serialize-javascript": "^3.1.0",
-    "slate": "0.77.0",
+    "slate": "0.82.0",
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.77.0",
-    "slate-react": "0.77.0",
+    "slate-react": "0.82.0",
     "source-map-support": "^0.5.13",
     "yup": "^0.32.9"
   },

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -15,7 +15,6 @@ import { IConcept } from '@ndla/types-concept-api';
 import { ConceptInlineElement } from '../inline/interfaces';
 import ConceptModal from '../ConceptModal';
 import { useFetchConceptData } from '../../../../../containers/FormikForm/formikConceptHooks';
-import mergeLastUndos from '../../../utils/mergeLastUndos';
 import { TYPE_CONCEPT_INLINE } from './types';
 import SlateNotion from './SlateNotion';
 
@@ -75,14 +74,13 @@ const InlineConcept = (props: Props) => {
         ...addedConcept,
         title: { title: nodeText },
       });
-      if (element && true) {
+      if (element) {
         const path = ReactEditor.findPath(editor, element);
         Transforms.setNodes(
           editor,
           { data: data.data },
           { at: path, match: node => Element.isElement(node) && node.type === TYPE_CONCEPT_INLINE },
         );
-        mergeLastUndos(editor);
       }
     }, 0);
   };

--- a/src/components/SlateEditor/plugins/concept/inline/utils.ts
+++ b/src/components/SlateEditor/plugins/concept/inline/utils.ts
@@ -20,6 +20,26 @@ export const insertInlineConcept = (editor: Editor) => {
     return;
   }
   if (Range.isRange(editor.selection) && !Range.isCollapsed(editor.selection)) {
+    const unhangedRange = Editor.unhangRange(editor, editor.selection);
+    Transforms.select(editor, unhangedRange);
+
+    const text = Editor.string(editor, unhangedRange);
+    const leftSpaces = text.length - text.trimStart().length;
+    const rightSpaces = text.length - text.trimEnd().length;
+
+    if (leftSpaces) {
+      Transforms.move(editor, { distance: leftSpaces, unit: 'offset', edge: 'start' });
+    }
+
+    if (rightSpaces) {
+      Transforms.move(editor, {
+        distance: rightSpaces,
+        unit: 'offset',
+        edge: 'end',
+        reverse: true,
+      });
+    }
+
     Transforms.wrapNodes(editor, slatejsx('element', { type: TYPE_CONCEPT_INLINE, data: {} }), {
       at: Editor.unhangRange(editor, editor.selection),
       split: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14764,10 +14764,10 @@ slate-hyperscript@^0.77.0:
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-react@0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.77.0.tgz#4df9d55448767c73ace1689c2d297be9896a2248"
-  integrity sha512-rBhEkJNOhPqPzaxo5YMf2NukZ4pP8CTx5/okWm40S/oL59ZcNTxddM3gX7UIPUHtID7B1WH/BVUg0sFUzzfqZQ==
+slate-react@0.82.0:
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.82.0.tgz#42be9615f79c4367bce6967e7a2ddb870032b795"
+  integrity sha512-kaLpphZ2apX1C7N+8LQElKZ3XKHdmuAZYfTtUOetxCQ6MctDMHg1GHE/tX5hNvF/2bvG5PSnEOrfUOqaSOpzMA==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -14778,10 +14778,10 @@ slate-react@0.77.0:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.77.0.tgz#a83425cb1499ebd3d4a85a7bbbeaf9faefb29769"
-  integrity sha512-1yg8h4wX3WjTecvTTqfg1+a1cM1wXzmQ4MCWwd+KSJBJCtAvjgRDDQq2ThhWhx2uviznQemRzdls/BI0c/KvYQ==
+slate@0.82.0:
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.82.0.tgz#3a948347df58af2800bef162179cebc467c08b34"
+  integrity sha512-2O2NQunBoIWp3M6HP9w1RnNYR6eC52jW4cAXiUDthTxeiwTjL+wrSncls+9jmfqVrUnUb13qbgOEmw6/EdE1yA==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
Fixes NDLANO/Issues#3188

Ved innsetting av forklaring vil nå spaces i start/slutt av ord ikke markeres. Slate har ingen direkte støtte for dette så vidt jeg kunne se, så må manuelt telle spaces og redusere det markerte området. Oppdaterer også Slate til siste versjon.

Hvordan teste:
- Åpne artikkel og skriv et par ord.
- Marker rundt et ord inkludert mellomrom.
- Sett inn forklaring via toolbar eller ctrl+alt+c
- Forklaringen som ble satt inn skal nå være uten de opprinnelig markerte mellomrommene.