### PR TITLE
Add new embeds

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,7 +65,7 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'Vimeo', url: ['vimeo.com', 'vimeopro.com'], height: '486px' },
   { name: 'Norgesfilm', url: ['ndla.filmiundervisning.no'] },
   { name: 'TED', url: ['ted.com', 'embed.ted.com'] },
-  { name: 'TV2 Skole', url: ['www.tv2skole.no'], height: '431px' },
+  { name: 'TV2 Skole', url: ['www.tv2skole.no', 'elevkanalen.no'], height: '431px' },
   { name: 'Khan Academy', url: ['nb.khanacademy.org', 'www.khanacademy.org'], height: '486px' },
   { name: 'Prezi', url: ['prezi.com'] },
   { name: 'SlideShare', url: ['www.slideshare.net'], height: '500px' },
@@ -95,6 +95,8 @@ export const EXTERNAL_WHITELIST_PROVIDERS = [
   { name: 'Our World in Data', url: ['ourworldindata.org'] },
   { name: 'SketchUp 3D Warehouse', url: ['3dwarehouse.sketchup.com'] },
   { name: 'Gapminder', url: ['www.gapminder.org'] },
+  { name: 'Facebook', url: ['www.facebook.com', 'fb.watch'] },
+  { name: 'Sketchfab', url: ['sketchfab.com'] },
 ];
 
 export const SearchTypeValues = [

--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -166,6 +166,28 @@ const sketchupTransformer: UrlTransformer = {
   },
 };
 
+const sketcfabTransformer: UrlTransformer = {
+  domains: ['sketchfab.com'],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    if (!aTag.href.includes('/3d-models/')) {
+      return false;
+    }
+    return true;
+  },
+  transform: async url => {
+    const embedId = url.split('-').pop();
+    if (embedId?.match(/\b[0-9a-f]{32}/)) {
+      return `https://sketchfab.com/models/${embedId}/embed`;
+    }
+    return url;
+  },
+};
+
 export const urlTransformers: UrlTransformer[] = [
   nrkTransformer,
   kahootTransformer,
@@ -173,4 +195,5 @@ export const urlTransformers: UrlTransformer[] = [
   tedTransformer,
   flourishTransformer,
   sketchupTransformer,
+  sketcfabTransformer,
 ];

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -122,6 +122,8 @@ const frameSrc = (() => {
     '*.vg.no',
     'vg.no',
     'https://www.tv2skole.no/',
+    '*.elevkanalen.no',
+    'elevkanalen.no',
     'https://www.scribd.com/',
     'https://www.youtube.com',
     'https://youtu.be',
@@ -176,6 +178,9 @@ const frameSrc = (() => {
     '*.sketchup.com',
     'www.gapminder.org',
     'https://*.clarity.ms',
+    'www.facebook.com',
+    'fb.watch',
+    'sketchfab.com',
   ];
   if (process.env.NODE_ENV === 'development') {
     return [


### PR DESCRIPTION
Gjør det mulig å embedde facebook og sketchfab. Legger også til nytt navn på tv2skole.

Test:
* Du kan legge inn facebook-videourler fra embedkode
* Du kan legge inn sketchfab urler fra embedkode
* Du kan legge inn sketchfab modell-urler, og disse blir oversatt til embed urler

Merk at du ikkje kan lagre før backend er oppdatert.