### PR TITLE
Content link to new embed type

### DIFF
--- a/src/components/SlateEditor/plugins/link/EditLink.tsx
+++ b/src/components/SlateEditor/plugins/link/EditLink.tsx
@@ -40,13 +40,16 @@ const StyledModalBody = styled(ModalBody)`
 const createContentLinkData = (
   id: string,
   resourceType: string | undefined,
-  targetRel: { 'open-in': string },
+  openIn: string,
 ): Partial<ContentLinkElement> => {
   return {
     type: TYPE_CONTENT_LINK,
-    'content-id': id,
-    'content-type': resourceType || 'article',
-    ...targetRel,
+    data: {
+      resource: TYPE_CONTENT_LINK,
+      contentId: id,
+      contentType: resourceType || 'article',
+      openIn,
+    },
   };
 };
 
@@ -112,7 +115,7 @@ const EditLink = (props: Props) => {
 
     const { resourceId, resourceType } = await getIdAndTypeFromUrl(href);
 
-    const targetRel = checkbox ? { 'open-in': 'new-context' } : { 'open-in': 'current-context' };
+    const targetRel = checkbox ? 'new-context' : 'current-context';
 
     const data = resourceId
       ? createContentLinkData(resourceId, resourceType, targetRel)

--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -37,8 +37,8 @@ const StyledLinkMenu = styled('span')<StyledLinkMenuProps>`
   z-index: 1;
 `;
 
-const fetchResourcePath = (data: ContentLinkElement, language: string, contentType: string) => {
-  const id = data['content-id'];
+const fetchResourcePath = (node: ContentLinkElement, language: string, contentType: string) => {
+  const id = node.data.contentId;
   return contentType === 'learningpath'
     ? toLearningpathFull(id, language)
     : `${config.editorialFrontendDomain}${toEditGenericArticle(id)}`;
@@ -46,7 +46,7 @@ const fetchResourcePath = (data: ContentLinkElement, language: string, contentTy
 
 function hasHrefOrContentId(node: LinkElement | ContentLinkElement) {
   if (node.type === 'content-link') {
-    return !!node['content-id'];
+    return !!node.data.contentId;
   } else {
     return !!node.href;
   }
@@ -109,9 +109,9 @@ const Link = (props: Props) => {
       let href;
       let checkbox;
       if (element.type === 'content-link') {
-        const contentType = element['content-type'] || 'article';
+        const contentType = element.data.contentType || 'article';
         href = `${fetchResourcePath(element, language, contentType)}`;
-        checkbox = element['open-in'] === 'new-context';
+        checkbox = element.data.openIn === 'new-context';
       } else {
         href = element.href;
         checkbox = element.target === '_blank';

--- a/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
@@ -81,9 +81,12 @@ describe('link normalizer tests', () => {
               { text: '' },
               {
                 type: TYPE_CONTENT_LINK,
-                'content-id': '123',
-                'content-type': 'article',
-                'open-in': 'current-context',
+                data: {
+                  resource: TYPE_CONTENT_LINK,
+                  contentId: '123',
+                  contentType: 'article',
+                  openIn: 'current-context',
+                },
                 children: [{ bold: true, italic: true, text: 'content' }],
               },
               { text: '' },
@@ -103,9 +106,12 @@ describe('link normalizer tests', () => {
               { text: '' },
               {
                 type: TYPE_CONTENT_LINK,
-                'content-id': '123',
-                'content-type': 'article',
-                'open-in': 'current-context',
+                data: {
+                  resource: TYPE_CONTENT_LINK,
+                  contentId: '123',
+                  contentType: 'article',
+                  openIn: 'current-context',
+                },
                 children: [{ bold: true, italic: true, text: 'content' }],
               },
               { text: '' },
@@ -140,9 +146,12 @@ describe('link normalizer tests', () => {
               { text: '' },
               {
                 type: TYPE_CONTENT_LINK,
-                'content-type': 'test',
-                'content-id': '123',
-                'open-in': 'test',
+                data: {
+                  resource: TYPE_CONTENT_LINK,
+                  contentType: 'test',
+                  contentId: '123',
+                  openIn: 'test',
+                },
                 children: [
                   {
                     text: '',

--- a/src/components/SlateEditor/plugins/link/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/serializer-test.ts
@@ -44,9 +44,12 @@ const editor: Descendant[] = [
           { text: '' },
           {
             type: TYPE_CONTENT_LINK,
-            'content-id': '123',
-            'content-type': 'article',
-            'open-in': 'new-context',
+            data: {
+              resource: TYPE_CONTENT_LINK,
+              contentId: '123',
+              contentType: 'article',
+              openIn: 'new-context',
+            },
             children: [
               {
                 text: 'content-link',

--- a/src/components/SlateEditor/plugins/link/index.tsx
+++ b/src/components/SlateEditor/plugins/link/index.tsx
@@ -9,9 +9,10 @@
 import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element, Text, Node, Transforms } from 'slate';
+import { ContentLinkEmbedData } from '@ndla/types-embed';
 import { SlateSerializer } from '../../interfaces';
 import Link from './Link';
-import { reduceElementDataAttributes } from '../../../../util/embedTagHelpers';
+import { reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { TYPE_CONTENT_LINK, TYPE_LINK } from './types';
 import { TYPE_NDLA_EMBED } from '../embed/types';
 
@@ -26,9 +27,7 @@ export interface LinkElement {
 
 export interface ContentLinkElement {
   type: 'content-link';
-  'content-type': string;
-  'content-id': string;
-  'open-in': string;
+  data: ContentLinkEmbedData;
   children: Descendant[];
 }
 
@@ -51,15 +50,13 @@ export const linkSerializer: SlateSerializer = {
     }
     if (tag === TYPE_NDLA_EMBED) {
       const embed = el as HTMLEmbedElement;
-      const embedAttributes = reduceElementDataAttributes(embed);
+      const embedAttributes = reduceElementDataAttributesV2(Array.from(embed.attributes));
       if (embedAttributes.resource !== 'content-link') return;
       return slatejsx(
         'element',
         {
           type: TYPE_CONTENT_LINK,
-          'content-type': embedAttributes['content-type'],
-          'open-in': embedAttributes['open-in'],
-          'content-id': embedAttributes['content-id'],
+          data: embedAttributes,
         },
         children,
       );
@@ -78,10 +75,10 @@ export const linkSerializer: SlateSerializer = {
     if (node.type === TYPE_CONTENT_LINK) {
       return (
         <ndlaembed
-          data-content-id={node['content-id']}
-          data-open-in={node['open-in']}
+          data-content-id={node.data.contentId}
+          data-open-in={node.data.openIn}
           data-resource="content-link"
-          data-content-type={node['content-type']}
+          data-content-type={node.data.contentType}
         >
           {children}
         </ndlaembed>

--- a/src/util/__tests__/slateMockValues.js
+++ b/src/util/__tests__/slateMockValues.js
@@ -84,9 +84,9 @@ export const valueWithInlineFootnotesAndContentLinks = {
         },
         {
           data: {
-            'content-id': '1031',
+            contentId: '1031',
             resource: 'content-link',
-            'link-text': 'dolore',
+            linkText: 'dolore',
           },
           type: 'content-link',
           children: [
@@ -119,9 +119,9 @@ export const valueWithInlineFootnotesAndContentLinks = {
         },
         {
           data: {
-            'content-id': '1031',
+            contentId: '1031',
             resource: 'content-link',
-            'link-text': 'laborum',
+            linkText: 'laborum',
           },
           type: 'content-link',
           children: [


### PR DESCRIPTION
Verdiene i `SlateMockValues` er litt... ish. I ED serialiserer vi barna til content-link til vanlig HTML, som deretter legges i `data-link-text` i GQL. Skal vi endre det, eller skal vi bare beholde det?