### PR TITLE
Fix input field comment being reset when click outside

### DIFF
--- a/src/containers/ArticlePage/components/InputComment.tsx
+++ b/src/containers/ArticlePage/components/InputComment.tsx
@@ -60,6 +60,7 @@ const InputComment = ({ comments, setComments }: Props) => {
   const { t } = useTranslation();
   const { userName } = useSession();
   const [inputValue, setInputValue] = useState('');
+  const [clickedInputField, setClickedInputField] = useState(false);
 
   const handleInputChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>): void => {
     setInputValue(e.target.value);
@@ -79,12 +80,16 @@ const InputComment = ({ comments, setComments }: Props) => {
     const formattedDate = formatDate(dateTime);
     const formattedTime = format(currentDate, 'HH:mm');
 
-    setInputValue(
-      `\n${t('form.workflow.addComment.createdBy')} ${
-        userName?.split(' ')[0]
-      } (${formattedDate} - ${formattedTime})`,
-    );
-    setTimeout(() => createComment.current?.setSelectionRange(0, 0), 0);
+    if (!clickedInputField) {
+      setInputValue(
+        `${inputValue}\n${t('form.workflow.addComment.createdBy')} ${
+          userName?.split(' ')[0]
+        } (${formattedDate} - ${formattedTime})`,
+      );
+      setTimeout(() => createComment.current?.setSelectionRange(0, 0), 0);
+    }
+
+    setClickedInputField(true);
   };
 
   return (
@@ -107,7 +112,10 @@ const InputComment = ({ comments, setComments }: Props) => {
             size="xsmall"
             colorTheme="danger"
             disabled={!inputValue}
-            onClick={() => setInputValue('')}
+            onClick={() => {
+              setInputValue('');
+              setClickedInputField(false);
+            }}
           >
             {t('form.abort')}
           </StyledButtonSmall>
@@ -119,6 +127,7 @@ const InputComment = ({ comments, setComments }: Props) => {
             onClick={() => {
               addComment();
               setInputValue('');
+              setClickedInputField(false);
             }}
           >
             {t('form.comment')}


### PR DESCRIPTION
fixes [https://trello.com/c/RdlbTvEd/61-innhold-i-gul-lapp-nullstilles-n%C3%A5r-man-klikker-ut](https://trello.com/c/RdlbTvEd/61-innhold-i-gul-lapp-nullstilles-n%C3%A5r-man-klikker-ut)

Fikser bug der det man har startet å skrive i øverste inputboks for kommentarer ble nullstilt når man klikket ut for så å klikke inn igjen.