### PR TITLE
Ignoring comma separeted lists in taxonomyquery for savedsearch

### DIFF
--- a/src/containers/WelcomePage/hooks/savedSearchHook.ts
+++ b/src/containers/WelcomePage/hooks/savedSearchHook.ts
@@ -39,7 +39,7 @@ export const useSavedSearchUrl = (
   const searchHook = getSearchHookFromType(searchObject['type']);
   const { data: subjectData, isLoading: subjectLoading } = useSubject(
     { id: subject, language: locale, taxonomyVersion },
-    { enabled: !!subject },
+    { enabled: !!subject && !subject.includes(',') },
   );
   const { data: resourceTypeData, isLoading: resourceTypeLoading } = useResourceType(
     { id: resourceType, language: locale, taxonomyVersion },


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3431

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/35299038/217583606-95cece35-5315-4c2f-9682-ff8427487138.png">
Gjør dette kallet conditional på om subjects inneholder `,` eller ikke, om den har komma vil den ikke fungere og vil da være søket `Mine favoritter`.  
