### PR TITLE
Reuse existing data instead of fetching new for structure resources

### DIFF
--- a/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
+++ b/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
@@ -6,17 +6,16 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import styled from '@emotion/styled';
 import addYears from 'date-fns/addYears';
 import isBefore from 'date-fns/isBefore';
-import { IArticle } from '@ndla/types-draft-api';
+import { IRevisionMeta } from '@ndla/types-draft-api';
 import Tooltip from '@ndla/tooltip';
 import { useTranslation } from 'react-i18next';
 import { Time } from '@ndla/icons/common';
-import { fetchDrafts } from '../../../modules/draft/draftApi';
-import handleError from '../../../util/handleError';
 import { getExpirationDate } from '../../ArticlePage/articleTransformers';
+import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
 
 const Wrapper = styled.div`
   width: 24px;
@@ -61,37 +60,27 @@ export const RevisionDateIcon = ({ text, phrasesKey }: RevisionDateProps) => {
 };
 
 interface Props {
-  articleIds?: number[];
+  resources: ResourceWithNodeConnectionAndMeta[];
 }
 
-export const getCountApproachingRevision = (articles: IArticle[]) => {
-  const expirationDates = articles
-    .map(a => getExpirationDate({ revisions: a.revisions }))
-    .filter(r => !!r);
-
+export const isApproachingRevision = (revisions?: IRevisionMeta[]) => {
+  if (!revisions?.length) return false;
+  const expirationDate = getExpirationDate({ revisions: revisions });
+  if (!expirationDate) return false;
   const currentDateAddYear = addYears(new Date(), 1);
-  const countApproachingRevision = expirationDates.filter(a =>
-    isBefore(new Date(a!), currentDateAddYear),
-  ).length;
-  return countApproachingRevision;
+  return isBefore(new Date(expirationDate), currentDateAddYear);
 };
 
-const ApproachingRevisionDate = ({ articleIds = [] }: Props) => {
-  const [count, setCount] = useState<number>(0);
-  useEffect(() => {
-    (async () => {
-      try {
-        const drafts = await fetchDrafts(articleIds);
-        const count = getCountApproachingRevision(drafts ?? []);
+const ApproachingRevisionDate = ({ resources }: Props) => {
+  const approachingRevision = useMemo(
+    () =>
+      resources.map(r => isApproachingRevision(r.contentMeta?.revisions)).filter(a => !!a).length,
+    [resources],
+  );
 
-        setCount(count);
-      } catch (e) {
-        handleError(e);
-      }
-    })();
-  }, [articleIds]);
-
-  return <RevisionDateIcon text={count} phrasesKey={'form.responsible.revisionDate'} />;
+  return (
+    <RevisionDateIcon text={approachingRevision} phrasesKey={'form.responsible.revisionDate'} />
+  );
 };
 
 export default ApproachingRevisionDate;

--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -26,13 +25,11 @@ import {
   useUpdateNodeConnectionMutation,
 } from '../../../modules/nodes/nodeMutations';
 import { getContentTypeFromResourceTypes } from '../../../util/resourceHelpers';
-import { getIdFromUrn } from '../../../util/taxonomyHelpers';
 import RelevanceOption from '../../../components/Taxonomy/RelevanceOption';
 import ResourceItemLink from './ResourceItemLink';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 import { resourcesWithNodeConnectionQueryKey } from '../../../modules/nodes/nodeQueries';
 import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
-import { useDraft, useResponsibleUserData } from '../../../modules/draft/draftQueries';
 import StatusIcons from './StatusIcons';
 import GrepCodesModal from './GrepCodesModal';
 import VersionHistory from './VersionHistory';
@@ -125,6 +122,7 @@ interface Props {
   currentNodeId: string;
   connectionId?: string; // required for MakeDndList, otherwise ignored
   id?: string; // required for MakeDndList, otherwise ignored
+  responsible?: string;
   resource: ResourceWithNodeConnectionAndMeta;
   onDelete?: (connectionId: string) => void;
   updateResource?: (resource: ResourceWithNodeConnection) => void;
@@ -138,6 +136,7 @@ const Resource = ({
   dragHandleProps,
   currentNodeId,
   contentMetaLoading,
+  responsible,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const location = useLocation();
@@ -171,14 +170,6 @@ const Resource = ({
     onMutate: async ({ id, body }) => onUpdateConnection(id, body),
     onSettled: () => qc.invalidateQueries(compKey),
   });
-
-  const id = getIdFromUrn(resource?.contentMeta?.contentUri);
-  const { data: article } = useDraft({ id: id! }, { enabled: !!id });
-  const { data: userData } = useResponsibleUserData(article);
-
-  const responsible = useMemo(() => {
-    return userData?.[0]?.name;
-  }, [userData]);
 
   const contentType =
     resource.resourceTypes.length > 0
@@ -242,12 +233,7 @@ const Resource = ({
                 size="small"
               />
             </StyledResourceBody>
-            <StatusIcons
-              article={article}
-              contentMetaLoading={contentMetaLoading}
-              resource={resource}
-              path={path}
-            />
+            <StatusIcons contentMetaLoading={contentMetaLoading} resource={resource} path={path} />
             <RelevanceOption relevanceId={resource.relevanceId} onChange={updateRelevanceId} />
           </StyledText>
           <ButtonRow>

--- a/src/containers/StructurePage/resourceComponents/ResourceBanner.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceBanner.tsx
@@ -16,6 +16,7 @@ import { ResourceGroupBanner, StyledShareIcon } from '../styles';
 import ApproachingRevisionDate from './ApproachingRevisionDate';
 import { ChildNodeType } from '../../../modules/nodes/nodeApiTypes';
 import GroupResourceSwitch from './GroupResourcesSwitch';
+import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
 
 const PublishedText = styled.div`
   font-weight: ${fonts.weight.normal};
@@ -56,6 +57,7 @@ interface Props {
   currentNode: ChildNodeType;
   onCurrentNodeChanged: (changedNode: ChildNodeType) => void;
   addButton?: ReactNode;
+  resources: ResourceWithNodeConnectionAndMeta[];
   articleIds?: number[];
 }
 
@@ -65,7 +67,7 @@ const ResourceBanner = ({
   currentNode,
   onCurrentNodeChanged,
   addButton,
-  articleIds,
+  resources,
 }: Props) => {
   const elementCount = Object.values(contentMeta).length;
   const publishedCount = useMemo(() => getPublishedCount(contentMeta), [contentMeta]);
@@ -87,7 +89,7 @@ const ResourceBanner = ({
             <PublishedText>{`${publishedCount}/${elementCount} ${t(
               'form.notes.published',
             ).toLowerCase()}`}</PublishedText>
-            <ApproachingRevisionDate articleIds={articleIds} />
+            <ApproachingRevisionDate resources={resources} />
             {currentNode && currentNode.id && (
               <GroupResourceSwitch
                 node={currentNode}

--- a/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
@@ -27,7 +27,7 @@ import {
   resourcesWithNodeConnectionQueryKey,
 } from '../../../modules/nodes/nodeQueries';
 import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
-import { Dictionary } from '../../../interfaces';
+import { Auth0UserData, Dictionary } from '../../../interfaces';
 
 const StyledResourceItems = styled.ul`
   list-style: none;
@@ -45,11 +45,18 @@ interface Props {
   currentNodeId: string;
   contentMeta: Dictionary<NodeResourceMeta>;
   contentMetaLoading: boolean;
+  users?: Dictionary<Auth0UserData>;
 }
 
 const isError = (error: unknown): error is Error => (error as Error).message !== undefined;
 
-const ResourceItems = ({ resources, currentNodeId, contentMeta, contentMetaLoading }: Props) => {
+const ResourceItems = ({
+  resources,
+  currentNodeId,
+  contentMeta,
+  contentMetaLoading,
+  users,
+}: Props) => {
   const { t, i18n } = useTranslation();
   const [deleteId, setDeleteId] = useState<string>('');
   const { taxonomyVersion } = useTaxonomyVersion();
@@ -125,6 +132,10 @@ const ResourceItems = ({ resources, currentNodeId, contentMeta, contentMetaLoadi
       <MakeDndList onDragEnd={onDragEnd} dragHandle disableDnd={false}>
         {resources.map(resource => (
           <Resource
+            responsible={
+              users?.[contentMeta[resource.contentUri ?? '']?.responsible?.responsibleId ?? '']
+                ?.name
+            }
             currentNodeId={currentNodeId}
             id={resource.id}
             connectionId={resource.connectionId}

--- a/src/containers/StructurePage/resourceComponents/ResourcesContainer.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourcesContainer.tsx
@@ -8,10 +8,10 @@
 
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import keyBy from 'lodash/keyBy';
 import styled from '@emotion/styled';
 import { Plus } from '@ndla/icons/action';
 import Tooltip from '@ndla/tooltip';
-import compact from 'lodash/compact';
 import { Spinner } from '@ndla/icons';
 import { IconButtonV2 } from '@ndla/button';
 import { breakpoints, mq } from '@ndla/core';
@@ -24,8 +24,10 @@ import Resource from './Resource';
 import { NodeResourceMeta, useNodes } from '../../../modules/nodes/nodeQueries';
 import ResourceBanner from './ResourceBanner';
 import { Dictionary } from '../../../interfaces';
-import { getIdFromUrn, groupResourcesByType } from '../../../util/taxonomyHelpers';
+import { groupResourcesByType } from '../../../util/taxonomyHelpers';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
+import { useAuth0Responsibles } from '../../../modules/auth0/auth0Queries';
+import { DRAFT_WRITE_SCOPE } from '../../../constants';
 
 const ResourceWrapper = styled.div`
   overflow-y: auto;
@@ -62,22 +64,17 @@ const ResourcesContainer = ({
   const { taxonomyVersion } = useTaxonomyVersion();
   const currentNodeId = currentNode.id;
 
+  const { data: users } = useAuth0Responsibles(
+    { permission: DRAFT_WRITE_SCOPE },
+    { select: users => keyBy(users, u => u.app_metadata.ndla_id) },
+  );
+
   const { data } = useNodes(
     { contentURI: currentNode.contentUri!, taxonomyVersion },
     { enabled: !!currentNode.contentUri },
   );
 
   const paths = useMemo(() => data?.map(d => d.path).filter(d => !!d) ?? [], [data]);
-
-  const articleIds = useMemo(
-    () =>
-      compact(
-        [currentNode.contentUri, nodeResources.map(n => n.contentUri)]
-          .flat()
-          .map(id => getIdFromUrn(id)),
-      ),
-    [currentNode, nodeResources],
-  );
 
   const nodeResourcesWithMeta: ResourceWithNodeConnectionAndMeta[] =
     useMemo(
@@ -89,10 +86,12 @@ const ResourcesContainer = ({
       [contentMeta, nodeResources],
     ) ?? [];
   const mapping = groupResourcesByType(nodeResourcesWithMeta ?? [], resourceTypes ?? []);
+  const currentMeta = currentNode.contentUri ? contentMeta[currentNode.contentUri] : undefined;
 
   return (
     <>
       <ResourceBanner
+        resources={nodeResourcesWithMeta}
         title={currentNode.name}
         contentMeta={contentMeta}
         currentNode={currentNode}
@@ -108,7 +107,6 @@ const ResourcesContainer = ({
             </IconButtonV2>
           </Tooltip>
         }
-        articleIds={articleIds}
       />
       <ResourceWrapper>
         {showAddModal && (
@@ -122,11 +120,16 @@ const ResourcesContainer = ({
         {currentNode.name && (
           <Resource
             currentNodeId={currentNode.id}
+            responsible={
+              currentMeta?.responsible
+                ? users?.[currentMeta.responsible.responsibleId]?.name
+                : undefined
+            }
             resource={{
               ...currentNode,
               paths,
               nodeId: '',
-              contentMeta: currentNode.contentUri ? contentMeta[currentNode.contentUri] : undefined,
+              contentMeta: currentMeta,
               resourceTypes: [],
               relevanceId: currentNode.relevanceId,
             }}
@@ -145,6 +148,7 @@ const ResourcesContainer = ({
                   currentNodeId={currentNodeId}
                   contentMeta={contentMeta}
                   contentMetaLoading={contentMetaLoading}
+                  users={users}
                 />
               ))
             ) : (
@@ -153,6 +157,7 @@ const ResourcesContainer = ({
                 currentNodeId={currentNodeId}
                 contentMeta={contentMeta}
                 contentMetaLoading={contentMetaLoading}
+                users={users}
               />
             )}
           </>

--- a/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
+++ b/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
@@ -13,12 +13,11 @@ import { colors } from '@ndla/core';
 import { AlertCircle, Check } from '@ndla/icons/editor';
 import Tooltip from '@ndla/tooltip';
 import SafeLink from '@ndla/safelink';
-import { IArticle } from '@ndla/types-draft-api';
 import config from '../../../config';
 import { PUBLISHED } from '../../../constants';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
-import { getCountApproachingRevision, RevisionDateIcon } from './ApproachingRevisionDate';
+import { isApproachingRevision, RevisionDateIcon } from './ApproachingRevisionDate';
 import WrongTypeError from './WrongTypeError';
 
 const StyledCheckIcon = styled(Check)`
@@ -43,27 +42,24 @@ const CheckedWrapper = styled.div`
 
 export const IconWrapper = styled.div`
   display: flex;
-  flex-align: center;
 `;
 
 interface Props {
-  article: IArticle | undefined;
   contentMetaLoading: boolean;
   resource: ResourceWithNodeConnectionAndMeta;
   path?: string;
 }
 
-const StatusIcons = ({ article, contentMetaLoading, resource, path }: Props) => {
+const StatusIcons = ({ contentMetaLoading, resource, path }: Props) => {
   const { t } = useTranslation();
-
-  const isApproachingRevision = useMemo(() => {
-    if (!article) return false;
-    return !!getCountApproachingRevision([article]);
-  }, [article]);
+  const approachingRevision = useMemo(
+    () => isApproachingRevision(resource.contentMeta?.revisions),
+    [resource.contentMeta?.revisions],
+  );
 
   return (
     <IconWrapper>
-      {isApproachingRevision ? (
+      {approachingRevision ? (
         <RevisionDateIcon phrasesKey="form.responsible.revisionDateSingle" />
       ) : null}
       {!contentMetaLoading && (

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -7,7 +7,7 @@
  */
 
 import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
-import { IEditorNote } from '@ndla/types-draft-api';
+import { IDraftResponsible, IEditorNote, IRevisionMeta } from '@ndla/types-draft-api';
 import { NodeTree } from '../../containers/NodeDiff/diffUtils';
 import { SearchResultBase, WithTaxonomyVersion } from '../../interfaces';
 import { PUBLISHED } from '../../constants';
@@ -82,6 +82,8 @@ export interface NodeResourceMeta {
   articleType?: string;
   revision?: number;
   notes?: IEditorNote[];
+  revisions?: IRevisionMeta[];
+  responsible?: IDraftResponsible;
 }
 
 export const nodeResourceMetasQueryKey = (params: Partial<UseNodeResourceMetas>) => [
@@ -137,12 +139,14 @@ const fetchNodeResourceMetas = async (
     : Promise.resolve([]);
   const [articles, learningpaths] = await Promise.all([articlesPromise, learningpathsPromise]);
   const transformedArticles: NodeResourceMeta[] = articles.map(
-    ({ status, grepCodes, articleType, id, revision, notes }) => ({
+    ({ status, grepCodes, articleType, id, revision, revisions, notes, responsible }) => ({
       status,
       grepCodes,
       articleType,
       contentUri: `urn:article:${id}`,
       revision,
+      responsible,
+      revisions,
       notes,
     }),
   );


### PR DESCRIPTION
Den nye ressurs-seksjonen i struktur henter unødvendig mye data. Denne PR'en reduserer antall API-kall fra 2n +1 (der n er ressurser) til 1 API-kall.

Dette er API-kallene som fjernes:
* Et API-kall per ressurs for å hente draft (responsible-id).
* Et API-kall per ressurs for å hente navn (basert på responsible-id).
* API-kall for å hente revisjonsdato (ressurs-banner).