### PR TITLE
Added url transformer for Jeopardylabs

### DIFF
--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -188,6 +188,27 @@ const sketcfabTransformer: UrlTransformer = {
   },
 };
 
+const jeopardyLabTransformer: UrlTransformer = {
+  domains: ['jeopardylabs.com'],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    if (!aTag.href.includes('/play/')) {
+      return false;
+    }
+    return true;
+  },
+  transform: async url => {
+    if (url.endsWith('?embed=1')) {
+      return url;
+    }
+    return url.concat('?embed=1');
+  },
+};
+
 export const urlTransformers: UrlTransformer[] = [
   nrkTransformer,
   kahootTransformer,
@@ -196,4 +217,5 @@ export const urlTransformers: UrlTransformer[] = [
   flourishTransformer,
   sketchupTransformer,
   sketcfabTransformer,
+  jeopardyLabTransformer,
 ];


### PR DESCRIPTION
La til automatisk transformering til embed av Jeopardylabs url'er. 


Sikkert ikke den fineste måten, kan virke irriterende når brukerne prøver å slette deler av `?embed=1` så vil det trigge en rerender som appender en ny `?embed=1` på slutten. Vil ikke breake linken da siste query vil ta presedens.   En løsning kan være å skrive om til regex matching på deler av stringen men ser ikke helt behovet om det ikke blir veldig irriterende for brukerne. 