### PR TITLE
Use valid language code for wiris

### DIFF
--- a/src/components/SlateEditor/plugins/mathml/EditMath.jsx
+++ b/src/components/SlateEditor/plugins/mathml/EditMath.jsx
@@ -46,7 +46,8 @@ class EditMath extends Component {
 
     const callback = function() {
       outer.mathEditor = window.com.wiris.jsEditor.JsEditor.newInstance({
-        language: locale,
+        language: ['nb', 'nn'].includes(locale) ? 'no' : locale,
+        toolbarHidden: false,
       });
 
       outer.mathEditor.setMathML(renderMathML);

--- a/src/components/SlateEditor/plugins/mathml/EditMath.jsx
+++ b/src/components/SlateEditor/plugins/mathml/EditMath.jsx
@@ -47,7 +47,6 @@ class EditMath extends Component {
     const callback = function() {
       outer.mathEditor = window.com.wiris.jsEditor.JsEditor.newInstance({
         language: ['nb', 'nn'].includes(locale) ? 'no' : locale,
-        toolbarHidden: false,
       });
 
       outer.mathEditor.setMathML(renderMathML);


### PR DESCRIPTION
Det viser seg at wiris vil ha 'no' for å vise matte-editor på norsk.

Test:
* Legg inn matte i en artikkel og sjekk at hjelpetekster i wiris er på norsk.