### PR TITLE
Removed unecessary objects in ActionsToShowInArea

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -262,16 +262,17 @@ const SlateBlockPicker = ({
     });
 
     for (const entry of nodes) {
-      const [node] = entry;
+      const [node, path] = entry;
       if (!Element.isElement(node)) return actions;
       if (node.type === 'section') {
         return actions;
       }
-      if (actionsToShowInAreas[node.type]) {
+      const [parent] = Editor.parent(editor, path);
+      if (Element.isElement(parent) && actionsToShowInAreas[parent.type]) {
         return actions.filter(
           (action) =>
-            actionsToShowInAreas[node.type].includes(action.data.type) ||
-            actionsToShowInAreas[node.type].includes(action.data.object),
+            actionsToShowInAreas[parent.type].includes(action.data.type) ||
+            actionsToShowInAreas[parent.type].includes(action.data.object),
         );
       }
     }

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -109,14 +109,8 @@ const visualElements = [
 
 const actions = [TYPE_TABLE, TYPE_CODEBLOCK, TYPE_FILE, TYPE_BLOGPOST].concat(visualElements);
 const actionsToShowInAreas = {
-  details: actions,
-  aside: actions,
-  bodybox: actions,
-  summary: actions,
-  list: actions,
-  'list-item': actions,
   table: ['image'],
-  paragraph: actions,
+  section: actions,
 };
 
 // Plugins are checked from last to first

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -73,7 +73,7 @@ import {
 import { TYPE_TABLE } from '../../../../components/SlateEditor/plugins/table/types';
 import { TYPE_CODEBLOCK } from '../../../../components/SlateEditor/plugins/codeBlock/types';
 import { TYPE_FILE } from '../../../../components/SlateEditor/plugins/file/types';
-import { blogPostPlugin } from '../../../../components/SlateEditor/plugins/blogPost';
+import { TYPE_SUMMARY } from '../../../../components/SlateEditor/plugins/details/types';
 
 const StyledFormikField = styled(FormikField)`
   display: flex;
@@ -122,10 +122,7 @@ const actionsToShowInAreas = {
   details: actions,
   aside: actions,
   bodybox: actions,
-  summary: actions,
-  list: actions,
-  'list-item': actions,
-  table: ['image'],
+  'table-cell': ['image'],
 };
 
 // Plugins are checked from last to first


### PR DESCRIPTION
Fant ut at ActionsToShowInAreas generelt ikke fungerte. Node type som ble sjekket mot var alltid av type 'paragraf', det er bedre å sjekke parent da det er den som bestemmer hva som skal være tillat i henhold til normalisering. 
Fjerner også noen ubrukte `areas` da de ikke er i bruk i den gitte artikkel typen eller generelt ikke fungerte. 

Gjerne ta å test ulike blocks for å se at det fungerer 😄 