### PR TITLE
Fix issue with toggling favorite subjects caused by root node memoization

### DIFF
--- a/src/containers/StructurePage/RootNode.tsx
+++ b/src/containers/StructurePage/RootNode.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { DropResult } from 'react-beautiful-dnd';
 import { useQueryClient } from 'react-query';
 import { isEqual, partition, sortBy } from 'lodash';
+import { IUserData } from '@ndla/types-draft-api';
 import { ChildNodeType, NodeType } from '../../modules/nodes/nodeApiTypes';
 import {
   childNodesWithArticleTypeQueryKey,
@@ -18,13 +19,13 @@ import { groupChildNodes } from '../../util/taxonomyHelpers';
 import NodeItem, { RenderBeforeFunction } from './NodeItem';
 import { useUpdateNodeConnectionMutation } from '../../modules/nodes/nodeMutations';
 import { useTaxonomyVersion } from '../StructureVersion/TaxonomyVersionProvider';
+import { userDataQueryKey, useUpdateUserDataMutation } from '../../modules/draft/draftQueries';
 
 interface Props {
   node: NodeType;
   toggleOpen: (path: string) => void;
   openedPaths: string[];
   isFavorite: boolean;
-  toggleFavorite: () => void;
   onNodeSelected: (node?: NodeType) => void;
   resourceSectionRef: MutableRefObject<HTMLDivElement | null>;
   allRootNodes: NodeType[];
@@ -36,7 +37,6 @@ const RootNode = ({
   node,
   openedPaths,
   toggleOpen,
-  toggleFavorite,
   onNodeSelected,
   resourceSectionRef,
   allRootNodes,
@@ -57,6 +57,7 @@ const RootNode = ({
     id: node.id,
     language: locale,
   });
+  const updateUserDataMutation = useUpdateUserDataMutation();
 
   const qc = useQueryClient();
 
@@ -88,6 +89,14 @@ const RootNode = ({
       body: { rank: newRank },
       taxonomyVersion,
     });
+  };
+
+  const toggleFavorite = () => {
+    const favorites = qc.getQueryData<IUserData>(userDataQueryKey())?.favoriteSubjects ?? [];
+    const updatedFavs = favorites.includes(node.id)
+      ? favorites.filter(s => s !== node.id)
+      : favorites.concat(node.id);
+    updateUserDataMutation.mutate({ favoriteSubjects: updatedFavs });
   };
 
   return (

--- a/src/containers/StructurePage/StructureContainer.tsx
+++ b/src/containers/StructurePage/StructureContainer.tsx
@@ -13,7 +13,7 @@ import { REMEMBER_FAVORITE_NODES, TAXONOMY_ADMIN_SCOPE } from '../../constants';
 import { useSession } from '../Session/SessionProvider';
 import InlineAddButton from '../../components/InlineAddButton';
 import { useAddNodeMutation } from '../../modules/nodes/nodeMutations';
-import { useUpdateUserDataMutation, useUserData } from '../../modules/draft/draftQueries';
+import { useUserData } from '../../modules/draft/draftQueries';
 import { useNodes } from '../../modules/nodes/nodeQueries';
 import { ChildNodeType, NodeType } from '../../modules/nodes/nodeApiTypes';
 import RootNode from './RootNode';
@@ -98,20 +98,9 @@ const StructureContainer = () => {
     return nodes.filter(node => favoriteNodeIds.includes(node.id));
   };
 
-  const updateUserDataMutation = useUpdateUserDataMutation();
   const nodes = showFavorites
     ? getFavoriteNodes(nodesQuery.data, [...favoriteNodeIds, subject])
     : nodesQuery.data!;
-
-  const toggleFavorite = (nodeId: string) => {
-    if (!favoriteNodes) {
-      return;
-    }
-    const updatedFavorites = favoriteNodeIds.includes(nodeId)
-      ? favoriteNodeIds.filter(s => s !== nodeId)
-      : [...favoriteNodeIds, nodeId];
-    updateUserDataMutation.mutate({ favoriteSubjects: updatedFavorites });
-  };
 
   const toggleStructure = () => {
     setEditStructureHidden(!editStructureHidden);
@@ -177,7 +166,6 @@ const StructureContainer = () => {
                     key={node.id}
                     node={node}
                     toggleOpen={handleStructureToggle}
-                    toggleFavorite={() => toggleFavorite(node.id)}
                   />
                 ))}
               </StructureWrapper>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3249

Gikk gjennom en merkelig reise for å finne ut av dette. Feilen har egentlig ingenting å gjøre med react-query, men heller måten jeg har valgt å memoisere nodetrær på. I nåværende løsning vil en rotnode og dens barn kun rendres på nytt dersom den åpnes/lukkes, hvis dens favorittstatus endres eller hvis noden har ny data. Dette kolliderer med toggleFavorite-funksjonen, da nye versjoner av den vil ignoreres. Vi vil med andre ord brukt utdaterte versjoner av funksjonen inntil favoritt-statusen til den nåværende noden endres. Det blir feil. 

Her var det to mulig løsninger. Den første var å ta hensyn til toggleFavorites-funksjonen i memoiseringen. Dette ville dog rerendre hele nodetreet hver gang man la til en ny favoritt, og skapte merkbar rendering-lag. Endte derfor opp med å flytte toggleFavorite ned til node-nivå, slik at enhver node alltid vil ha en oppdatert toggle-funksjon.