### PR TITLE
Add status as sortable field in worklist

### DIFF
--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -36,7 +36,7 @@ interface Props {
   ndlaId: string | undefined;
 }
 
-type SortOptionRevision = 'title' | 'revisionDate';
+type SortOptionRevision = 'title' | 'revisionDate' | 'status';
 
 const Revisions = ({ userData, ndlaId }: Props) => {
   const [filterSubject, setFilterSubject] = useState<SingleValue | undefined>(undefined);
@@ -52,7 +52,7 @@ const Revisions = ({ userData, ndlaId }: Props) => {
 
   const tableTitles: TitleElement<SortOptionRevision>[] = [
     { title: t('form.article.label'), sortableField: 'title' },
-    { title: t('welcomePage.workList.status') },
+    { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.primarySubject') },
     { title: t('welcomePage.revisionDate'), sortableField: 'revisionDate' },
   ];

--- a/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
@@ -128,7 +128,7 @@ const ConceptListTabContent = ({
 
   const tableTitles: TitleElement<SortOption>[] = [
     { title: t('welcomePage.workList.name'), sortableField: 'title' },
-    { title: t('welcomePage.workList.status') },
+    { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.conceptSubject') },
     { title: t('welcomePage.workList.date'), sortableField: 'responsibleLastUpdated' },
   ];

--- a/src/containers/WelcomePage/components/worklist/WorkList.tsx
+++ b/src/containers/WelcomePage/components/worklist/WorkList.tsx
@@ -20,7 +20,7 @@ interface Props {
   ndlaId: string;
 }
 
-export type SortOption = 'title' | 'responsibleLastUpdated';
+export type SortOption = 'title' | 'responsibleLastUpdated' | 'status';
 
 const WorkList = ({ ndlaId }: Props) => {
   const [sortOption, setSortOption] = useState<Prefix<'-', SortOption>>('-responsibleLastUpdated');

--- a/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
@@ -90,7 +90,7 @@ const WorkListTabContent = ({
 
   const tableTitles: TitleElement<SortOption>[] = [
     { title: t('welcomePage.workList.name'), sortableField: 'title' },
-    { title: t('welcomePage.workList.status') },
+    { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.contentType') },
     { title: t('welcomePage.workList.primarySubject') },
     { title: t('welcomePage.workList.topicRelation') },


### PR DESCRIPTION
Kan testes ved å sjekke at status-sortering fungerer for artikler, forklaringer og revisjoner på dashboard