### PR TITLE
Separate between node connections and resource connections by node-connection

### DIFF
--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -198,9 +198,9 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
 
   const updateRelevanceId = async (relevanceId: string) => {
     const { connectionId, primary, rank } = resource;
-    const func = connectionId.includes('node-connection')
-      ? updateNodeConnection
-      : updateResourceConnection;
+    const func = connectionId.includes('-resource')
+      ? updateResourceConnection
+      : updateNodeConnection;
     await func({
       id: connectionId,
       body: { relevanceId, primary, rank: rank },

--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -198,10 +198,9 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
 
   const updateRelevanceId = async (relevanceId: string) => {
     const { connectionId, primary, rank } = resource;
-    const func =
-      connectionId.includes('subject-topic') || connectionId.includes('topic-subtopic')
-        ? updateNodeConnection
-        : updateResourceConnection;
+    const func = connectionId.includes('node-connection')
+      ? updateNodeConnection
+      : updateResourceConnection;
     await func({
       id: connectionId,
       body: { relevanceId, primary, rank: rank },


### PR DESCRIPTION
Regner med at dette har å gjøre med en oppdatering i taksonomi? I nye struktur er det ingenting annet som eksplisitt tar hensyn til topic-subtopic og subject-topic, så jeg regner med at alt skal være i orden etter dette.