### PR TITLE
remove supportedLanguages > 1 condition from PreviewLightBox concept,…

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -25,19 +25,12 @@ interface PreviewLightBoxProps {
   article?: IArticle;
   concept?: IConcept;
   type: string;
-  supportedLanguages?: string[];
   currentLanguage: string;
 }
 
-const PreviewLightBox = ({
-  type,
-  supportedLanguages = [],
-  currentLanguage,
-  article,
-  concept,
-}: PreviewLightBoxProps) => {
+const PreviewLightBox = ({ type, currentLanguage, article, concept }: PreviewLightBoxProps) => {
   const { t } = useTranslation();
-  if (type === 'concept' && concept && supportedLanguages.length > 1) {
+  if (type === 'concept' && concept) {
     return (
       <PreviewDraftLightboxV2
         type="conceptCompare"
@@ -148,7 +141,6 @@ const HeaderActions = ({
               article={article}
               concept={concept}
               type={type}
-              supportedLanguages={supportedLanguages}
               currentLanguage={values.language}
             />
             <StyledSplitter />


### PR DESCRIPTION
… in order to be more consistent with article type

Fikser styled splitter som dobla seg. Legger til `sammenlign språkversjoner` knappen på forklaringer selvom det er kun 1 språk, for å holde koden konsistent med artikler.

## BEFORE
![image](https://github.com/NDLANO/editorial-frontend/assets/10486712/ee1e9f74-7448-4238-bcc8-3445fbfcfc37)

## AFTER
![image](https://github.com/NDLANO/editorial-frontend/assets/10486712/772ab42e-b598-4fd1-866c-52b6b785e65c)
