### PR TITLE
Sort subjects in dropdown in revisions alphabetically

### DIFF
--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -15,9 +15,8 @@ import { Select, SingleValue } from '@ndla/select';
 import Pager from '@ndla/pager';
 import sortBy from 'lodash/sortBy';
 import styled from '@emotion/styled';
-import { mq, breakpoints, spacing, fonts } from '@ndla/core';
+import { mq, breakpoints } from '@ndla/core';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
-import { Switch } from '@ndla/switch';
 import Tooltip from '@ndla/tooltip';
 import {
   ControlWrapperDashboard,
@@ -74,7 +73,7 @@ const Revisions = ({ userData }: Props) => {
   const { taxonomyVersion } = useTaxonomyVersion();
 
   const tableTitles: TitleElement<SortOptionRevision>[] = [
-    { title: t('form.name.title'), sortableField: 'title' },
+    { title: t('form.name.title'), sortableField: 'title', width: '40%' },
     { title: t('welcomePage.workList.status'), sortableField: 'status', width: '15%' },
     { title: t('welcomePage.workList.primarySubject') },
     { title: t('welcomePage.revisionDate'), sortableField: 'revisionDate' },
@@ -109,16 +108,19 @@ const Revisions = ({ userData }: Props) => {
     {
       select: (res) => ({
         ...res,
-        results: sortBy(res.results, (r) => r.metadata.customFields.subjectCategory === 'archive'),
+        results: sortBy(res.results, (r) => r.name),
       }),
       enabled: !!userData?.favoriteSubjects?.length,
     },
   );
 
-  const favoriteSubjects = useMemo(
-    () => subjectData?.results.map((s) => ({ label: s.name, value: s.id })),
-    [subjectData],
-  );
+  const favoriteSubjects = useMemo(() => {
+    const archivedAtBottom = sortBy(
+      subjectData?.results,
+      (r) => r.metadata.customFields.subjectCategory === 'archive',
+    );
+    return archivedAtBottom.map((s) => ({ label: s.name, value: s.id }));
+  }, [subjectData]);
 
   const getDataPrimaryConnectionToFavorite = useCallback(
     (results: IMultiSearchSummary[] | undefined) => {


### PR DESCRIPTION
- Legger på alfabetisk sortering på fag i dropdown i revisjonsblokk (På samme måte som i arbeidsliste)
- Gjør også tittel-kolonne litt bredere