### PR TITLE
Extract new serializers and deserializers. Convert concepts as a POC

### DIFF
--- a/src/components/SlateEditor/plugins/concept/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/concept/__tests__/serializer-test.ts
@@ -26,8 +26,8 @@ const editor: Descendant[] = [
           {
             type: TYPE_CONCEPT_INLINE,
             data: {
-              'content-id': '123',
-              'link-text': 'my concept',
+              contentId: '123',
+              linkText: 'my concept',
               resource: 'concept',
               type: 'inline',
             },

--- a/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
@@ -23,7 +23,7 @@ import { Dictionary } from '../../../../../interfaces';
 const getConceptDataAttributes = ({ id }: Dictionary<any>) => ({
   type: TYPE_CONCEPT_BLOCK,
   data: {
-    'content-id': id,
+    contentId: id,
     resource: 'concept',
     type: 'block',
   },
@@ -54,7 +54,7 @@ const BlockConcept = ({ element, locale, editor, attributes, children }: Props) 
   const [showConcept, setShowConcept] = useState(false);
 
   const { concept, subjects, ...conceptHooks } = useFetchConceptData(
-    parseInt(element.data['content-id']),
+    parseInt(element.data.contentId),
     locale,
   );
   const conceptId = concept && concept.id ? concept.id : undefined;
@@ -104,7 +104,7 @@ const BlockConcept = ({ element, locale, editor, attributes, children }: Props) 
   };
 
   const onClose = () => {
-    if (!element.data['content-id']) {
+    if (!element.data.contentId) {
       handleRemove();
     } else {
       setShowConcept(false);
@@ -113,7 +113,7 @@ const BlockConcept = ({ element, locale, editor, attributes, children }: Props) 
   };
 
   useEffect(() => {
-    if (!element.data['content-id']) {
+    if (!element.data.contentId) {
       setShowConcept(true);
     }
   }, [element]);

--- a/src/components/SlateEditor/plugins/concept/block/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/index.tsx
@@ -9,7 +9,10 @@
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { RenderElementProps } from 'slate-react';
-import { createEmbedTag, reduceElementDataAttributes } from '../../../../../util/embedTagHelpers';
+import {
+  createEmbedTagV2,
+  reduceElementDataAttributesV2,
+} from '../../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../../interfaces';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../../utils/defaultNormalizer';
 import { afterOrBeforeTextBlockElement } from '../../../utils/normalizationHelpers';
@@ -30,10 +33,10 @@ const normalizerConfig: NormalizerConfig = {
 };
 
 export const blockConceptSerializer: SlateSerializer = {
-  deserialize(el: HTMLElement, children: Descendant[]) {
+  deserialize(el: HTMLElement) {
     if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
     const embed = el as HTMLEmbedElement;
-    const embedAttributes = reduceElementDataAttributes(embed);
+    const embedAttributes = reduceElementDataAttributesV2(embed);
     if (embedAttributes.resource === 'concept' && embedAttributes.type === 'block') {
       return slatejsx(
         'element',
@@ -46,14 +49,8 @@ export const blockConceptSerializer: SlateSerializer = {
     }
   },
   serialize(node: Descendant) {
-    if (!Element.isElement(node)) return;
-    if (node.type !== TYPE_CONCEPT_BLOCK) return;
-
-    const data = {
-      ...node.data,
-    };
-
-    return createEmbedTag(data);
+    if (!Element.isElement(node) || node.type !== TYPE_CONCEPT_BLOCK) return;
+    return createEmbedTagV2(node.data);
   },
 };
 

--- a/src/components/SlateEditor/plugins/concept/block/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/index.tsx
@@ -36,7 +36,7 @@ export const blockConceptSerializer: SlateSerializer = {
   deserialize(el: HTMLElement) {
     if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
     const embed = el as HTMLEmbedElement;
-    const embedAttributes = reduceElementDataAttributesV2(embed);
+    const embedAttributes = reduceElementDataAttributesV2(Array.from(embed.attributes));
     if (embedAttributes.resource === 'concept' && embedAttributes.type === 'block') {
       return slatejsx(
         'element',

--- a/src/components/SlateEditor/plugins/concept/block/interfaces.ts
+++ b/src/components/SlateEditor/plugins/concept/block/interfaces.ts
@@ -6,10 +6,11 @@
  *
  */
 
+import { ConceptEmbedData } from '@ndla/types-embed';
 import { Descendant } from 'slate';
 
 export interface ConceptBlockElement {
   type: 'concept-block';
-  data: { [key: string]: string };
+  data: ConceptEmbedData;
   children: Descendant[];
 }

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -22,8 +22,8 @@ import { Dictionary } from '../../../../../interfaces';
 const getConceptDataAttributes = ({ id, title: { title } }: Dictionary<any>) => ({
   type: TYPE_CONCEPT_INLINE,
   data: {
-    'content-id': id,
-    'link-text': title,
+    contentId: id,
+    linkText: title,
     resource: 'concept',
     type: 'inline',
   },
@@ -48,7 +48,7 @@ const InlineConcept = (props: Props) => {
   };
 
   const { concept, subjects, fetchSearchTags, conceptArticles, createConcept, updateConcept } =
-    useFetchConceptData(parseInt(element.data['content-id']), locale);
+    useFetchConceptData(parseInt(element.data.contentId), locale);
 
   const handleSelectionChange = (isNewConcept: boolean) => {
     ReactEditor.focus(editor);
@@ -95,7 +95,7 @@ const InlineConcept = (props: Props) => {
   };
 
   const onClose = () => {
-    if (!element.data['content-id']) {
+    if (!element.data.contentId) {
       handleRemove();
     } else {
       toggleConceptModal();
@@ -104,7 +104,7 @@ const InlineConcept = (props: Props) => {
   };
 
   useEffect(() => {
-    if (!element.data['content-id']) {
+    if (!element.data.contentId) {
       setShowConcept(true);
     }
   }, [element]);

--- a/src/components/SlateEditor/plugins/concept/inline/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/index.tsx
@@ -10,7 +10,10 @@ import { Descendant, Editor, Element, Node, Range, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { RenderElementProps } from 'slate-react';
 import hasNodeOfType from '../../../utils/hasNodeOfType';
-import { createEmbedTag, reduceElementDataAttributes } from '../../../../../util/embedTagHelpers';
+import {
+  createEmbedTagV2,
+  reduceElementDataAttributesV2,
+} from '../../../../../util/embedTagHelpers';
 import InlineConcept from './InlineConcept';
 import { KEY_BACKSPACE } from '../../../utils/keys';
 import { SlateSerializer } from '../../../interfaces';
@@ -18,10 +21,10 @@ import { TYPE_CONCEPT_INLINE } from './types';
 import { TYPE_NDLA_EMBED } from '../../embed/types';
 
 export const inlineConceptSerializer: SlateSerializer = {
-  deserialize(el: HTMLElement, children: Descendant[]) {
+  deserialize(el: HTMLElement) {
     if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
     const embed = el as HTMLEmbedElement;
-    const embedAttributes = reduceElementDataAttributes(embed);
+    const embedAttributes = reduceElementDataAttributesV2(embed);
     if (embedAttributes.resource === 'concept' && embedAttributes.type === 'inline') {
       return slatejsx(
         'element',
@@ -31,24 +34,21 @@ export const inlineConceptSerializer: SlateSerializer = {
         },
         [
           {
-            text: embedAttributes['link-text']
-              ? embedAttributes['link-text']
-              : 'Ukjent forklaringstekst',
+            text: embedAttributes.linkText ? embedAttributes.linkText : 'Ukjent forklaringstekst',
           },
         ],
       );
     }
   },
   serialize(node: Descendant) {
-    if (!Element.isElement(node)) return;
-    if (node.type !== TYPE_CONCEPT_INLINE) return;
+    if (!Element.isElement(node) || node.type !== TYPE_CONCEPT_INLINE) return;
 
     const data = {
       ...node.data,
-      'link-text': Node.string(node),
+      linkText: Node.string(node),
     };
 
-    return createEmbedTag(data);
+    return createEmbedTagV2(data);
   },
 };
 

--- a/src/components/SlateEditor/plugins/concept/inline/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/index.tsx
@@ -24,7 +24,7 @@ export const inlineConceptSerializer: SlateSerializer = {
   deserialize(el: HTMLElement) {
     if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
     const embed = el as HTMLEmbedElement;
-    const embedAttributes = reduceElementDataAttributesV2(embed);
+    const embedAttributes = reduceElementDataAttributesV2(Array.from(embed.attributes));
     if (embedAttributes.resource === 'concept' && embedAttributes.type === 'inline') {
       return slatejsx(
         'element',

--- a/src/components/SlateEditor/plugins/concept/inline/interfaces.ts
+++ b/src/components/SlateEditor/plugins/concept/inline/interfaces.ts
@@ -6,10 +6,11 @@
  *
  */
 
+import { ConceptEmbedData } from '@ndla/types-embed';
 import { Descendant } from 'slate';
 
 export interface ConceptInlineElement {
   type: 'concept-inline';
-  data: { [key: string]: string };
+  data: ConceptEmbedData;
   children: Descendant[];
 }

--- a/src/util/__tests__/__snapshots__/embedTagHelpers-test.js.snap
+++ b/src/util/__tests__/__snapshots__/embedTagHelpers-test.js.snap
@@ -29,6 +29,30 @@ exports[`createEmbedTag creates image embed tag from object 1`] = `
 />
 `;
 
+exports[`createEmbedTagV2 converts camel-case to kebab-case 1`] = `
+<ndlaembed
+  data-resource="audio"
+  data-resource-id="123"
+  data-type="standard"
+  data-url="https://api.test.ndla.no/audio-api/v1/audio/3000"
+/>
+`;
+
+exports[`createEmbedTagV2 creates h5p embed tag from object 1`] = `
+<ndlaembed
+  data-resource="h5p"
+  data-url="https://h5p-test.ndla.no/resource/3ab6850d/oembed"
+/>
+`;
+
+exports[`createEmbedTagV2 filters out null and undefined values, but not false values 1`] = `
+<ndlaembed
+  data-auto-play="false"
+  data-resource="unknown"
+  data-videoid="123"
+/>
+`;
+
 exports[`deserializing related-content works 1`] = `
 [
   {

--- a/src/util/embedTagHelpers.tsx
+++ b/src/util/embedTagHelpers.tsx
@@ -20,25 +20,27 @@ export const removeEmptyElementDataAttributes = (obj: Dictionary<any>) => {
   return newObject;
 };
 
-const reduceDataRegexp = /^data-/g;
 const reduceRegexp = /-[a-z]/g;
 
 export const reduceElementDataAttributesV2 = (
-  el: Element,
+  attributes: Attr[],
   filter?: string[],
 ): Record<string, string> => {
-  let attributes: Attr[] = [].slice.call(el.attributes) ?? [];
-  attributes = attributes.filter((a) => a.name !== 'style');
+  const _attributes = attributes.filter((a) => a.name !== 'style');
   const filteredAttributes = filter?.length
-    ? attributes.filter((a) => filter.includes(a.name))
-    : attributes;
+    ? _attributes.filter((a) => filter.includes(a.name))
+    : _attributes;
   return filteredAttributes.reduce<Record<string, string>>((acc, attr) => {
-    const key = attr.name
-      // replace data-
-      .replace(reduceDataRegexp, '')
-      // convert "-a" with "A". image-id becomes imageId
-      .replace(reduceRegexp, (m) => m.charAt(1).toUpperCase());
-    acc[key] = attr.value;
+    if (attr.name.startsWith('data-')) {
+      const key = attr.name
+        .replace('data-', '')
+        // convert "-a" with "A". image-id becomes imageId
+        .replace(reduceRegexp, (m) => m.charAt(1).toUpperCase());
+      acc[key] = attr.value;
+    } else {
+      // Handle regular dash attributes like aria-label.
+      acc[attr.name] = attr.value;
+    }
     return acc;
   }, {});
 };
@@ -90,11 +92,6 @@ export const reduceChildElements = (el: HTMLElement, type: string) => {
 
   return { nodes: children };
 };
-
-export const createDataProps = (obj: Dictionary<string>) =>
-  Object.keys(obj)
-    .filter((key) => obj[key] !== undefined && !isObject(obj[key]))
-    .reduce((acc, key) => ({ ...acc, [`data-${key}`]: obj[key] }), {});
 
 export const createProps = (obj: Dictionary<string>) =>
   Object.keys(obj)

--- a/src/util/embedTagHelpers.tsx
+++ b/src/util/embedTagHelpers.tsx
@@ -120,13 +120,22 @@ export const parseEmbedTag = (embedTag?: string): Embed | undefined => {
 
 const attributeRegex = /[A-Z]/g;
 
-export const createEmbedTagV2 = (data: Record<string, any>) => {
-  if (Object.keys(data).length === 0) {
+type EmbedProps<T extends object> = {
+  [Key in keyof T]: string | undefined;
+};
+
+export const createEmbedTagV2 = <T extends object>(
+  data: EmbedProps<T>,
+): JSX.Element | undefined => {
+  const entries = Object.entries(data);
+  if (entries.length === 0) {
     return undefined;
   }
-  const dataSet = Object.entries(data).reduce<Record<string, any>>((acc, [key, value]) => {
+  const dataSet = entries.reduce<Record<string, string>>((acc, [key, value]) => {
     const newKey = key.replace(attributeRegex, (m) => `-${m.toLowerCase()}`);
-    acc[`data-${newKey}`] = value;
+    if (value != null && typeof value === 'string') {
+      acc[`data-${newKey}`] = value.toString();
+    }
     return acc;
   }, {});
 

--- a/src/util/embedTagHelpers.tsx
+++ b/src/util/embedTagHelpers.tsx
@@ -20,6 +20,29 @@ export const removeEmptyElementDataAttributes = (obj: Dictionary<any>) => {
   return newObject;
 };
 
+const reduceDataRegexp = /^data-/g;
+const reduceRegexp = /-[a-z]/g;
+
+export const reduceElementDataAttributesV2 = (
+  el: Element,
+  filter?: string[],
+): Record<string, string> => {
+  let attributes: Attr[] = [].slice.call(el.attributes) ?? [];
+  attributes = attributes.filter((a) => a.name !== 'style');
+  const filteredAttributes = filter?.length
+    ? attributes.filter((a) => filter.includes(a.name))
+    : attributes;
+  return filteredAttributes.reduce<Record<string, string>>((acc, attr) => {
+    const key = attr.name
+      // replace data-
+      .replace(reduceDataRegexp, '')
+      // convert "-a" with "A". image-id becomes imageId
+      .replace(reduceRegexp, (m) => m.charAt(1).toUpperCase());
+    acc[key] = attr.value;
+    return acc;
+  }, {});
+};
+
 export const reduceElementDataAttributes = (
   el: Element,
   filter?: string[],
@@ -93,6 +116,21 @@ export const parseEmbedTag = (embedTag?: string): Embed | undefined => {
   const obj = reduceElementDataAttributes(embedElements[0]);
   delete obj.id;
   return obj as unknown as Embed;
+};
+
+const attributeRegex = /[A-Z]/g;
+
+export const createEmbedTagV2 = (data: Record<string, any>) => {
+  if (Object.keys(data).length === 0) {
+    return undefined;
+  }
+  const dataSet = Object.entries(data).reduce<Record<string, any>>((acc, [key, value]) => {
+    const newKey = key.replace(attributeRegex, (m) => `-${m.toLowerCase()}`);
+    acc[`data-${newKey}`] = value;
+    return acc;
+  }, {});
+
+  return <ndlaembed {...dataSet}></ndlaembed>;
 };
 
 export const createEmbedTag = (data: { [key: string]: any }) => {


### PR DESCRIPTION
Helper-funksjonene er dratt ut fra https://github.com/NDLANO/editorial-frontend/pull/176.
Jeg mener at dette er ett steg nærmere bedre typesikkerhet i ED, samt at vi får slått sammen typene i ED og i types-embed. Tar en plugin om gangen for å gjøre det enklere å verifisere at ting går som det skal. Har et par til lokalt som er klare hvis denne går inn.

Har blitt en del strengere på hva som kan sendes inn til helper-funksjonene. I fremtiden håper jeg at vi kun skal ta i mot strings, i og med at alle attributtene skal bli strings til slutt. Selv om React til slutt klarer å serialisere ting riktig mener jeg dette kan hjelpe oss med å skrive embed-typer som er enklere å serialisere.