### PR TITLE
Sets width for monaco editor

### DIFF
--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -92,6 +92,7 @@ const StyledErrorMessage = styled.p`
 const Container = styled.div`
   margin: 0 auto;
   max-width: 1000px;
+  width: 100%;
 `;
 
 const LanguageWrapper = styled.div`


### PR DESCRIPTION
Fikser slik at monaco-editor tar opp den plassen den skal ha.

Test: Åpne html-editor og sammenlign med test og staging. Bredda skal være tilsvarende som staging.