### PR TITLE
Add toggle for resources with primary connection in revision block

### DIFF
--- a/src/containers/WelcomePage/WelcomePage.tsx
+++ b/src/containers/WelcomePage/WelcomePage.tsx
@@ -72,7 +72,7 @@ export const WelcomePage = () => {
           )}
         </Column>
         <Column colStart={6} colEnd={12}>
-          {ndlaId && <Revisions ndlaId={ndlaId} userData={data} />}
+          {ndlaId && <Revisions userData={data} />}
         </Column>
       </GridContainer>
 

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -46,6 +46,9 @@ const RevisionsWrapper = styled.div`
 
 const SwitchWrapper = styled.div`
   margin-top: ${spacing.xxsmall};
+  & button {
+    margin-left: auto;
+  }
 `;
 
 const getLastPage = (totalCount: number, pageSize: number) =>

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -15,7 +15,7 @@ import { Select, SingleValue } from '@ndla/select';
 import Pager from '@ndla/pager';
 import sortBy from 'lodash/sortBy';
 import styled from '@emotion/styled';
-import { mq, breakpoints, spacing } from '@ndla/core';
+import { mq, breakpoints, spacing, fonts } from '@ndla/core';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
 import { Switch } from '@ndla/switch';
 import Tooltip from '@ndla/tooltip';
@@ -45,10 +45,23 @@ const RevisionsWrapper = styled.div`
 `;
 
 const SwitchWrapper = styled.div`
-  margin-top: ${spacing.xxsmall};
+  margin-top: ${spacing.small};
   & button {
     margin-left: auto;
   }
+`;
+
+const StyledSwitch = styled(Switch)`
+  white-space: nowrap;
+  label {
+    font-size: ${fonts.sizes('16px')};
+    margin-left: auto;
+  }
+`;
+
+const StyledRevisionControls = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 const getLastPage = (totalCount: number, pageSize: number) =>
@@ -194,44 +207,46 @@ const Revisions = ({ userData }: Props) => {
             Icon={Alarm}
             infoText={t('welcomePage.revisionInfo')}
           />
-          <ControlWrapperDashboard>
+          <StyledRevisionControls>
+            <ControlWrapperDashboard>
+              <DropdownWrapper>
+                <Select<false>
+                  label={t('welcomePage.chooseFavoriteSubject')}
+                  options={favoriteSubjects ?? []}
+                  placeholder={t('welcomePage.chooseFavoriteSubject')}
+                  value={filterSubject}
+                  onChange={setFilterSubject}
+                  menuPlacement="bottom"
+                  small
+                  outline
+                  isLoading={isInitialLoadingSubjects}
+                  isSearchable
+                  noOptionsMessage={() => t('form.responsible.noResults')}
+                  isClearable
+                />
+              </DropdownWrapper>
+              <GoToSearch
+                filterSubject={filterSubject?.value ?? FAVOURITES_SUBJECT_ID}
+                searchEnv="content"
+                revisionDateTo={currentDateAddYear}
+              />
+            </ControlWrapperDashboard>
             <Tooltip tooltip={t('welcomePage.primaryConnection')}>
               <SwitchWrapper>
-                <Switch
+                <StyledSwitch
                   checked={checked}
                   onChange={() => {
                     setChecked(!checked);
                     setPage(1);
                   }}
-                  label={''}
-                  id={'filter-primary-connection-switch'}
+                  label={t('welcomePage.primaryConnectionLabel')}
+                  id="filter-primary-connection-switch"
                   aria-label={t('welcomePage.primaryConnection')}
                   thumbCharacter="P"
                 />
               </SwitchWrapper>
             </Tooltip>
-            <DropdownWrapper>
-              <Select<false>
-                label={t('welcomePage.chooseFavoriteSubject')}
-                options={favoriteSubjects ?? []}
-                placeholder={t('welcomePage.chooseFavoriteSubject')}
-                value={filterSubject}
-                onChange={setFilterSubject}
-                menuPlacement="bottom"
-                small
-                outline
-                isLoading={isInitialLoadingSubjects}
-                isSearchable
-                noOptionsMessage={() => t('form.responsible.noResults')}
-                isClearable
-              />
-            </DropdownWrapper>
-            <GoToSearch
-              filterSubject={filterSubject?.value ?? FAVOURITES_SUBJECT_ID}
-              searchEnv="content"
-              revisionDateTo={currentDateAddYear}
-            />
-          </ControlWrapperDashboard>
+          </StyledRevisionControls>
         </StyledTopRowDashboardInfo>
         <TableComponent
           isLoading={isInitialLoading}

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -45,7 +45,6 @@ const RevisionsWrapper = styled.div`
 `;
 
 const SwitchWrapper = styled.div`
-  float: right;
   margin-top: ${spacing.xxsmall};
 `;
 
@@ -125,7 +124,7 @@ const Revisions = ({ userData }: Props) => {
             ?.map((r) => {
               const primarySubject = r.contexts.find((c) => c.isPrimary);
               const isFavorite = userData?.favoriteSubjects?.some(
-                (fs) => fs === primarySubject?.subjectId,
+                (fs) => fs === primarySubject?.rootId,
               );
               return isFavorite ? r : undefined;
             })

--- a/src/containers/WelcomePage/styles.tsx
+++ b/src/containers/WelcomePage/styles.tsx
@@ -48,7 +48,7 @@ export const DropdownWrapper = styled.div`
 export const ControlWrapperDashboard = styled.div`
   display: flex;
   gap: ${spacing.small};
-  ${mq.range({ until: breakpoints.desktop })} {
+  ${mq.range({ until: breakpoints.tablet })} {
     flex-direction: column;
   }
 `;

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -135,6 +135,7 @@ const phrases = {
     revisionDate: 'Revision date',
     welcomeText: 'to ED',
     revisionInfo: 'Choose your favorite subjects by marking them with a star in structure editing',
+    primaryConnection: 'Only show resources with primary connection to my favorite subjects',
     workList: {
       title: 'My tasks',
       description: 'Articles where you are responsible',

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -136,6 +136,7 @@ const phrases = {
     welcomeText: 'to ED',
     revisionInfo: 'Choose your favorite subjects by marking them with a star in structure editing',
     primaryConnection: 'Only show resources with primary connection to my favorite subjects',
+    primaryConnectionLabel: 'Only show primary connection',
     workList: {
       title: 'My tasks',
       description: 'Articles where you are responsible',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -136,6 +136,7 @@ const phrases = {
     revisionDate: 'Revisjonsdato',
     welcomeText: 'til ED',
     revisionInfo: 'Velg favorittfag ved å stjernemarkere i strukturredigering',
+    primaryConnection: 'Vis kun ressurser med primærkobling til mine favorittfag',
     workList: {
       title: 'Mine arbeidsoppgaver',
       description: 'Artikler hvor du står som ansvarlig',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -137,7 +137,7 @@ const phrases = {
     welcomeText: 'til ED',
     revisionInfo: 'Velg favorittfag ved å stjernemarkere i strukturredigering',
     primaryConnection: 'Vis kun ressurser med primærkobling til mine favorittfag',
-    primaryConnectionLabel: 'Kun vis primærkobling',
+    primaryConnectionLabel: 'Vis kun primærkobling',
     workList: {
       title: 'Mine arbeidsoppgaver',
       description: 'Artikler hvor du står som ansvarlig',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -137,6 +137,7 @@ const phrases = {
     welcomeText: 'til ED',
     revisionInfo: 'Velg favorittfag ved å stjernemarkere i strukturredigering',
     primaryConnection: 'Vis kun ressurser med primærkobling til mine favorittfag',
+    primaryConnectionLabel: 'Kun vis primærkobling',
     workList: {
       title: 'Mine arbeidsoppgaver',
       description: 'Artikler hvor du står som ansvarlig',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -137,6 +137,7 @@ const phrases = {
     welcomeText: 'til ED',
     revisionInfo: 'Vel favorittfag ved å stjernemarkere i strukturredigering',
     primaryConnection: 'Vis berre ressursar med primærkopling til mine favorittfag',
+    primaryConnectionLabel: 'Kun vis primærkopling',
     workList: {
       title: 'Mine arbeidsoppgåver',
       description: 'Artiklar der du står som ansvarleg',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -136,8 +136,8 @@ const phrases = {
     revisionDate: 'Revisjonsdato',
     welcomeText: 'til ED',
     revisionInfo: 'Vel favorittfag ved å stjernemarkere i strukturredigering',
-    primaryConnection: 'Vis berre ressursar med primærkopling til mine favorittfag',
-    primaryConnectionLabel: 'Kun vis primærkopling',
+    primaryConnection: 'Berre vis ressursar med primærkopling til mine favorittfag',
+    primaryConnectionLabel: 'Berre vis primærkopling',
     workList: {
       title: 'Mine arbeidsoppgåver',
       description: 'Artiklar der du står som ansvarleg',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -136,6 +136,7 @@ const phrases = {
     revisionDate: 'Revisjonsdato',
     welcomeText: 'til ED',
     revisionInfo: 'Vel favorittfag ved å stjernemarkere i strukturredigering',
+    primaryConnection: 'Vis berre ressursar med primærkopling til mine favorittfag',
     workList: {
       title: 'Mine arbeidsoppgåver',
       description: 'Artiklar der du står som ansvarleg',


### PR DESCRIPTION
fixes https://trello.com/c/Dn1pxrim/63-revisjonsblokka-kunne-filtrere-p%C3%A5-prim%C3%A6rkobling

Legger til toggle for å filtrere på kun artikler med primærkobling til favorittfag i revisjonsblokka