### PR TITLE
Sorts requests by breadcrumbs

### DIFF
--- a/src/containers/NodeDiff/NodeDiffContainer.tsx
+++ b/src/containers/NodeDiff/NodeDiffContainer.tsx
@@ -10,8 +10,9 @@ import styled from '@emotion/styled';
 import { ButtonV2 } from '@ndla/button';
 import { spacing } from '@ndla/core';
 import { ContentLoader, MessageBox } from '@ndla/ui';
+import { ChevronRight } from '@ndla/icons/lib/common';
 import isEqual from 'lodash/isEqual';
-import { ReactNode, useEffect, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
@@ -53,6 +54,12 @@ interface NodeOptions {
   nodeView: string | null;
   fieldView: string | null;
 }
+
+const StyledBreadCrumb = styled('div')`
+  flex-grow: 1;
+  flex-direction: row;
+  font-style: italic;
+`;
 
 const filterNodes = <T,>(diff: DiffType<T>[], options: NodeOptions): DiffType<T>[] => {
   const afterNodeOption =
@@ -215,6 +222,16 @@ const NodeDiffcontainer = ({ originalHash, otherHash, nodeId }: Props) => {
           {t(`diff.${isPublishing ? 'publishing' : 'publish'}`)}
         </PublishButton>
       )}
+      <StyledBreadCrumb>
+        {defaultQuery.data?.root?.breadcrumbs?.map((path, index) => {
+          return (
+            <Fragment key={`${path}_${index}`}>
+              {path}
+              {index + 1 !== defaultQuery.data?.root?.breadcrumbs?.length && <ChevronRight />}
+            </Fragment>
+          );
+        })}
+      </StyledBreadCrumb>
       {hasPublished && <MessageBox>{t('diff.published')}</MessageBox>}
       {equal && <MessageBox>{t('diff.equalNodes')}</MessageBox>}
       {error && <MessageBox>{t(error)}</MessageBox>}

--- a/src/containers/NodeDiff/NodeDiffContainer.tsx
+++ b/src/containers/NodeDiff/NodeDiffContainer.tsx
@@ -223,11 +223,11 @@ const NodeDiffcontainer = ({ originalHash, otherHash, nodeId }: Props) => {
         </PublishButton>
       )}
       <StyledBreadCrumb>
-        {defaultQuery.data?.root?.breadcrumbs?.map((path, index) => {
+        {defaultQuery.data?.root?.breadcrumbs?.map((path, index, arr) => {
           return (
             <Fragment key={`${path}_${index}`}>
               {path}
-              {index + 1 !== defaultQuery.data?.root?.breadcrumbs?.length && <ChevronRight />}
+              {index + 1 !== arr.length && <ChevronRight />}
             </Fragment>
           );
         })}

--- a/src/containers/NodeDiff/NodeDiffContainer.tsx
+++ b/src/containers/NodeDiff/NodeDiffContainer.tsx
@@ -8,7 +8,7 @@
 
 import styled from '@emotion/styled';
 import { ButtonV2 } from '@ndla/button';
-import { spacing } from '@ndla/core';
+import { spacing, fonts } from '@ndla/core';
 import { ContentLoader, MessageBox } from '@ndla/ui';
 import { ChevronRight } from '@ndla/icons/lib/common';
 import isEqual from 'lodash/isEqual';
@@ -59,6 +59,7 @@ const StyledBreadCrumb = styled('div')`
   flex-grow: 1;
   flex-direction: row;
   font-style: italic;
+  font-size: ${fonts.sizes(16)};
 `;
 
 const filterNodes = <T,>(diff: DiffType<T>[], options: NodeOptions): DiffType<T>[] => {

--- a/src/containers/PublishRequests/PublishRequestsContainer.tsx
+++ b/src/containers/PublishRequests/PublishRequestsContainer.tsx
@@ -123,11 +123,11 @@ const PublishRequestsContainer = () => {
                     {node.name}
                   </StyledTitleRow>
                   <StyledBreadCrumb>
-                    {node?.breadcrumbs?.map((path, index) => {
+                    {node?.breadcrumbs?.map((path, index, arr) => {
                       return (
                         <Fragment key={`${path}_${index}`}>
                           {path}
-                          {index + 1 !== node?.breadcrumbs?.length && <ChevronRight />}
+                          {index + 1 !== arr.length && <ChevronRight />}
                         </Fragment>
                       );
                     })}

--- a/src/containers/PublishRequests/PublishRequestsContainer.tsx
+++ b/src/containers/PublishRequests/PublishRequestsContainer.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { spacing, colors, fonts } from '@ndla/core';
 import { Spinner } from '@ndla/icons';
 import { OneColumn } from '@ndla/ui';
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
+import sortBy from 'lodash/sortBy';
 import { useTranslation } from 'react-i18next';
 import isBefore from 'date-fns/isBefore';
 import { SafeLinkButton } from '@ndla/safelink';
@@ -73,6 +74,10 @@ const PublishRequestsContainer = () => {
     value: 'true',
   });
 
+  const sorted = useMemo(() => sortBy(nodesQuery?.data, n => n.breadcrumbs?.join('')), [
+    nodesQuery,
+  ]);
+
   const versionsQuery = useVersions(
     {},
     {
@@ -99,18 +104,14 @@ const PublishRequestsContainer = () => {
     return toNodeDiff(node.id, otherVersion.hash, 'default');
   };
 
-  nodesQuery.data?.sort(
-    (a, b) => a.breadcrumbs?.join(' > ')?.localeCompare(b.breadcrumbs?.join(' > ') || '') || 0,
-  );
-
   return (
     <>
       <OneColumn>
         <h1>{t('publishRequests.title')}</h1>
         {error && <ErrorMessage>{t(error)}</ErrorMessage>}
-        <h3>{`${t('publishRequests.numberRequests')}: ${nodesQuery.data?.length ?? 0}`}</h3>
+        <h3>{`${t('publishRequests.numberRequests')}: ${sorted?.length ?? 0}`}</h3>
         <StyledRequestList>
-          {nodesQuery.data?.map((node, i) => (
+          {sorted?.map((node, i) => (
             <StyledNodeContainer key={`node-request-${i}`}>
               <StyledTitleRow>
                 <StyledTitleColumn>

--- a/src/containers/PublishRequests/PublishRequestsContainer.tsx
+++ b/src/containers/PublishRequests/PublishRequestsContainer.tsx
@@ -99,6 +99,10 @@ const PublishRequestsContainer = () => {
     return toNodeDiff(node.id, otherVersion.hash, 'default');
   };
 
+  nodesQuery.data?.sort(
+    (a, b) => a.breadcrumbs?.join(' > ')?.localeCompare(b.breadcrumbs?.join(' > ') || '') || 0,
+  );
+
   return (
     <>
       <OneColumn>

--- a/src/containers/PublishRequests/PublishRequestsContainer.tsx
+++ b/src/containers/PublishRequests/PublishRequestsContainer.tsx
@@ -63,6 +63,7 @@ const StyledBreadCrumb = styled('div')`
   flex-grow: 1;
   flex-direction: row;
   font-style: italic;
+  font-size: ${fonts.sizes(16)};
 `;
 
 const PublishRequestsContainer = () => {
@@ -115,13 +116,6 @@ const PublishRequestsContainer = () => {
             <StyledNodeContainer key={`node-request-${i}`}>
               <StyledTitleRow>
                 <StyledTitleColumn>
-                  <StyledTitleRow>
-                    <NodeIconType node={node} />
-                    {node.metadata.customFields[TAXONOMY_CUSTOM_FIELD_IS_PUBLISHING] === 'true' && (
-                      <Spinner size="nsmall" margin="0" />
-                    )}
-                    {node.name}
-                  </StyledTitleRow>
                   <StyledBreadCrumb>
                     {node?.breadcrumbs?.map((path, index, arr) => {
                       return (
@@ -132,6 +126,13 @@ const PublishRequestsContainer = () => {
                       );
                     })}
                   </StyledBreadCrumb>
+                  <StyledTitleRow>
+                    <NodeIconType node={node} />
+                    {node.metadata.customFields[TAXONOMY_CUSTOM_FIELD_IS_PUBLISHING] === 'true' && (
+                      <Spinner size="nsmall" margin="0" />
+                    )}
+                    {node.name}
+                  </StyledTitleRow>
                 </StyledTitleColumn>
               </StyledTitleRow>
               <StyledButtonRow>


### PR DESCRIPTION
Viser publiseringsforespørsler i alfabetisk rekkefølge. Litt overraska over at eg ikkje måtte putte resultatet av sort inn i en const.

Test: 
* Gå til side for publiseringsforespørsler, og sjekk at lista er sortert alfabetisk på brødsmulesti.
* Klikk på knapp for sammenligning, og sjekk at brødsmulesti også vises der.