### PR TITLE
Bruker nytt info-endepunkt for å hente tittel

### DIFF
--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -11,7 +11,7 @@ import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import { ErrorMessage } from '@ndla/ui';
 import handleError from '../../util/handleError';
-import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PMetadata } from './h5pApi';
+import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PInfo } from './h5pApi';
 
 const FlexWrapper = styled.div`
   width: 100%;
@@ -81,8 +81,8 @@ const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: P
     const url = oembedUrl.match(/url=([^&]*)/)?.[0].replace('url=', '');
     const path = url?.replace(/https?:\/\/h5p.{0,8}.ndla.no/, '');
     try {
-      const metadata = await fetchH5PMetadata(event.data.embed_id);
-      const title = metadata.h5p.title;
+      const metadata = await fetchH5PInfo(event.data.embed_id);
+      const title = metadata.title;
       onSelect({ path, title });
     } catch (e) {
       onSelect({ path });

--- a/src/components/H5PElement/h5pApi.ts
+++ b/src/components/H5PElement/h5pApi.ts
@@ -10,26 +10,14 @@ import { IAuthor } from '@ndla/types-draft-api';
 import config from '../../config';
 import { fetchReAuthorized, resolveJsonOrRejectWithError } from '../../util/apiHelpers';
 
-export interface H5PData {
-  authors: IAuthor[];
-  contentType: string;
-  license: string;
-  licenseExtras: string;
-  licenseVersion: string;
-  source: string;
-  thumbnail: string;
-  title: string;
-  yearFrom: string;
-  yearTo: string;
-}
-export interface H5PMetadata {
-  assets: H5PData[];
-  h5p: H5PData;
+export interface H5PInfo {
   h5pLibrary: {
     majorVersion: number;
     minorVersion: number;
     name: string;
   };
+  published: boolean;
+  title: string;
 }
 
 export const fetchH5PiframeUrl = (
@@ -62,7 +50,7 @@ export const getH5pLocale = (language: string) => {
   return language === 'en' ? 'en-gb' : 'nn' === language ? 'nn-no' : 'nb-no';
 };
 
-export const fetchH5PMetadata = async (resourceId: string): Promise<H5PMetadata> => {
-  const url = `${config.h5pApiUrl}/v1/resource/${resourceId}/copyright`;
+export const fetchH5PInfo = async (resourceId: string): Promise<H5PInfo> => {
+  const url = `${config.h5pApiUrl}/v1/resource/${resourceId}/info`;
   return fetch(url).then(r => resolveJsonOrRejectWithError(r));
 };


### PR DESCRIPTION
Bruker nytt info-endepunkt for å hente tittel på h5p.

Test:
* Sett inn h5p i artikkel. Sjekk med html-editor i etterkant at du har fått data-title satt på ndlaembed. Det skal du få sjølv om h5p ikkje har satt lisens. Det ser du på h5p om den har ikon for gjenbruk nederst i iframe.