### PR TITLE
Styling updates WelcomePage

### DIFF
--- a/src/containers/WelcomePage/components/LastUsedItems.tsx
+++ b/src/containers/WelcomePage/components/LastUsedItems.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pencil } from '@ndla/icons/action';
 import orderBy from 'lodash/orderBy';
+import Pager from '@ndla/pager';
 import { StyledDashboardInfo, StyledLink } from '../styles';
 import TableComponent, { FieldElement, Prefix, TitleElement } from './TableComponent';
 import TableTitle from './TableTitle';
@@ -32,6 +33,7 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
   ];
   const [sortOption, setSortOption] = useState<Prefix<'-', SortOptionLastUsed>>('-lastUpdated');
   const [error, setError] = useState<string | undefined>(undefined);
+  const [page, setPage] = useState(1);
 
   const { data, isInitialLoading } = useSearchDrafts(
     {
@@ -49,12 +51,15 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
   const sortedData = useMemo(() => {
     if (!data?.results) return [];
     const sortDesc = sortOption.charAt(0) === '-';
+    const startIndex = page > 1 ? (page - 1) * 6 : 0;
+    const currentPageElements = data?.results.slice(startIndex, startIndex + 6);
+
     return orderBy(
-      data.results,
+      currentPageElements,
       (t) => (sortOption.includes('title') ? t.title?.title : t.updated),
       [sortDesc ? 'desc' : 'asc'],
     );
-  }, [data?.results, sortOption]);
+  }, [data?.results, sortOption, page]);
 
   const tableData: FieldElement[][] = useMemo(
     () =>
@@ -67,7 +72,6 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
       ]) ?? [[]],
     [sortedData],
   );
-
   return (
     <StyledDashboardInfo>
       <TableTitle
@@ -83,6 +87,15 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
         sortOption={sortOption}
         error={error}
         noResultsText={t('welcomePage.emptyLastUsed')}
+      />
+      <Pager
+        page={page ?? 1}
+        lastPage={2}
+        query={{}}
+        onClick={(el) => setPage(el.page)}
+        small
+        colorTheme="lighter"
+        pageItemComponentClass="button"
       />
     </StyledDashboardInfo>
   );

--- a/src/containers/WelcomePage/components/LastUsedItems.tsx
+++ b/src/containers/WelcomePage/components/LastUsedItems.tsx
@@ -78,7 +78,7 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
   );
 
   const lastPage = useMemo(
-    () => (data?.results.length ? Math.ceil(data.results.length / (PAGE_SIZE ?? 1)) : 1),
+    () => (data?.results.length ? Math.ceil(data.results.length / PAGE_SIZE) : 1),
     [data?.results],
   );
 

--- a/src/containers/WelcomePage/components/LastUsedItems.tsx
+++ b/src/containers/WelcomePage/components/LastUsedItems.tsx
@@ -24,6 +24,8 @@ interface Props {
 
 type SortOptionLastUsed = 'title' | 'lastUpdated';
 
+const PAGE_SIZE = 6;
+
 const LastUsedItems = ({ lastUsed = [] }: Props) => {
   const { t, i18n } = useTranslation();
 
@@ -51,8 +53,10 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
   const sortedData = useMemo(() => {
     if (!data?.results) return [];
     const sortDesc = sortOption.charAt(0) === '-';
-    const startIndex = page > 1 ? (page - 1) * 6 : 0;
-    const currentPageElements = data?.results.slice(startIndex, startIndex + 6);
+    // Pagination logic. startIndex indicates start position in data.results for current page
+    // currentPageElements is data to be displayed at current page
+    const startIndex = page > 1 ? (page - 1) * PAGE_SIZE : 0;
+    const currentPageElements = data?.results.slice(startIndex, startIndex + PAGE_SIZE);
 
     return orderBy(
       currentPageElements,
@@ -72,6 +76,12 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
       ]) ?? [[]],
     [sortedData],
   );
+
+  const lastPage = useMemo(
+    () => (data?.results.length ? Math.ceil(data.results.length / (PAGE_SIZE ?? 1)) : 1),
+    [data?.results],
+  );
+
   return (
     <StyledDashboardInfo>
       <TableTitle
@@ -89,8 +99,8 @@ const LastUsedItems = ({ lastUsed = [] }: Props) => {
         noResultsText={t('welcomePage.emptyLastUsed')}
       />
       <Pager
-        page={page ?? 1}
-        lastPage={2}
+        page={page}
+        lastPage={lastPage}
         query={{}}
         onClick={(el) => setPage(el.page)}
         small

--- a/src/containers/WelcomePage/components/TableComponent.tsx
+++ b/src/containers/WelcomePage/components/TableComponent.tsx
@@ -35,6 +35,7 @@ const StyledTable = styled.table`
     padding: 0px ${spacing.xsmall};
     border-bottom: 1px solid ${colors.text.primary};
     background-color: ${colors.brand.lighter};
+    overflow-wrap: anywhere;
   }
   th:not(:first-of-type) {
     border-left: 1px solid ${colors.text.primary};

--- a/src/containers/WelcomePage/components/TableComponent.tsx
+++ b/src/containers/WelcomePage/components/TableComponent.tsx
@@ -16,6 +16,10 @@ import Tooltip from '@ndla/tooltip';
 import { useTranslation } from 'react-i18next';
 import Spinner from '../../../components/Spinner';
 
+const TableWrapper = styled.div`
+  height: 250px;
+`;
+
 const StyledTable = styled.table`
   font-family: arial, sans-serif;
   border-collapse: separate;
@@ -25,6 +29,7 @@ const StyledTable = styled.table`
   margin-bottom: 0px;
   table-layout: fixed;
   display: inline-table;
+  overflow: hidden;
   th {
     font-weight: ${fonts.weight.bold};
     padding: 0px ${spacing.xsmall};
@@ -40,9 +45,6 @@ const StyledTable = styled.table`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-  tr {
-    height: 30px;
   }
   tr:nth-of-type(even) {
     background: ${colors.brand.lightest};
@@ -127,7 +129,7 @@ const TableComponent = <T extends string>({
   if (error) return <StyledError>{error}</StyledError>;
 
   return (
-    <>
+    <TableWrapper>
       <StyledTable>
         <thead>
           <tr>
@@ -185,7 +187,7 @@ const TableComponent = <T extends string>({
       ) : noResultsText && isEmpty(tableData.flat()) ? (
         <NoResultsText>{noResultsText}</NoResultsText>
       ) : null}
-    </>
+    </TableWrapper>
   );
 };
 


### PR DESCRIPTION
Noen små styling-updates:
- Fixed høyde på boksene på dashboard
- Legger til pager til Sist redigert-boks for likt utseende
- Legger til bedre overflow-handling i tabell-titler (**NB**: Burde vi gjøre dette på en annen måte? Nå vil titler deles midt i ord ved overflow, Men det er kanskje fortsatt bedre enn å kutte deler av tittelen .. se bilder under for sammenligning)

![Skjermbilde 2023-04-11 kl  11 53 53](https://user-images.githubusercontent.com/26788204/231125440-d7e9cc10-5fe1-455c-916f-9c2cee48179d.png)
![Skjermbilde 2023-04-11 kl  11 53 43](https://user-images.githubusercontent.com/26788204/231125456-bb78b3be-ec55-44d4-af09-7dc3de1fde3c.png)
