### PR TITLE
Use title in welcome-page tables for more consistency

### DIFF
--- a/src/containers/WelcomePage/components/LastUsedItems.tsx
+++ b/src/containers/WelcomePage/components/LastUsedItems.tsx
@@ -102,7 +102,7 @@ const LastUsedItems = ({ lastUsedResources = [], lastUsedConcepts = [] }: Props)
   const lastPageConcepts = useMemo(() => getLastPage(conceptsData), [conceptsData]);
 
   const tableTitles: TitleElement<SortOptionLastUsed>[] = [
-    { title: t('form.article.label'), sortableField: 'title' },
+    { title: t('form.name.title'), sortableField: 'title' },
     { title: t('searchForm.sort.lastUpdated'), sortableField: 'lastUpdated' },
   ];
 

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -61,7 +61,7 @@ const Revisions = ({ userData, ndlaId }: Props) => {
   const { taxonomyVersion } = useTaxonomyVersion();
 
   const tableTitles: TitleElement<SortOptionRevision>[] = [
-    { title: t('form.article.label'), sortableField: 'title' },
+    { title: t('form.name.title'), sortableField: 'title' },
     { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.primarySubject') },
     { title: t('welcomePage.revisionDate'), sortableField: 'revisionDate' },

--- a/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
@@ -136,7 +136,7 @@ const ConceptListTabContent = ({
   );
 
   const tableTitles: TitleElement<SortOption>[] = [
-    { title: t('welcomePage.workList.name'), sortableField: 'title' },
+    { title: t('welcomePage.workList.title'), sortableField: 'title' },
     { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.conceptSubject') },
     { title: t('welcomePage.workList.date'), sortableField: 'responsibleLastUpdated' },
@@ -148,7 +148,7 @@ const ConceptListTabContent = ({
     <>
       <StyledTopRowDashboardInfo>
         <TableTitle
-          title={t('welcomePage.workList.title')}
+          title={t('welcomePage.workList.heading')}
           description={t('welcomePage.workList.conceptDescription')}
           Icon={Calendar}
         />

--- a/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
@@ -111,7 +111,7 @@ const WorkListTabContent = ({
   );
 
   const tableTitles: TitleElement<SortOption>[] = [
-    { title: t('welcomePage.workList.name'), sortableField: 'title' },
+    { title: t('welcomePage.workList.title'), sortableField: 'title' },
     { title: t('welcomePage.workList.status'), sortableField: 'status' },
     { title: t('welcomePage.workList.contentType') },
     { title: t('welcomePage.workList.primarySubject') },
@@ -125,7 +125,7 @@ const WorkListTabContent = ({
     <>
       <StyledTopRowDashboardInfo>
         <TableTitle
-          title={t('welcomePage.workList.title')}
+          title={t('welcomePage.workList.heading')}
           description={t('welcomePage.workList.description')}
           Icon={Calendar}
         />

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -136,9 +136,9 @@ const phrases = {
     welcomeText: 'to ED',
     revisionInfo: 'Choose your favorite subjects by marking them with a star in structure editing',
     workList: {
-      title: 'My tasks',
+      heading: 'My tasks',
       description: 'Articles where you are responsible',
-      name: 'Name',
+      title: 'Title',
       status: 'Status',
       contentType: 'Content type',
       primarySubject: 'Primary subject',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -137,9 +137,9 @@ const phrases = {
     welcomeText: 'til ED',
     revisionInfo: 'Velg favorittfag ved å stjernemarkere i strukturredigering',
     workList: {
-      title: 'Mine arbeidsoppgaver',
+      heading: 'Mine arbeidsoppgaver',
       description: 'Artikler hvor du står som ansvarlig',
-      name: 'Navn',
+      title: 'Tittel',
       status: 'Status',
       contentType: 'Innholdstype',
       primarySubject: 'Primærfag',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -137,9 +137,9 @@ const phrases = {
     welcomeText: 'til ED',
     revisionInfo: 'Vel favorittfag ved å stjernemarkere i strukturredigering',
     workList: {
-      title: 'Mine arbeidsoppgåver',
+      heading: 'Mine arbeidsoppgåver',
       description: 'Artiklar der du står som ansvarleg',
-      name: 'Namn',
+      title: 'Tittel',
       status: 'Status',
       contentType: 'Innhaldstype',
       primarySubject: 'Primærfag',


### PR DESCRIPTION
Artikler og forklaringer har titler og ikkje navn. Endrer tabeller på forsida til å være meir i henhold til dette.