### PR TITLE
Øker størrelsen på h5p-iframe.

### DIFF
--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -14,15 +14,14 @@ import handleError from '../../util/handleError';
 import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PInfo } from './h5pApi';
 
 const FlexWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  flex: 1;
   display: flex;
+  flex: 1;
+  width: 100%;
 `;
 
 const StyledIFrame = styled.iframe`
-  height: 100%;
   flex: 1;
+  overflow: hidden;
 `;
 
 interface OnSelectObject {
@@ -101,7 +100,7 @@ const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: P
   };
 
   return (
-    <FlexWrapper data-cy="h5p-editor" id="h5p-editor">
+    <FlexWrapper data-cy="h5p-editor">
       {fetchFailed && (
         <ErrorMessage
           illustration={{

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -16,10 +16,13 @@ import { fetchH5PiframeUrl, editH5PiframeUrl, fetchH5PInfo } from './h5pApi';
 const FlexWrapper = styled.div`
   width: 100%;
   height: 100%;
+  flex: 1;
+  display: flex;
 `;
 
 const StyledIFrame = styled.iframe`
   height: 100%;
+  flex: 1;
 `;
 
 interface OnSelectObject {

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -98,7 +98,7 @@ const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: P
   };
 
   return (
-    <FlexWrapper data-cy="h5p-editor">
+    <FlexWrapper data-cy="h5p-editor" id="h5p-editor">
       {fetchFailed && (
         <ErrorMessage
           illustration={{

--- a/src/containers/H5PPage/H5PPage.tsx
+++ b/src/containers/H5PPage/H5PPage.tsx
@@ -13,7 +13,6 @@ const H5PPage = () => {
       <Global
         styles={{
           '#h5p-editor': {
-            height: '93vh',
             display: 'flex',
             flexDirection: 'column',
           },

--- a/src/containers/H5PPage/H5PPage.tsx
+++ b/src/containers/H5PPage/H5PPage.tsx
@@ -1,23 +1,21 @@
-import { Global } from '@emotion/react';
+import styled from '@emotion/styled';
 import { HelmetWithTracker } from '@ndla/tracker';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import H5PElement from '../../components/H5PElement/H5PElement';
+
+const H5PWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
 
 const H5PPage = () => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const locale = i18n.language;
   return (
-    <>
-      <Global
-        styles={{
-          '#h5p-editor': {
-            display: 'flex',
-            flexDirection: 'column',
-          },
-        }}
-      />
+    <H5PWrapper>
       <HelmetWithTracker title={t('htmlTitles.h5pPage')} />
       <H5PElement
         canReturnResources={false}
@@ -27,7 +25,7 @@ const H5PPage = () => {
         }}
         locale={locale}
       />
-    </>
+    </H5PWrapper>
   );
 };
 

--- a/src/containers/H5PPage/H5PPage.tsx
+++ b/src/containers/H5PPage/H5PPage.tsx
@@ -12,8 +12,8 @@ const H5PPage = () => {
     <>
       <Global
         styles={{
-          '.o-content': {
-            height: '100vh',
+          '#h5p-editor': {
+            height: '93vh',
             display: 'flex',
             flexDirection: 'column',
           },


### PR DESCRIPTION
Bruker flex for å la h5p-iframe ta opp resten av skjermen.

Test: Etter å ha logga inn, klikk på "Rediger H5P" i menyen og sjekk at edlib tar opp alt av skjermbilde under header.