### PR TITLE
Bruker permissions og ikkje scope for tilgangssjekk

### DIFF
--- a/src/server/server.tsx
+++ b/src/server/server.tsx
@@ -38,7 +38,7 @@ import { translateDocument } from './translate';
 type NdlaUser = (Express.User | undefined) & {
   'https://ndla.no/user_email'?: string;
   'https://ndla.no/user_name'?: string;
-  scope?: string[];
+  permissions?: string[];
 };
 
 const app = express();
@@ -160,8 +160,9 @@ app.get(
 
     const hasWriteAccess =
       user &&
-      user.scope &&
-      (user.scope.includes(DRAFT_WRITE_SCOPE) || user.scope.includes(DRAFT_PUBLISH_SCOPE));
+      user.permissions &&
+      (user.permissions.includes(DRAFT_WRITE_SCOPE) ||
+        user.permissions.includes(DRAFT_PUBLISH_SCOPE));
 
     if (!hasWriteAccess) {
       res.status(FORBIDDEN).json({ status: FORBIDDEN, text: 'No access allowed' });


### PR DESCRIPTION
Meir korrekt å bruke permissions fordi disse settes fra rolla i auth0. Scope settes fra en rule som vi har laga sjølv, men den bør egentlig fases ut.