### PR TITLE
Fix unique key warning in lightboxpreview

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -20,7 +20,6 @@ import DeleteLanguageVersion from './DeleteLanguageVersion';
 import HeaderSupportedLanguages from './HeaderSupportedLanguages';
 import HeaderLanguagePill from './HeaderLanguagePill';
 import PreviewConceptLightbox from '../PreviewConcept/PreviewConceptLightbox';
-import { createReturnTypeGuard } from '../../util/guards';
 
 type PreviewTypes = IConcept | IUpdatedArticle;
 
@@ -33,10 +32,6 @@ interface PreviewLightBoxProps {
   currentLanguage: string;
 }
 
-const isConceptReturnType = createReturnTypeGuard<IConcept>('articleIds');
-const isDraftReturnType = (value: () => PreviewTypes): value is () => IUpdatedArticle =>
-  !isConceptReturnType(value);
-
 const PreviewLightBox = ({
   type,
   getEntity,
@@ -46,9 +41,14 @@ const PreviewLightBox = ({
   articleId,
 }: PreviewLightBoxProps) => {
   const { t } = useTranslation();
-  if (type === 'concept' && isConceptReturnType(getEntity) && supportedLanguages.length > 1) {
-    return <PreviewConceptLightbox typeOfPreview="previewLanguageArticle" getConcept={getEntity} />;
-  } else if (isDraftReturnType(getEntity) && (type === 'standard' || type === 'topic-article')) {
+  if (type === 'concept' && supportedLanguages.length > 1) {
+    return (
+      <PreviewConceptLightbox
+        typeOfPreview="previewLanguageArticle"
+        getConcept={getEntity as () => IConcept}
+      />
+    );
+  } else if (type === 'standard' || type === 'topic-article') {
     return (
       <PreviewDraftLightbox
         articleId={articleId}
@@ -56,7 +56,7 @@ const PreviewLightBox = ({
         label={t(`articleType.${articleType!}`)}
         typeOfPreview="previewLanguageArticle"
         supportedLanguages={supportedLanguages}
-        getArticle={_ => getEntity()}>
+        getArticle={_ => getEntity() as IUpdatedArticle}>
         {(openPreview: () => void) => (
           <StyledFilledButton type="button" onClick={openPreview}>
             <FileCompare />


### PR DESCRIPTION
Jeg kan ikke forklare hvorfor denne typeguarden lagde den warningen, men dette fikser det.
Jeg ser også at `createReturnTypeGuard` faktisk kaller på funksjonen vi typeguarder (som kanskje er eneste måte?), men det føles ut som en veldig dårlig ide, spesielt om funksjonen har sideeffekter sånn som denne har.

Jeg elsker ikke casts, men vet ikke helt hvordan vi kommer rundt det i typescript uten å gjøre noe annet skittent 😕 