### PR TITLE
Enable node resource meta query when no resources are available, but the child node has a contentUri

### DIFF
--- a/src/containers/StructurePage/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePage/resourceComponents/StructureResources.tsx
@@ -88,7 +88,7 @@ const StructureResources = ({ currentChildNode, resourceRef, setCurrentNode }: P
           .filter<string>((uri): uri is string => !!uri) ?? [],
       language: i18n.language,
     },
-    { enabled: !!nodeResources?.length },
+    { enabled: !!currentChildNode.contentUri || !!nodeResources?.length },
   );
 
   const keyedMetas = keyBy(nodeResourceMetas, m => m.contentUri);


### PR DESCRIPTION
Fikser kanskje til og med https://github.com/NDLANO/Issues/issues/3407?

Kan testes ved å sammenligne https://ed.test.ndla.no/structure/urn:subject:b1c2d3e8-4f32-4a00-9291-d944602842b6/urn:topic:890be79b-0b35-4783-b891-723519a56abb/urn:topic:1f2172af-0d33-4be4-9550-1b24605e07fb på test og i PR-instansen.