### PR TITLE
Avoid using cached image in image-editor

### DIFF
--- a/src/containers/ImageUploader/components/ImageContent.tsx
+++ b/src/containers/ImageUploader/components/ImageContent.tsx
@@ -41,6 +41,10 @@ interface Props {
 const ImageContent = ({ formik }: Props) => {
   const { t } = useTranslation();
   const { values, errors, setFieldValue, submitForm } = formik;
+
+  // We use the timestamp to avoid caching of the `imageFile` url in the browser
+  const timestamp = new Date().getTime();
+  const imgSrc = values.filepath || `${values.imageFile}?ts=${timestamp}`;
   return (
     <>
       <TitleField handleSubmit={submitForm} />
@@ -85,7 +89,7 @@ const ImageContent = ({ formik }: Props) => {
       {values.imageFile && (
         <>
           <SafeLink target="_blank" to={values.imageFile}>
-            <StyledImage src={values.filepath || values.imageFile} alt="" />
+            <StyledImage src={imgSrc} alt="" />
           </SafeLink>
           <ImageMeta
             contentType={values.contentType ?? ''}


### PR DESCRIPTION
Legger til et timestamp i bilde-editoren for å unngå å bruke cachet bilde etter oppdatering.

Kan testes ved å se at å erstatte en bildefil for et bilde ikke gjør at det gamle bildet henger igjen frem til refresh.