### PR TITLE
Fix z-index issue at dashboard

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -26,7 +26,7 @@ const appearances: Record<string, SerializedStyles> = {
   `,
   lighter: css`
     background: rgba(1, 1, 1, 0.3);
-    z-index: 2;
+    z-index: 3;
   `,
 };
 

--- a/src/containers/Masthead/components/Navigation.tsx
+++ b/src/containers/Masthead/components/Navigation.tsx
@@ -33,7 +33,7 @@ interface StyledNavigationWrapperProps {
 
 const StyledNavigationWrapper = styled.div<StyledNavigationWrapperProps>`
   position: absolute;
-  z-index: ${(props) => props.open && '3'};
+  z-index: ${(props) => props.open && '4'};
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Fikser opp i dette når NavigationMenu er åpen:
<img width="411" alt="Skjermbilde 2023-05-23 kl  14 51 00" src="https://github.com/NDLANO/editorial-frontend/assets/26788204/825e5d22-4dc4-436a-9d1e-28806b6fb9c0">

Skal gå fint å oppdatere z-index direkte sånn i Overlay, ettersom lighter apperance kun blir brukt i Navigtion