### PR TITLE
Remove more old type references

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -14,7 +14,7 @@ import { Check, AlertCircle } from '@ndla/icons/editor';
 import Tooltip from '@ndla/tooltip';
 import { IConceptSummary } from '@ndla/types-backend/concept-api';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import config from '../../config';
 import LearningpathConnection from './LearningpathConnection';
 import EmbedConnection from './EmbedInformation/EmbedConnection';

--- a/src/components/HeaderWithLanguage/LearningpathConnection.tsx
+++ b/src/components/HeaderWithLanguage/LearningpathConnection.tsx
@@ -14,7 +14,7 @@ import { LearningPath } from '@ndla/icons/contentType';
 import Modal, { ModalHeader, ModalCloseButton, ModalBody } from '@ndla/modal';
 import Tooltip from '@ndla/tooltip';
 import { ButtonV2 } from '@ndla/button';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import { normalPaddingCSS } from '../HowTo';
 import ElementList from '../../containers/FormikForm/components/ElementList';
 import { fetchLearningpathsWithArticle } from '../../modules/learningpath/learningpathApi';

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageAccordionPanels.tsx
@@ -8,7 +8,7 @@ import { Accordions, AccordionSection } from '@ndla/accordion';
 import { useTranslation } from 'react-i18next';
 import { FormikErrors } from 'formik';
 import { IArticle } from '@ndla/types-backend/draft-api';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import SubjectpageAbout from './SubjectpageAbout';
 import SubjectpageMetadata from './SubjectpageMetadata';
 import SubjectpageArticles from './SubjectpageArticles';

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageArticles.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageArticles.tsx
@@ -8,7 +8,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FieldHeader } from '@ndla/forms';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
 import { IArticle } from '@ndla/types-backend/draft-api';
 import { useField, useFormikContext } from 'formik';

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -14,7 +14,7 @@ import {
   IUpdatedSubjectFrontPageData,
 } from '@ndla/types-backend/frontpage-api';
 import { IImageMetaInformationV3 } from '@ndla/types-backend/image-api';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import { IArticle } from '@ndla/types-backend/draft-api';
 import Field from '../../../components/Field';
 import SimpleLanguageHeader from '../../../components/HeaderWithLanguage/SimpleLanguageHeader';

--- a/src/containers/NdlaFilm/components/DropdownSearch.tsx
+++ b/src/containers/NdlaFilm/components/DropdownSearch.tsx
@@ -7,7 +7,7 @@
 
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
 import { IArticle } from '@ndla/types-backend/draft-api';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import AsyncDropdown from '../../../components/Dropdown/asyncDropdown/AsyncDropdown';
 import { searchResources } from '../../../modules/search/searchApi';
 

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
@@ -11,7 +11,7 @@ import { colors } from '@ndla/core';
 import { Spinner } from '@ndla/icons';
 import { Done } from '@ndla/icons/editor';
 import { IArticle } from '@ndla/types-backend/draft-api';
-import { ILearningPathV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import partition from 'lodash/partition';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/StructurePage/resourceComponents/AddResourceModal.tsx
+++ b/src/containers/StructurePage/resourceComponents/AddResourceModal.tsx
@@ -11,7 +11,7 @@ import { Input } from '@ndla/forms';
 import styled from '@emotion/styled';
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ILearningPathSummaryV2 } from '@ndla/types-learningpath-api';
+import { ILearningPathSummaryV2 } from '@ndla/types-backend/learningpath-api';
 import { IGroupSearchResult, IMultiSearchSummary } from '@ndla/types-backend/search-api';
 import { IArticleV2 } from '@ndla/types-backend/article-api';
 import TaxonomyLightbox from '../../../components/Taxonomy/TaxonomyLightbox';


### PR DESCRIPTION
Dersom vi oppgraderer pakker vil CI feile på grunn av typefeil. Dette er fordi vi ender opp med types-learningpath som en dev-dep fra nåværende pakker, men det er fjernet i den nyeste versjonen.