### PR TITLE
Transform unknown licenses to undefined for initial form values to trigger proper form errors

### DIFF
--- a/src/containers/ArticlePage/articleTransformers.ts
+++ b/src/containers/ArticlePage/articleTransformers.ts
@@ -53,6 +53,8 @@ const draftApiTypeToArticleFormType = (
   articleType: string,
   contentFunc: (html: string) => Descendant[],
 ): ArticleFormType => {
+  const license = article?.copyright?.license?.license;
+  const articleLicense = !license || license === 'unknown' ? DEFAULT_LICENSE.license : license;
   return {
     agreementId: article?.copyright?.agreementId,
     articleType,
@@ -61,7 +63,7 @@ const draftApiTypeToArticleFormType = (
     id: article?.id,
     introduction: plainTextToEditorValue(article?.introduction?.introduction ?? ''),
     language,
-    license: article?.copyright?.license?.license ?? DEFAULT_LICENSE.license,
+    license: articleLicense,
     metaDescription: plainTextToEditorValue(article?.metaDescription?.metaDescription ?? ''),
     metaImageAlt: article?.metaImage?.alt ?? '',
     metaImageId: parseImageUrl(article?.metaImage),

--- a/src/containers/ConceptPage/conceptTransformers.ts
+++ b/src/containers/ConceptPage/conceptTransformers.ts
@@ -27,6 +27,9 @@ export const conceptApiTypeToFormType = (
   initialTitle = '',
 ): ConceptFormValues => {
   const conceptSubjects = subjects.filter(s => concept?.subjectIds?.find(id => id === s.id)) ?? [];
+  const license = concept?.copyright?.license?.license;
+  const conceptLicense = license === 'unknown' ? undefined : license;
+
   // Make sure to omit the content field from concept. It will crash Slate.
   return {
     id: concept?.id,
@@ -44,7 +47,7 @@ export const conceptApiTypeToFormType = (
     rightsholders: concept?.copyright?.rightsholders ?? [],
     processors: concept?.copyright?.processors ?? [],
     source: concept?.source ?? '',
-    license: concept?.copyright?.license?.license ?? '',
+    license: conceptLicense,
     metaImageId: parseImageUrl(concept?.metaImage),
     metaImageAlt: concept?.metaImage?.alt ?? '',
     tags: concept?.tags?.tags ?? [],

--- a/src/containers/ImageUploader/imageTransformers.ts
+++ b/src/containers/ImageUploader/imageTransformers.ts
@@ -47,7 +47,8 @@ export const imageApiTypeToFormType = (
     processors: image?.copyright.processors ?? [],
     rightsholders: image?.copyright.rightsholders ?? [],
     origin: image?.copyright.origin ?? '',
-    license: image?.copyright.license.license,
+    license:
+      image?.copyright.license.license !== 'unknown' ? image?.copyright.license.license : undefined,
     modelReleased: image?.modelRelease ?? 'not-set',
     contentType: image?.image.contentType,
     fileSize: image?.image.size,

--- a/src/util/audioHelpers.ts
+++ b/src/util/audioHelpers.ts
@@ -23,6 +23,8 @@ export const audioApiTypeToFormType = (
     rightsholders: [],
     license: DEFAULT_LICENSE,
   };
+  const license = audio?.copyright.license.license;
+  const audioLicense = !license || license === 'unknown' ? DEFAULT_LICENSE.license : license;
 
   return {
     ...audio,
@@ -31,7 +33,7 @@ export const audioApiTypeToFormType = (
     tags: audio?.tags.tags ?? [],
     ...copyright,
     origin: audio?.copyright.origin ?? '',
-    license: audio?.copyright?.license?.license || DEFAULT_LICENSE.license,
+    license: audioLicense,
     audioFile: audio?.audioFile ? { storedFile: audio.audioFile } : {},
     language,
     supportedLanguages: audio?.supportedLanguages ?? [language],


### PR DESCRIPTION
Gamle bilder kunne lagres uten å ha satt en lisenstype. Da returnerer backenden de som "unknown". Skjemaet tolker dette som at en verdi er satt, og velger automatisk den første lisensen når den ikke finner "unknown". Denne PR'en sørger for at unknown ikke settes som default-verdi.