### PR TITLE
Automatically fetch meta data and update resource list when adding a new resource

### DIFF
--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -252,13 +252,20 @@ const Resource = ({ resource, onDelete, dragHandleProps, currentNodeId }: Props)
     setShowGrepCodes(false);
     if (!newGrepCodes || isEqual(newGrepCodes, resource.contentMeta?.grepCodes)) return;
     const compKey = nodeResourceMetasQueryKey({ nodeId: currentNodeId, language: i18n.language });
-    const metas = qc.getQueryData<NodeResourceMeta[]>(compKey) ?? [];
-    const newMetas = metas.map(meta =>
-      meta.contentUri === resource.contentMeta?.contentUri
-        ? { ...meta, grepCodes: newGrepCodes }
-        : meta,
+    qc.setQueriesData<NodeResourceMeta[]>(
+      {
+        queryKey: compKey,
+      },
+      data => {
+        return (
+          data?.map(meta =>
+            meta.contentUri === resource.contentMeta?.contentUri
+              ? { ...meta, grepCodes: newGrepCodes }
+              : meta,
+          ) ?? []
+        );
+      },
     );
-    qc.setQueryData(compKey, newMetas);
     qc.cancelQueries(compKey);
     await qc.invalidateQueries(compKey);
   };

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -86,10 +86,7 @@ export interface NodeResourceMeta {
 
 export const nodeResourceMetasQueryKey = (params: Partial<UseNodeResourceMetas>) => [
   NODE_RESOURCES,
-  {
-    nodeId: params.nodeId,
-    language: params.language,
-  },
+  params,
 ];
 
 export const useNodeResourceMetas = (


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3421

Dette tvinger frem noen hundre milisekunder med rød statustekst, men det er vanskelig å fikse opp i uten videre. Kan testes ved å legge til en ressurs på et emne, og se at metadata hentes automatisk.