### PR TITLE
Send concept embed data as strings. Use proper types for both block and inline concepts

### DIFF
--- a/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockConcept.tsx
@@ -12,21 +12,19 @@ import { Editor, Element, Transforms, Path } from 'slate';
 import { ReactEditor, RenderElementProps, useSelected } from 'slate-react';
 import styled from '@emotion/styled';
 import { IConcept, IConceptSummary } from '@ndla/types-backend/concept-api';
+import { ConceptEmbedData } from '@ndla/types-embed';
 import ConceptModal from '../ConceptModal';
 import { useFetchConceptData } from '../../../../../containers/FormikForm/formikConceptHooks';
 import mergeLastUndos from '../../../utils/mergeLastUndos';
 import { TYPE_CONCEPT_BLOCK } from './types';
 import { ConceptBlockElement } from './interfaces';
 import BlockConceptPreview from './BlockConceptPreview';
-import { Dictionary } from '../../../../../interfaces';
 
-const getConceptDataAttributes = ({ id }: Dictionary<any>) => ({
-  type: TYPE_CONCEPT_BLOCK,
-  data: {
-    contentId: id,
-    resource: 'concept',
-    type: 'block',
-  },
+const getConceptDataAttributes = ({ id }: IConceptSummary | IConcept): ConceptEmbedData => ({
+  contentId: id.toString(),
+  resource: 'concept',
+  type: 'block',
+  linkText: '',
 });
 
 interface Props {
@@ -78,7 +76,7 @@ const BlockConcept = ({ element, locale, editor, attributes, children }: Props) 
         const path = ReactEditor.findPath(editor, element);
         Transforms.setNodes(
           editor,
-          { data: data.data },
+          { data },
           {
             at: path,
             match: (node) => Element.isElement(node) && node.type === TYPE_CONCEPT_BLOCK,

--- a/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineConcept.tsx
@@ -12,21 +12,21 @@ import { Editor, Element, Node, Transforms, Path } from 'slate';
 import { ReactEditor, RenderElementProps } from 'slate-react';
 import uniqueId from 'lodash/uniqueId';
 import { IConcept, IConceptSummary } from '@ndla/types-backend/concept-api';
+import { ConceptEmbedData } from '@ndla/types-embed';
 import { ConceptInlineElement } from '../inline/interfaces';
 import ConceptModal from '../ConceptModal';
 import { useFetchConceptData } from '../../../../../containers/FormikForm/formikConceptHooks';
 import { TYPE_CONCEPT_INLINE } from './types';
 import SlateNotion from './SlateNotion';
-import { Dictionary } from '../../../../../interfaces';
 
-const getConceptDataAttributes = ({ id, title: { title } }: Dictionary<any>) => ({
-  type: TYPE_CONCEPT_INLINE,
-  data: {
-    contentId: id,
-    linkText: title,
-    resource: 'concept',
-    type: 'inline',
-  },
+const getConceptDataAttributes = (
+  concept: IConcept | IConceptSummary,
+  title: string,
+): ConceptEmbedData => ({
+  contentId: concept.id.toString(),
+  linkText: title,
+  resource: 'concept',
+  type: 'inline',
 });
 
 interface Props {
@@ -64,15 +64,12 @@ const InlineConcept = (props: Props) => {
     toggleConceptModal();
     setTimeout(() => {
       handleSelectionChange(true);
-      const data = getConceptDataAttributes({
-        ...addedConcept,
-        title: { title: nodeText },
-      });
+      const data = getConceptDataAttributes(addedConcept, nodeText);
       if (element) {
         const path = ReactEditor.findPath(editor, element);
         Transforms.setNodes(
           editor,
-          { data: data.data },
+          { data },
           {
             at: path,
             match: (node) => Element.isElement(node) && node.type === TYPE_CONCEPT_INLINE,


### PR DESCRIPTION
Fikser feilen jeg nettopp innførte i ED. Vi filtrerer nå ut alt av attributter som ikke er strenger, og da ble ikke conceptId med. Bruker nå ordentlige typer så vi er sikre på at vi sender inn riktig data.