### PR TITLE
Rewrite h5p view to use modal v2

### DIFF
--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
@@ -32,17 +32,14 @@ const DisplayExternalModal = ({
       resource={allowedProvider.name.toLowerCase()}
       isOpen={isEditMode}
       onClose={onClose}>
-      {setH5pFetchFail => (
-        <VisualElementSearch
-          selectedResource={allowedProvider.name}
-          selectedResourceUrl={src}
-          selectedResourceType={type}
-          handleVisualElementChange={rt => (rt.type === 'ndlaembed' ? onEditEmbed(rt.value) : null)}
-          closeModal={onClose}
-          embed={embed}
-          setH5pFetchFail={setH5pFetchFail}
-        />
-      )}
+      <VisualElementSearch
+        selectedResource={allowedProvider.name}
+        selectedResourceUrl={src}
+        selectedResourceType={type}
+        handleVisualElementChange={rt => (rt.type === 'ndlaembed' ? onEditEmbed(rt.value) : null)}
+        closeModal={onClose}
+        embed={embed}
+      />
     </VisualElementModalWrapper>
   );
 };

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -14,7 +14,6 @@ import handleError from '../../util/handleError';
 import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PMetadata } from './h5pApi';
 
 const FlexWrapper = styled.div`
-  height: 100%;
   width: 100%;
 `;
 
@@ -45,14 +44,7 @@ interface MessageEvent extends Event {
   };
 }
 
-const H5PElement = ({
-  h5pUrl,
-  onSelect,
-  onClose,
-  locale,
-  canReturnResources,
-  setH5pFetchFail,
-}: Props) => {
+const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: Props) => {
   const { t } = useTranslation();
   const [url, setUrl] = useState<string>('');
   const [fetchFailed, setFetchFailed] = useState<boolean>(false);
@@ -64,7 +56,6 @@ const H5PElement = ({
       fetchAndSetH5PUrl();
     } catch (e) {
       setFetchFailed(true);
-      setH5pFetchFail && setH5pFetchFail(true);
     }
 
     return () => {

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -15,6 +15,7 @@ import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PMetadata } from './h5pApi'
 
 const FlexWrapper = styled.div`
   width: 100%;
+  height: 100%;
 `;
 
 const StyledIFrame = styled.iframe`

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
@@ -84,17 +84,14 @@ const SlateVisualElementPicker = ({
       resource={resource}
       isOpen
       onClose={onVisualElementClose}>
-      {setH5pFetchFail => (
-        <VisualElementSearch
-          articleLanguage={articleLanguage}
-          selectedResource={resource}
-          handleVisualElementChange={onVisualElementAdd}
-          closeModal={onVisualElementClose}
-          setH5pFetchFail={setH5pFetchFail}
-          showCheckbox={showCheckbox}
-          checkboxAction={(image: IImageMetaInformationV3) => checkboxAction(image, formikContext)}
-        />
-      )}
+      <VisualElementSearch
+        articleLanguage={articleLanguage}
+        selectedResource={resource}
+        handleVisualElementChange={onVisualElementAdd}
+        closeModal={onVisualElementClose}
+        showCheckbox={showCheckbox}
+        checkboxAction={(image: IImageMetaInformationV3) => checkboxAction(image, formikContext)}
+      />
     </VisualElementModalWrapper>
   );
 };

--- a/src/containers/VisualElement/VisualElementModalWrapper.tsx
+++ b/src/containers/VisualElement/VisualElementModalWrapper.tsx
@@ -1,25 +1,25 @@
 import { useTranslation } from 'react-i18next';
-import { ReactElement, useState } from 'react';
-
-import { css } from '@emotion/react';
+import { ReactElement } from 'react';
 import styled from '@emotion/styled';
-import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
-import Lightbox from '../../components/Lightbox';
+import { ModalHeader, ModalBody, ModalCloseButton, ModalV2 } from '@ndla/modal';
 
 interface Props {
   resource: string;
   onClose: () => void;
   isOpen: boolean;
-  children: (setH5pFetchFail: (failed: boolean) => void) => ReactElement;
+  children: ReactElement;
   label?: string;
 }
 
-const h5pContentCss = css`
+const StyledModal = styled(ModalV2)`
   padding: 0;
+  width: 100%;
+  height: 100%;
+  max-height: 95%;
+  overflow: hidden;
 `;
 
-const StyledVisualElementModal = styled(Modal)`
-  overflow: hidden;
+const StyledVisualElementModal = styled(ModalV2)`
   .modal-body {
     height: 90%;
     h2 {
@@ -28,37 +28,34 @@ const StyledVisualElementModal = styled(Modal)`
   }
 `;
 
+const StyledModalBody = styled.div`
+  display: flex;
+  flex: 1;
+`;
+
 const VisualElementModalWrapper = ({ resource, children, onClose, isOpen, label }: Props) => {
   const { t } = useTranslation();
-  const [h5pFetchFail, setH5pFetchFail] = useState(false);
 
   if (resource === 'h5p') {
     return (
-      <Lightbox
-        display={isOpen}
-        appearance={'fullscreen'}
-        onClose={onClose}
-        hideCloseButton={!h5pFetchFail}
-        contentCss={!h5pFetchFail ? h5pContentCss : undefined}>
-        {children(setH5pFetchFail)}
-      </Lightbox>
+      <StyledModal controlled isOpen={isOpen} size="large" onClose={onClose}>
+        {_ => <StyledModalBody>{children}</StyledModalBody>}
+      </StyledModal>
     );
   }
   return (
     <StyledVisualElementModal
+      controlled
       label={label}
-      narrow
-      controllable
       isOpen={isOpen}
       size="large"
-      backgroundColor="white"
       onClose={onClose}>
       {(onCloseModal: () => void) => (
         <>
           <ModalHeader>
             <ModalCloseButton title={t('dialog.close')} onClick={onCloseModal} />
           </ModalHeader>
-          <ModalBody>{children(setH5pFetchFail)}</ModalBody>
+          <ModalBody>{children}</ModalBody>
         </>
       )}
     </StyledVisualElementModal>

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -41,7 +41,6 @@ interface Props {
   selectedResource: string;
   selectedResourceUrl?: string;
   selectedResourceType?: string;
-  setH5pFetchFail?: (failed: boolean) => void;
   handleVisualElementChange: (returnType: VisualElementChangeReturnType) => void;
   articleLanguage?: string;
   closeModal: () => void;
@@ -73,7 +72,6 @@ const VisualElementSearch = ({
   selectedResource,
   selectedResourceUrl,
   selectedResourceType,
-  setH5pFetchFail,
   handleVisualElementChange,
   articleLanguage,
   closeModal,
@@ -178,7 +176,6 @@ const VisualElementSearch = ({
           }
           onClose={closeModal}
           locale={articleLanguage ?? locale}
-          setH5pFetchFail={setH5pFetchFail}
         />
       );
     }


### PR DESCRIPTION
Fjerner også litt error-håndtering som fjernet litt styling og skjuler lukkeknapp, da man kan lukke ModalV2 både ved esc og ved å klikke utenfor modalen.