### PR TITLE
Patch: make diff work with old taxonomy

### DIFF
--- a/src/containers/NodeDiff/NodeDiff.tsx
+++ b/src/containers/NodeDiff/NodeDiff.tsx
@@ -232,7 +232,7 @@ const NodeDiff = ({ node, isRoot }: Props) => {
 };
 
 interface ResourceDiffListProps {
-  resources?: DiffType<ChildNodeType>[];
+  resources?: DiffType<ResourceWithNodeConnection>[];
   fieldFilter: string;
 }
 
@@ -254,7 +254,7 @@ const ResourceDiffList = ({ resources, fieldFilter }: ResourceDiffListProps) => 
 };
 
 interface ResourceDiffProps {
-  resource: DiffType<ChildNodeType>;
+  resource: DiffType<ResourceWithNodeConnection>;
   fieldView: string;
 }
 
@@ -288,7 +288,9 @@ const ResourceDiff = ({ resource, fieldView }: ResourceDiffProps) => {
         )}
         {res.id && <FieldDiff fieldName="id" result={res.id} toDisplayValue={v => v} />}
         {res.name && <FieldDiff fieldName="name" result={res.name} toDisplayValue={v => v} />}
-        {res.parent && <FieldDiff fieldName="parent" result={res.parent} toDisplayValue={v => v} />}
+        {res.parentId && (
+          <FieldDiff fieldName="parent" result={res.parentId} toDisplayValue={v => v} />
+        )}
         {res.primary && (
           <FieldDiff
             fieldName="primary"

--- a/src/containers/NodeDiff/__tests__/diffTestData.ts
+++ b/src/containers/NodeDiff/__tests__/diffTestData.ts
@@ -2091,7 +2091,7 @@ export const nodeTreeWithNestedChildrenAndResources: NodeTree = {
             },
           ],
           supportedLanguages: ['nb', 'nn'],
-          parent: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
+          parentId: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
           connectionId: 'urn:topic-resource:4e8305fa-7aac-4c08-97dc-9630becdb83a',
           rank: 2,
           primary: true,
@@ -2299,7 +2299,7 @@ export const nodeTreeWithNestedChildrenAndResourcesUpdated: NodeTree = {
             },
           ],
           supportedLanguages: ['nb', 'nn'],
-          parent: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
+          parentId: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
           connectionId: 'urn:topic-resource:4e8305fa-7aac-4c08-97dc-9630becdb83a',
           rank: 2,
           primary: true,
@@ -2817,7 +2817,7 @@ export const nodeTreeWithNestedChildrenAndResourcesDiff: DiffTree = {
                 other: ['nb', 'nn'],
                 diffType: 'NONE',
               },
-              parent: {
+              parentId: {
                 original: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
                 other: 'urn:topic:1:35efa357-acc7-4828-b241-cad5467d1dc6',
                 diffType: 'NONE',

--- a/src/containers/NodeDiff/diffUtils.ts
+++ b/src/containers/NodeDiff/diffUtils.ts
@@ -51,11 +51,11 @@ export interface NodeTree {
 }
 
 export interface NodeTypeWithResources extends NodeType {
-  resources: ChildNodeType[];
+  resources: ResourceWithNodeConnection[];
 }
 
 export interface ChildNodeTypeWithResources extends ChildNodeType {
-  resources: ChildNodeType[];
+  resources: ResourceWithNodeConnection[];
 }
 
 type TagType = 'original' | 'other';
@@ -72,11 +72,11 @@ interface Grouping<T> {
 
 export interface DiffTypeWithChildren extends DiffType<Omit<ChildNodeType, 'resources'>> {
   children?: DiffTypeWithChildren[];
-  resources?: DiffType<ChildNodeType>[];
+  resources?: DiffType<ResourceWithNodeConnection>[];
 }
 
 export interface RootDiffType extends DiffType<Omit<NodeTypeWithResources, 'resources'>> {
-  resources?: DiffType<ChildNodeType>[];
+  resources?: DiffType<ResourceWithNodeConnection>[];
 }
 
 const diffAndGroupChildren = <T extends NodeType = NodeType>(

--- a/src/modules/nodes/nodeApiTypes.ts
+++ b/src/modules/nodes/nodeApiTypes.ts
@@ -87,6 +87,7 @@ export interface ResourceWithNodeConnection {
   translations: NodeTranslation[];
   supportedLanguages: string[];
   nodeType: NodeTypeValue;
+  isPrimary?: boolean;
   resourceTypes: {
     id: string;
     name: string;

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -217,22 +217,22 @@ const fetchNodeTree = async ({
   language,
   taxonomyVersion,
 }: NodeTreeGetParams): Promise<NodeTree> => {
-  const [root, children] = await Promise.all([
+  const [root, children, allResources] = await Promise.all([
     fetchNode({ id, language, taxonomyVersion }),
     fetchChildNodesWithArticleType({ id, language, taxonomyVersion }),
+    fetchNodeResources({ id, language, taxonomyVersion, recursive: true }),
   ]);
 
   const rootFromChildren: ChildNodeType | undefined = children.find(child => child.id === id);
   const childOrRegularRoot = rootFromChildren ?? root;
-  const allResources = children.filter(n => n.nodeType === RESOURCE_NODE);
-  const resourcesForNodeIdMap = allResources.reduce<Record<string, ChildNodeType[]>>(
+  const resourcesForNodeIdMap = allResources.reduce<Record<string, ResourceWithNodeConnection[]>>(
     (acc, curr) => {
-      if (!curr.parent) return acc;
+      if (!curr.parentId) return acc;
 
-      if (acc[curr.parent]) {
-        acc[curr.parent] = acc[curr.parent].concat([curr]);
+      if (acc[curr.parentId]) {
+        acc[curr.parentId] = acc[curr.parentId].concat([curr]);
       } else {
-        acc[curr.parent] = [curr];
+        acc[curr.parentId] = [curr];
       }
 
       return acc;


### PR DESCRIPTION
Patch for å fikse diff mot gammel taksonomi. Denne skal også fungere med ny, men pr treng ikkje merges. Lager heller en anna pr på det.

Må testes mot staging eller prod for å sjekke at endringer i ressurser dukker opp. Branchen er basert på versjonen i prod.