### PR TITLE
Bug fix: Accordion toggle all

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -33,6 +33,7 @@ import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
 import { blockContentToHTML } from '../../../../util/articleContentConverter';
 import { DraftStatusType } from '../../../../interfaces';
 import StyledForm from '../../../../components/StyledFormComponents';
+import { TaxonomyVersionProvider } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   article?: IArticle;
@@ -110,14 +111,16 @@ const LearningResourceForm = ({
           type="standard"
           expirationDate={getExpirationDate(article)}
         />
-        <LearningResourcePanels
-          articleLanguage={articleLanguage}
-          article={article}
-          taxonomy={articleTaxonomy}
-          updateNotes={updateArticle}
-          getArticle={getArticle}
-          handleSubmit={handleSubmit}
-        />
+        <TaxonomyVersionProvider>
+          <LearningResourcePanels
+            articleLanguage={articleLanguage}
+            article={article}
+            taxonomy={articleTaxonomy}
+            updateNotes={updateArticle}
+            getArticle={getArticle}
+            handleSubmit={handleSubmit}
+          />
+        </TaxonomyVersionProvider>
         <EditorFooter
           showSimpleFooter={!article}
           formIsDirty={formIsDirty}

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -21,7 +21,6 @@ import { LearningResourceFormType } from '../../../FormikForm/articleFormHooks';
 import { useSession } from '../../../Session/SessionProvider';
 import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
 import RevisionNotes from '../../components/RevisionNotes';
-import { TaxonomyVersionProvider } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   handleSubmit: (
@@ -65,18 +64,16 @@ const LearningResourcePanels = ({
         />
       </AccordionSection>
       {article && taxonomy && !!userPermissions?.includes(TAXONOMY_WRITE_SCOPE) && (
-        <TaxonomyVersionProvider>
-          <AccordionSection
-            id={'learning-resource-taxonomy'}
-            title={t('form.taxonomySection')}
-            className={'u-6/6'}>
-            <LearningResourceTaxonomy
-              article={article}
-              updateNotes={updateNotes}
-              taxonomy={taxonomy}
-            />
-          </AccordionSection>
-        </TaxonomyVersionProvider>
+        <AccordionSection
+          id={'learning-resource-taxonomy'}
+          title={t('form.taxonomySection')}
+          className={'u-6/6'}>
+          <LearningResourceTaxonomy
+            article={article}
+            updateNotes={updateNotes}
+            taxonomy={taxonomy}
+          />
+        </AccordionSection>
       )}
       <AccordionSection
         id={'learning-resource-copyright'}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -22,7 +22,6 @@ import { useSession } from '../../../Session/SessionProvider';
 import { onSaveAsVisualElement } from '../../../FormikForm/utils';
 import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
 import RevisionNotes from '../../components/RevisionNotes';
-import { TaxonomyVersionProvider } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   handleSubmit: () => Promise<void>;
@@ -56,14 +55,12 @@ const TopicArticleAccordionPanels = ({
         <TopicArticleContent handleSubmit={handleSubmit} values={values} />
       </AccordionSection>
       {article && taxonomy && !!userPermissions?.includes(TAXONOMY_WRITE_SCOPE) && (
-        <TaxonomyVersionProvider>
-          <AccordionSection
-            id={'topic-article-taxonomy'}
-            title={t('form.taxonomySection')}
-            className={'u-6/6'}>
-            <TopicArticleTaxonomy article={article} updateNotes={updateNotes} taxonomy={taxonomy} />
-          </AccordionSection>
-        </TaxonomyVersionProvider>
+        <AccordionSection
+          id={'topic-article-taxonomy'}
+          title={t('form.taxonomySection')}
+          className={'u-6/6'}>
+          <TopicArticleTaxonomy article={article} updateNotes={updateNotes} taxonomy={taxonomy} />
+        </AccordionSection>
       )}
       <AccordionSection
         id={'topic-article-copyright'}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -31,6 +31,7 @@ import { ArticleTaxonomy } from '../../../FormikForm/formikDraftHooks';
 import { blockContentToHTML } from '../../../../util/articleContentConverter';
 import { DraftStatusType } from '../../../../interfaces';
 import StyledForm from '../../../../components/StyledFormComponents';
+import { TaxonomyVersionProvider } from '../../../StructureVersion/TaxonomyVersionProvider';
 
 interface Props {
   article?: IArticle;
@@ -114,14 +115,16 @@ const TopicArticleForm = ({
           type="topic-article"
           expirationDate={getExpirationDate(article)}
         />
-        <TopicArticleAccordionPanels
-          taxonomy={articleTaxonomy}
-          articleLanguage={articleLanguage}
-          updateNotes={updateArticle}
-          article={article}
-          getArticle={getArticle}
-          handleSubmit={async () => handleSubmit(values, formik)}
-        />
+        <TaxonomyVersionProvider>
+          <TopicArticleAccordionPanels
+            taxonomy={articleTaxonomy}
+            articleLanguage={articleLanguage}
+            updateNotes={updateArticle}
+            article={article}
+            getArticle={getArticle}
+            handleSubmit={async () => handleSubmit(values, formik)}
+          />
+        </TaxonomyVersionProvider>
         <EditorFooter
           showSimpleFooter={!article?.id}
           formIsDirty={formIsDirty}


### PR DESCRIPTION
Fikser toggle all funksjonalitet av accordions på artikkel-redigerings-siden. Funksjonaliteten kommer fra Accordions-komponenten i frontend-packages, så løsningen ble å wrappe `TaxonomyVersionProvider` noen nivåer høyere opp