### PR TITLE
Bruker image-dimensions for å validere podkastbilde.

### DIFF
--- a/src/containers/FormikForm/MetaImageSearch.tsx
+++ b/src/containers/FormikForm/MetaImageSearch.tsx
@@ -31,7 +31,7 @@ interface Props {
   onChange: FormikHandlers['handleChange'];
   name: string;
   setFieldTouched: (field: string, isTouched?: boolean, shouldValidate?: boolean) => void;
-  onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
+  onImageLoad?: (width: number, height: number) => void;
   showRemoveButton: boolean;
   showCheckbox: boolean;
   checkboxAction: (image: IImageMetaInformationV3) => void;

--- a/src/containers/FormikForm/components/MetaImageField.tsx
+++ b/src/containers/FormikForm/components/MetaImageField.tsx
@@ -34,7 +34,7 @@ interface Props {
   onImageSelectOpen: () => void;
   onImageRemove: () => void;
   showRemoveButton: boolean;
-  onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
+  onImageLoad?: (width: number, height: number) => void;
 }
 
 const MetaImageField = ({ image, onImageRemove, onImageLoad }: Props) => {
@@ -71,10 +71,15 @@ const MetaImageField = ({ image, onImageRemove, onImageLoad }: Props) => {
     title: t('form.metaImage.imageTitle'),
     copyright: t('form.metaImage.copyright'),
   };
+  const imageUrl = `${image.image.imageUrl}?width=400`;
+  const { width, height } = image.image?.dimensions || { width: 0, height: 0 };
+  const onLoad = (_: SyntheticEvent<HTMLImageElement, Event>) => {
+    onImageLoad?.(width, height);
+  };
   return (
     <>
       <MetaImageContainer>
-        <StyledImage src={image.image.imageUrl} alt={alt} onLoad={onImageLoad} />
+        <StyledImage src={imageUrl} alt={alt} onLoad={onLoad} />
         <MetaInformation
           title={title}
           copyright={copyright}

--- a/src/containers/ImageUploader/components/ImageContent.tsx
+++ b/src/containers/ImageUploader/components/ImageContent.tsx
@@ -44,7 +44,7 @@ const ImageContent = ({ formik }: Props) => {
 
   // We use the timestamp to avoid caching of the `imageFile` url in the browser
   const timestamp = new Date().getTime();
-  const imgSrc = values.filepath || `${values.imageFile}?ts=${timestamp}`;
+  const imgSrc = values.filepath || `${values.imageFile}?width=600&ts=${timestamp}`;
   return (
     <>
       <TitleField handleSubmit={submitForm} />

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -273,11 +273,8 @@ const PodcastForm = ({
                   )}>
                   <PodcastMetaData
                     language={language}
-                    onImageLoad={el => {
-                      size.current = [
-                        el.currentTarget.naturalWidth,
-                        el.currentTarget.naturalHeight,
-                      ];
+                    onImageLoad={(width, height) => {
+                      size.current = [width, height];
                       validateForm();
                     }}
                   />

--- a/src/containers/Podcast/components/PodcastMetaData.tsx
+++ b/src/containers/Podcast/components/PodcastMetaData.tsx
@@ -16,7 +16,7 @@ import { MetaImageSearch } from '../../FormikForm';
 
 interface Props {
   language?: string;
-  onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
+  onImageLoad?: (width: number, height: number) => void;
 }
 
 const plugins = [textTransformPlugin];

--- a/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
@@ -193,8 +193,8 @@ const PodcastSeriesForm = ({
                 hasError={['title', 'coverPhotoId', 'metaImageAlt'].some(field => field in errors)}>
                 <PodcastSeriesMetaData
                   language={language}
-                  onImageLoad={el => {
-                    size.current = [el.currentTarget.naturalWidth, el.currentTarget.naturalHeight];
+                  onImageLoad={(width, height) => {
+                    size.current = [width, height];
                     validateForm();
                   }}
                 />

--- a/src/containers/PodcastSeries/components/PodcastSeriesMetaData.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesMetaData.tsx
@@ -18,7 +18,7 @@ import { textTransformPlugin } from '../../../components/SlateEditor/plugins/tex
 
 interface Props {
   language?: string;
-  onImageLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
+  onImageLoad?: (width: number, height: number) => void;
 }
 
 const PodcastSeriesMetaData = ({ language, onImageLoad }: Props) => {


### PR DESCRIPTION
Problemet her var at om eg satte width på henting av bilde, så blei valideringa feil fordi bildet som blei henta var mindre enn faktisk størrelse. Dette sjekker dimensjonene som er lagra og ikkje størrelsen på bildet som hentes.

Viser også litt mindre bilder i ed. Trenger ikkje vise full størrelse i skjema.