### PR TITLE
Bug fix: calculation number approacing revision date 

### DIFF
--- a/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
+++ b/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
@@ -16,6 +16,7 @@ import Tooltip from '@ndla/tooltip';
 import { useTranslation } from 'react-i18next';
 import { fetchDrafts } from '../../../modules/draft/draftApi';
 import handleError from '../../../util/handleError';
+import { getExpirationDate } from '../../ArticlePage/articleTransformers';
 
 const StyledWrapper = styled.div`
   color: ${colors.white};
@@ -49,9 +50,13 @@ interface Props {
 }
 
 export const getCountApproachingRevision = (articles: IArticle[]) => {
+  const expirationDates = articles
+    .map(a => getExpirationDate({ revisions: a.revisions }))
+    .filter(r => !!r);
+
   const currentDateAddYear = addYears(new Date(), 1);
-  const countApproachingRevision = articles.filter(a =>
-    isBefore(new Date(a?.revisions?.[0]?.revisionDate), currentDateAddYear),
+  const countApproachingRevision = expirationDates.filter(a =>
+    isBefore(new Date(a!), currentDateAddYear),
   ).length;
   return countApproachingRevision;
 };


### PR DESCRIPTION
Bug fix der alle revision-dates blir tatt høyde for og ikke bare første i lista når antall som nærmer seg revisjonsdato regnes ut.

![Skjermbilde 2023-02-17 kl  16 01 57](https://user-images.githubusercontent.com/26788204/219689908-98f3a7d1-2cc7-4f6b-8aa3-afffbacf6f8a.png)
