### PR TITLE
Improve error handling

### DIFF
--- a/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
+++ b/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
@@ -33,7 +33,6 @@ import {
 } from '../../util/routeHelpers';
 import AlertModal from '../AlertModal';
 import StyledFilledButton from '../StyledFilledButton';
-import { formatErrorMessage } from '../../util/apiHelpers';
 import { useMessages } from '../../containers/Messages/MessagesProvider';
 import { NdlaErrorPayload } from '../../util/resolveJsonOrRejectWithError';
 
@@ -59,7 +58,7 @@ interface Props {
 const DeleteLanguageVersion = ({ values, type, disabled }: Props) => {
   const { t } = useTranslation();
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
-  const { createMessage } = useMessages();
+  const { createMessage, formatErrorMessage } = useMessages();
   const navigate = useNavigate();
 
   const toggleShowDeleteWarning = () => {

--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -17,7 +17,6 @@ import { IUpdatedArticle, IStatus as DraftStatus } from '@ndla/types-draft-api';
 import { useFormikContext } from 'formik';
 
 import { toPreviewDraft } from '../../util/routeHelpers';
-import { formatErrorMessage } from '../../util/apiHelpers';
 import PreviewConceptLightbox from '../PreviewConcept/PreviewConceptLightbox';
 import SaveMultiButton from '../SaveMultiButton';
 import { createGuard, createReturnTypeGuard } from '../../util/guards';
@@ -74,7 +73,7 @@ function EditorFooter<T extends FormValues>({
 }: Props) {
   const { t } = useTranslation();
   const { values, setFieldValue, isSubmitting } = useFormikContext<T>();
-  const { createMessage } = useMessages();
+  const { createMessage, formatErrorMessage } = useMessages();
   // Wait for newStatus to be set to trigger since formik doesn't update fields instantly
   const [newStatus, setNewStatus] = useState<string | null>(null);
   useEffect(() => {

--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -31,7 +31,6 @@ import SaveButton from '../../components/SaveButton';
 import HelpMessage from '../../components/HelpMessage';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { useMessages } from '../Messages/MessagesProvider';
-import { formatErrorMessage } from '../../util/apiHelpers';
 import { NdlaErrorPayload } from '../../util/resolveJsonOrRejectWithError';
 
 declare global {
@@ -140,7 +139,7 @@ const EditMarkupPage = () => {
   const [draft, setDraft] = useState<IArticle | undefined>(undefined);
   const location = useLocation();
   const locationState = location.state as LocationState | undefined;
-  const { createMessage } = useMessages();
+  const { createMessage, formatErrorMessage } = useMessages();
 
   useEffect(() => {
     const session = getSessionStateFromLocalStorage();

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -33,7 +33,6 @@ import {
   subjectpageFormikTypeToPostType,
 } from '../../../util/subjectHelpers';
 import { useMessages } from '../../Messages/MessagesProvider';
-import { formatErrorMessage } from '../../../util/apiHelpers';
 import { queryLearningPathResource, queryResources, queryTopics } from '../../../modules/taxonomy';
 import { Resource, Topic } from '../../../modules/taxonomy/taxonomyApiInterfaces';
 import { TYPE_EMBED } from '../../../components/SlateEditor/plugins/embed/types';
@@ -98,7 +97,7 @@ const SubjectpageForm = ({
   const { t } = useTranslation();
   const { taxonomyVersion } = useTaxonomyVersion();
   const [savedToServer, setSavedToServer] = useState(false);
-  const { createMessage, applicationError } = useMessages();
+  const { createMessage, applicationError, formatErrorMessage } = useMessages();
   const initialValues = subjectpageApiTypeToFormikType(
     subjectpage,
     elementName,

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -12,7 +12,6 @@ import { FormikHelpers } from 'formik';
 import { Descendant } from 'slate';
 import { IArticle, ILicense, IStatus, IUpdatedArticle, IAuthor } from '@ndla/types-draft-api';
 import { deleteFile } from '../../modules/draft/draftApi';
-import { formatErrorMessage } from '../../util/apiHelpers';
 import * as articleStatuses from '../../util/constants/ArticleStatus';
 import { isFormikFormDirty } from '../../util/formHelper';
 import { DraftStatusType, RelatedContent } from '../../interfaces';
@@ -186,8 +185,11 @@ export function useArticleFormHooks<T extends ArticleFormType>({
           message: t('alertModal.needToRefresh'),
           timeToLive: 0,
         });
-      } else if (err && err.json && err.json.messages) {
-        createMessage(formatErrorMessage(err));
+      } else if (false && err && err.status && err.status === 500) {
+        createMessage({
+          message: t('errorMessage.errorOnSave'),
+          timeToLive: 0,
+        });
       } else {
         applicationError(err);
       }

--- a/src/containers/FormikForm/ndlaFilmFormHooks.ts
+++ b/src/containers/FormikForm/ndlaFilmFormHooks.ts
@@ -8,7 +8,6 @@ import { FormikProps } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IFilmFrontPageData } from '@ndla/types-frontpage-api';
-import { formatErrorMessage } from '../../util/apiHelpers';
 import { getInitialValues } from '../../util/ndlaFilmHelpers';
 import { getNdlaFilmFromSlate } from '../../util/ndlaFilmHelpers';
 import { FilmFormikType } from '../../containers/NdlaFilm/components/NdlaFilmForm';
@@ -22,7 +21,7 @@ export function useNdlaFilmFormHooks(filmFrontpage: IFilmFrontPageData, selected
   const updateFilmFrontpage = useUpdateFilmFrontpageMutation();
 
   const initialValues = getInitialValues(filmFrontpage, selectedLanguage);
-  const { createMessage, applicationError } = useMessages();
+  const { createMessage, applicationError, formatErrorMessage } = useMessages();
 
   const handleSubmit = async (formik: FormikProps<FilmFormikType>) => {
     formik.setSubmitting(true);

--- a/src/containers/Messages/MessagesProvider.tsx
+++ b/src/containers/Messages/MessagesProvider.tsx
@@ -1,6 +1,7 @@
 import { uuid } from '@ndla/util';
 import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
 
+import { useTranslation } from 'react-i18next';
 import { MessageType } from './Messages';
 
 interface Props {
@@ -20,6 +21,7 @@ export interface MessagesFunctions {
 }
 
 export interface MessageError extends Partial<Error> {
+  messages?: string;
   json?: {
     messages?: {
       field: string;
@@ -37,18 +39,47 @@ export const MessagesProvider = ({ children, initialValues = [] }: Props) => {
 
 export const useMessages = () => {
   const context = useContext(MessagesContext);
+  const { t } = useTranslation();
   if (context === undefined) {
     throw new Error('useMessages can only be used witin a MessagesContext');
   }
   const [messages, setMessages] = context;
 
-  const createMessage = (newMessage: NewMessageType) => {
-    const message: MessageType = {
+  const formatNewMessage = (newMessage: NewMessageType): MessageType => {
+    return {
       ...newMessage,
       id: uuid(),
       timeToLive: typeof newMessage.timeToLive === 'undefined' ? 1500 : newMessage.timeToLive,
     };
+  };
+
+  const errorMessageFromError = (error: MessageError): string => {
+    const jsonMessage = error?.json?.messages
+      ?.map(message => `${message.field}: ${message.message}`)
+      .join(', ');
+    if (jsonMessage !== undefined) return jsonMessage;
+
+    const errorMessages = error?.messages;
+    if (errorMessages && typeof errorMessages === 'string') return errorMessages;
+    return t('errorMessage.genericError');
+  };
+
+  const formatErrorMessage = (error: MessageError): NewMessageType => {
+    return {
+      message: errorMessageFromError(error),
+      severity: 'danger',
+      timeToLive: 0,
+    };
+  };
+
+  const createMessage = (newMessage: NewMessageType) => {
+    const message = formatNewMessage(newMessage);
     setMessages(messages => [...messages, message]);
+  };
+
+  const createMessages = (newMessages: NewMessageType[]) => {
+    const formattedMessages = newMessages.map(newMessage => formatNewMessage(newMessage));
+    setMessages(messages => [...messages, ...formattedMessages]);
   };
 
   const applicationError = (error: MessageError) => {
@@ -58,8 +89,14 @@ export const useMessages = () => {
       severity: 'danger',
       timeToLive: 0,
     }));
+
     const newMessages = maybeMessages ?? [];
-    setMessages(prevMessages => [...prevMessages, ...newMessages]);
+
+    if (newMessages.length === 0) {
+      createMessage(formatErrorMessage(error));
+    } else {
+      createMessages(newMessages);
+    }
   };
 
   const clearMessage = (id: string) => setMessages(prev => prev.filter(m => m.id !== id));
@@ -71,5 +108,6 @@ export const useMessages = () => {
     clearMessage,
     clearMessages,
     applicationError,
+    formatErrorMessage,
   };
 };

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1203,6 +1203,8 @@ const phrases = {
       409: 'This article has already been updated. Keep what you have changed and reload the page to save.',
     },
     grepCodes: 'The following codes have wrong format or does not exist, and will not be added: ',
+    errorOnSave: 'Something went wrong when saving the article.',
+    genericError: 'Something went wrong, the action could not be completed.',
   },
   warningMessage: {
     fieldWithWrongLanguage: 'This value is fetched from language code: {{language}}',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1205,6 +1205,8 @@ const phrases = {
       409: 'Denne artikkelen har allerede blitt oppdatert. Ta vare på det du har endret og last siden på nytt for å kunne lagre.',
     },
     grepCodes: 'Følgende koder har feil format eller eksisterer ikke, og vil ikke bli lagt til: ',
+    errorOnSave: 'Noe gikk galt under lagring av artikkelen.',
+    genericError: 'Noe gikk galt, handlingen kunne ikke utføres.',
   },
   warningMessage: {
     fieldWithWrongLanguage: 'Dette feltet er hentet fra språkkode: {{language}}',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1206,7 +1206,7 @@ const phrases = {
     },
     grepCodes: 'Følgande koder har feil format eller eksisterer ikkje, og blir ikkje lagt til: ',
     errorOnSave: 'Noko gjekk gale under lagring av artikkelen.',
-    genericError: 'Noko gjekk gale, handlingen kunne ikke utføres.',
+    genericError: 'Noko gjekk gale, handlinga kunne ikkje utførast.',
   },
   warningMessage: {
     fieldWithWrongLanguage: 'Dette feltet er henta frå språkkode: {{language}}',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1205,6 +1205,8 @@ const phrases = {
       409: 'Denne artikkelen har allerede blitt oppdatert. Ta vare på det du har endra og last sida på nytt for å kunne lagre.',
     },
     grepCodes: 'Følgande koder har feil format eller eksisterer ikkje, og blir ikkje lagt til: ',
+    errorOnSave: 'Noko gjekk gale under lagring av artikkelen.',
+    genericError: 'Noko gjekk gale, handlingen kunne ikke utføres.',
   },
   warningMessage: {
     fieldWithWrongLanguage: 'Dette feltet er henta frå språkkode: {{language}}',

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -7,23 +7,10 @@
  */
 import fetch from 'cross-fetch';
 import queryString from 'query-string';
-import { BrightcoveAccessToken, H5POembed, NdlaError } from '../interfaces';
+import { BrightcoveAccessToken, H5POembed } from '../interfaces';
 import config from '../config';
 import { apiBaseUrl, getAccessToken, isAccessTokenValid, renewAuth } from './authHelpers';
 import { resolveJsonOrRejectWithError, throwErrorPayload } from './resolveJsonOrRejectWithError';
-
-export const formatErrorMessage = (error: {
-  json: {
-    messages?: {
-      field: string;
-      message: string;
-    }[];
-  };
-}): NdlaError => ({
-  message: error?.json?.messages?.map(message => `${message.field}: ${message.message}`).join(', '),
-  severity: 'danger',
-  timeToLive: 0,
-});
 
 export interface HttpHeadersType {
   'Content-Type': string;


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3303

Legger til en ekstra feilmelding i `articleFormHooks` for 500 error.
Legger også til en fallback feilmelding så `applicationError` alltid vil gi en eller annen feilmelding. Enten en som den finner i exceptionen, eller en fallback generisk en om den ikke finner noen.