### PR TITLE
Writeable field below visualelementpciker

### DIFF
--- a/src/components/SlateEditor/VisualElementEditor.tsx
+++ b/src/components/SlateEditor/VisualElementEditor.tsx
@@ -67,7 +67,7 @@ const VisualElementEditor = ({ name, value, plugins, onChange, types, language }
         }}>
         <VisualElementPicker editor={editor} types={types} language={language} />
         <Editable
-          readOnly={false}
+          readOnly={true}
           renderElement={renderElement}
           onDragStart={e => {
             e.stopPropagation();


### PR DESCRIPTION
Er et tryktbar felt under visueltelement picker. Editor var satt til `readOnly=false` ved å bytte til true ble buggen borte og funksjonaliteten vedvarer. 

Måte å teste:
Gå inn på en emne artikkel og prøv å trykke under visueltelement picker, dette skal da ikke fungere. 