### PR TITLE
Remove svg titles to avoid 'double tooltip' for svgs

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -172,13 +172,13 @@ const HeaderStatusInformation = ({
 
   const multipleTaxonomyIcon = taxonomyPaths && taxonomyPaths?.length > 2 && (
     <Tooltip tooltip={t('form.workflow.multipleTaxonomy')}>
-      <StyledWarnIcon title={t('form.taxonomySection')} />
+      <StyledWarnIcon />
     </Tooltip>
   );
 
   const publishedIcon = (
     <Tooltip tooltip={t('form.workflow.published')}>
-      <StyledCheckIcon title={t('form.status.published')} />
+      <StyledCheckIcon />
     </Tooltip>
   );
 


### PR DESCRIPTION
Kan testes ved å se at "publisert" ikke lenger legger seg over tooltip dersom man holder over publisert-ikonet i et skjema for lenge.