### PR TITLE
Limit ids fetched at once draft-api

### DIFF
--- a/src/containers/NodeDiff/NodeDiff.tsx
+++ b/src/containers/NodeDiff/NodeDiff.tsx
@@ -10,11 +10,7 @@ import styled from '@emotion/styled';
 import { spacing, colors } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
-import {
-  ChildNodeType,
-  NodeType,
-  ResourceWithNodeConnection,
-} from '../../modules/nodes/nodeApiTypes';
+import { ChildNodeType, NodeType } from '../../modules/nodes/nodeApiTypes';
 import ArrayDiffField from './ArrayDiffField';
 import { diffField, DiffType, DiffTypeWithChildren, removeType } from './diffUtils';
 import { DiffTypePill } from './TreeNode';

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -8,6 +8,8 @@
 
 import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
 import { IDraftResponsible, IEditorNote, IRevisionMeta } from '@ndla/types-draft-api';
+import chunk from 'lodash/chunk';
+import uniqBy from 'lodash/uniqBy';
 import { NodeTree } from '../../containers/NodeDiff/diffUtils';
 import { SearchResultBase, WithTaxonomyVersion } from '../../interfaces';
 import { PUBLISHED } from '../../constants';
@@ -183,14 +185,17 @@ const fetchChildNodesWithArticleType = async ({
   if (childNodes.length === 0) return [];
 
   const childIds = childNodes.map(n => Number(n.contentUri?.split(':').pop())).filter(id => !!id);
-  const searchRes = await fetchDrafts(childIds);
 
-  const articleTypeMap = searchRes.reduce<Record<number, string>>((acc, curr) => {
+  const chunks = chunk(childIds, 250);
+  const searchRes = await Promise.all(chunks.map(async chunk => await fetchDrafts(chunk)));
+
+  const flattenedUniqueSeachRes = uniqBy(searchRes.flat(), s => s.id);
+  const articleTypeMap = flattenedUniqueSeachRes.reduce<Record<number, string>>((acc, curr) => {
     acc[curr.id] = curr.articleType;
     return acc;
   }, {});
 
-  const isPublishedMap = searchRes.reduce<Record<number, boolean>>((acc, curr) => {
+  const isPublishedMap = flattenedUniqueSeachRes.reduce<Record<number, boolean>>((acc, curr) => {
     acc[curr.id] = curr.status.current === PUBLISHED || curr.status.other.includes(PUBLISHED);
     return acc;
   }, {});

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -187,7 +187,7 @@ const fetchChildNodesWithArticleType = async ({
   const childIds = childNodes.map(n => Number(n.contentUri?.split(':').pop())).filter(id => !!id);
 
   const chunks = chunk(childIds, 250);
-  const searchRes = await Promise.all(chunks.map(async chunk => await fetchDrafts(chunk)));
+  const searchRes = await Promise.all(chunks.map(chunk => fetchDrafts(chunk)));
 
   const flattenedUniqueSeachRes = uniqBy(searchRes.flat(), s => s.id);
   const articleTypeMap = flattenedUniqueSeachRes.reduce<Record<number, string>>((acc, curr) => {


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3476

Noen kommentarer:
1. Prøvde også en løsning der jeg brukte paginering i draft-api (page-size/page parametre), men dette ga fortsatt 431 i respons når id'er nådde en visst nivå, tror uansett det er lurt å begrense størrelsen på id'er som legges med spørringen, så landet derfor på nåværende løsning
2. Ser at lignende fetching av mange drafts gjøres i blant annet `fetchNodeResourceMetas` i nodeQueries, burde denne typen logikk innføres der og kanskje? eventuelt om logikken burde være implementert i fetchDrafts direkte? (Litt usikker på om det blir rotete, derfor jeg unngikk det i første omgang .. )