### PR TITLE
Only fetch subjects for structure-page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 scripts/.cache/
 .vscode
 .env
+.tool-versions

--- a/cypress/e2e/Taxonomy/subject_spec.js
+++ b/cypress/e2e/Taxonomy/subject_spec.js
@@ -16,7 +16,7 @@ describe('Subject editing', () => {
     setToken();
 
     cy.apiroute('GET', `${taxonomyApi}/versions`, 'allVersions');
-    cy.apiroute('GET', `${taxonomyApi}/nodes?isRoot=true&language=nb`, 'allSubjects');
+    cy.apiroute('GET', `${taxonomyApi}/nodes?language=nb&nodeType=SUBJECT`, 'allSubjects');
     cy.apiroute(
       'GET',
       `${taxonomyApi}/nodes/${selectSubject}/nodes?language=nb&recursive=true`,

--- a/cypress/e2e/Taxonomy/topic_spec.js
+++ b/cypress/e2e/Taxonomy/topic_spec.js
@@ -17,7 +17,7 @@ describe('Topic editing', () => {
     setToken();
 
     cy.apiroute('GET', `${taxonomyApi}/versions`, 'allVersions');
-    cy.apiroute('GET', `${taxonomyApi}/nodes?isRoot=true&language=nb`, 'allSubjects');
+    cy.apiroute('GET', `${taxonomyApi}/nodes?language=nb&nodeType=SUBJECT`, 'allSubjects');
     cy.apiroute(
       'GET',
       `${taxonomyApi}/nodes/${selectSubject}/nodes?language=nb&recursive=true`,

--- a/src/containers/StructurePage/StructureContainer.tsx
+++ b/src/containers/StructurePage/StructureContainer.tsx
@@ -76,7 +76,7 @@ const StructureContainer = () => {
     }, {}) ?? {};
   const favoriteNodeIds = Object.keys(favoriteNodes);
   const nodesQuery = useNodes(
-    { language: i18n.language, nodeType: 'SUBJECT' , taxonomyVersion },
+    { language: i18n.language, nodeType: 'SUBJECT', taxonomyVersion },
     {
       select: (nodes) => nodes.sort((a, b) => a.name?.localeCompare(b.name)),
       placeholderData: [],

--- a/src/containers/StructurePage/StructureContainer.tsx
+++ b/src/containers/StructurePage/StructureContainer.tsx
@@ -76,7 +76,7 @@ const StructureContainer = () => {
     }, {}) ?? {};
   const favoriteNodeIds = Object.keys(favoriteNodes);
   const nodesQuery = useNodes(
-    { language: i18n.language, isRoot: true, taxonomyVersion },
+    { language: i18n.language, nodeType: 'SUBJECT' , taxonomyVersion },
     {
       select: (nodes) => nodes.sort((a, b) => a.name?.localeCompare(b.name)),
       placeholderData: [],


### PR DESCRIPTION
Når vi legger inn støtte for programfag så vil disse ligge _over_ subjects. Så dagens struktur-verktøy må tilpasses då. Enn så lenge gir det meining at det er fag som redigeres her.