### PR TITLE
Fix unique key errors in editor

### DIFF
--- a/src/components/SlateEditor/plugins/table/TableActions.tsx
+++ b/src/components/SlateEditor/plugins/table/TableActions.tsx
@@ -225,8 +225,8 @@ const TableActions = ({ editor, element }: Props) => {
           {/* Row 1 - Row actions */}
           <StyledRowTitle>{`${t('form.content.table.row')}:`}</StyledRowTitle>
           <ActionGroup>
-            {rowActions.map(action => (
-              <TableIconButton operation={action.name} onClick={handleOnClick}>
+            {rowActions.map((action, idx) => (
+              <TableIconButton key={idx} operation={action.name} onClick={handleOnClick}>
                 {action.icon}
               </TableIconButton>
             ))}
@@ -245,8 +245,8 @@ const TableActions = ({ editor, element }: Props) => {
           {/* Row 2  - Column actions*/}
           <StyledRowTitle>{`${t('form.content.table.column')}:`}</StyledRowTitle>
           <ActionGroup>
-            {columnActions.map(action => (
-              <TableIconButton operation={action.name} onClick={handleOnClick}>
+            {columnActions.map((action, idx) => (
+              <TableIconButton key={idx} operation={action.name} onClick={handleOnClick}>
                 {action.icon}
               </TableIconButton>
             ))}

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import { Fragment } from 'react';
 import escapeHtml from 'escape-html';
 import { compact, toArray } from 'lodash';
 import { Descendant, Element, Node, Text } from 'slate';
@@ -116,12 +117,12 @@ const topicArticleRules: SlateSerializer[] = [
 ];
 
 const articleContentToHTML = (value: Descendant[], rules: SlateSerializer[]) => {
-  const serialize = (node: Descendant): JSX.Element | null => {
+  const serialize = (node: Descendant, nodeIdx: number): JSX.Element | null => {
     let children: JSX.Element[];
     if (Text.isText(node)) {
       children = [escapeHtml(node.text)];
     } else {
-      children = compact(node.children.map((n: Descendant) => serialize(n)));
+      children = compact(node.children.map((n: Descendant, idx: number) => serialize(n, idx)));
     }
 
     for (const rule of rules) {
@@ -135,15 +136,15 @@ const articleContentToHTML = (value: Descendant[], rules: SlateSerializer[]) => 
       } else if (ret === null) {
         return null;
       } else {
-        return ret;
+        return <Fragment key={nodeIdx}>{ret}</Fragment>;
       }
     }
     return <>{children}</>;
   };
 
   const elements = value
-    .map((descendant: Descendant) => {
-      const html = serialize(descendant);
+    .map((descendant: Descendant, idx: number) => {
+      const html = serialize(descendant, idx);
       return html ? renderToStaticMarkup(html) : '';
     })
     .join('');

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -10,6 +10,7 @@ import escapeHtml from 'escape-html';
 import { compact, toArray } from 'lodash';
 import { Descendant, Element, Node, Text } from 'slate';
 import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
 import { Plain } from './slatePlainSerializer';
 import { convertFromHTML } from './convertFromHTML';
 import { sectionSerializer } from '../components/SlateEditor/plugins/section';
@@ -136,7 +137,7 @@ const articleContentToHTML = (value: Descendant[], rules: SlateSerializer[]) => 
       } else if (ret === null) {
         return null;
       } else {
-        return <Fragment key={nodeIdx}>{ret}</Fragment>;
+        return React.cloneElement(ret, { key: nodeIdx });
       }
     }
     return <>{children}</>;


### PR DESCRIPTION
Fikser to unique key feil i editoren.
Kan testes ved å sjekke at vi ikke får unique key errors i konsollen i editoren. Den ene oppstod kun om det fantes tabeller, mens den andre oppstod i alle (tror jeg) slate elementer.