### PR TITLE
Bug fix: Draft status reset in SearchContentForm

### DIFF
--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -116,7 +116,7 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
       query: '',
       subjects: '',
       'resource-types': '',
-      status: '',
+      'draft-status': '',
       users: '',
       language: '',
       'revision-date-from': '',


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3605

Fikser sånn at draft-status også nullstilles når man tømmer filtre på søkesiden