### PR TITLE
Reuse approaching revision component at structure edit page

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -54,6 +54,38 @@ const Splitter = ({
   );
 };
 
+export const getWarnStatus = (date?: string): 'warn' | 'expired' | undefined => {
+  if (!date) return undefined;
+  const parsedDate = new Date(date);
+
+  const daysToWarn = 365;
+  const errorDate = new Date();
+  const warnDate = new Date();
+  warnDate.setDate(errorDate.getDate() + daysToWarn);
+
+  if (errorDate > parsedDate) return 'expired';
+  if (warnDate > parsedDate) return 'warn';
+};
+
+export const StyledTimeIcon = styled(Time)<{
+  status: 'warn' | 'expired';
+  height?: string;
+  width?: string;
+}>`
+  height: ${(p) => (p.height ? p.height : spacing.normal)};
+  width: ${(p) => (p.width ? p.width : spacing.normal)};
+  fill: ${(p) => {
+    switch (p.status) {
+      case 'warn':
+        return '#c77623';
+      case 'expired':
+        return colors.support.red;
+      default:
+        unreachable(p.status);
+    }
+  }};
+`;
+
 interface Props {
   noStatus?: boolean;
   statusText?: string;
@@ -128,34 +160,6 @@ const HeaderStatusInformation = ({
 
   const StyledLink = styled(SafeLink)`
     box-shadow: inset 0 0;
-  `;
-
-  const getWarnStatus = (date?: string): 'warn' | 'expired' | undefined => {
-    if (!date) return undefined;
-    const parsedDate = new Date(date);
-
-    const daysToWarn = 365;
-    const errorDate = new Date();
-    const warnDate = new Date();
-    warnDate.setDate(errorDate.getDate() + daysToWarn);
-
-    if (errorDate > parsedDate) return 'expired';
-    if (warnDate > parsedDate) return 'warn';
-  };
-
-  const StyledTimeIcon = styled(Time)<{ status: 'warn' | 'expired' }>`
-    height: ${spacing.normal};
-    width: ${spacing.normal};
-    fill: ${(p) => {
-      switch (p.status) {
-        case 'warn':
-          return colors.support.yellow;
-        case 'expired':
-          return colors.support.red;
-        default:
-          unreachable(p.status);
-      }
-    }};
   `;
 
   const expirationColor = getWarnStatus(expirationDate);

--- a/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
+++ b/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
@@ -13,7 +13,6 @@ import isBefore from 'date-fns/isBefore';
 import { IRevisionMeta } from '@ndla/types-draft-api';
 import Tooltip from '@ndla/tooltip';
 import { useTranslation } from 'react-i18next';
-import { Time } from '@ndla/icons/common';
 import { getExpirationDate } from '../../ArticlePage/articleTransformers';
 
 const Wrapper = styled.div`
@@ -37,27 +36,6 @@ const StyledIcon = styled.div`
   color: #c77623;
 `;
 
-const StyledTimeIcon = styled(Time)`
-  width: 24px;
-  height: 24px;
-  color: #c77623;
-`;
-
-interface RevisionDateProps {
-  text?: string | number;
-  phrasesKey: string;
-}
-
-export const RevisionDateIcon = ({ text, phrasesKey }: RevisionDateProps) => {
-  const { t } = useTranslation();
-
-  return (
-    <Tooltip tooltip={t(phrasesKey)}>
-      <Wrapper>{text || text === 0 ? <StyledIcon>{text}</StyledIcon> : <StyledTimeIcon />}</Wrapper>
-    </Tooltip>
-  );
-};
-
 interface Props {
   revisions: (IRevisionMeta[] | undefined)[];
 }
@@ -71,13 +49,19 @@ export const isApproachingRevision = (revisions?: IRevisionMeta[]) => {
 };
 
 const ApproachingRevisionDate = ({ revisions }: Props) => {
+  const { t } = useTranslation();
+
   const approachingRevision = useMemo(
     () => revisions.map((r) => isApproachingRevision(r)).filter((a) => !!a).length,
     [revisions],
   );
 
   return (
-    <RevisionDateIcon text={approachingRevision} phrasesKey={'form.responsible.revisionDate'} />
+    <Tooltip tooltip={t('form.responsible.revisionDate')}>
+      <Wrapper>
+        <StyledIcon>{approachingRevision}</StyledIcon>
+      </Wrapper>
+    </Tooltip>
   );
 };
 

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1031,7 +1031,6 @@ const phrases = {
       noResults: 'No results',
       noResponible: 'No responsible',
       revisionDate: 'Amount approaching revision date',
-      revisionDateSingle: 'Approaching revision date',
       error: 'Something went wrong when updating responsible',
     },
     origin: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1032,7 +1032,6 @@ const phrases = {
       noResults: 'Ingen treff',
       noResponible: 'Ingen ansvarlig',
       revisionDate: 'Antall som nærmer seg revisjonsdato',
-      revisionDateSingle: 'Nærmer seg revisjonsdato',
       error: 'Noe gikk galt ved oppdatering av ansvarlig.',
     },
     origin: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1032,7 +1032,6 @@ const phrases = {
       noResults: 'Ingen treff',
       noResponible: 'Ingen ansvarleg',
       revisionDate: 'Antall som nærmar seg revisjonsdato',
-      revisionDateSingle: 'Nærmar seg revisjonsdato',
       error: 'Noe gjekk gale ved oppdatering av ansvarleg.',
     },
     origin: {


### PR DESCRIPTION
Liten refakturering der vi heller gjenbruker samme klokke-ikon som brukes inne på artikler sånn at de vil være samme farge, oppdaterer også fargen for 'warn' etter ønske fra NDLA.

kan f.eks testes her: /structure/urn:subject:da2379d0-3c91-4e4d-94d7-fc42f69593d2/urn:topic:3ce397d1-4939-474d-8242-15faaa0a06e6
<img width="399" alt="Skjermbilde 2023-03-22 kl  14 22 35" src="https://user-images.githubusercontent.com/26788204/226917666-a913576c-1a61-4a82-8a9a-f817cac7046f.png">
