### PR TITLE
Use `app_metadata.isOrWasEdUser` when searching for auth0 editors

### DIFF
--- a/src/containers/SearchPage/components/form/SearchConceptForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchConceptForm.tsx
@@ -33,13 +33,10 @@ interface Props {
 const SearchConceptForm = ({ search: doSearch, searchObject: search, subjects }: Props) => {
   const { t } = useTranslation();
   const [queryInput, setQueryInput] = useState(search.query ?? '');
-  const { data: users } = useAuth0Editors(
-    { permission: CONCEPT_WRITE_SCOPE },
-    {
-      select: (users) => users.map((u) => ({ id: `${u.app_metadata.ndla_id}`, name: u.name })),
-      placeholderData: [],
-    },
-  );
+  const { data: users } = useAuth0Editors({
+    select: (users) => users.map((u) => ({ id: `${u.app_metadata.ndla_id}`, name: u.name })),
+    placeholderData: [],
+  });
 
   const { data: responsibles } = useAuth0Responsibles(
     { permission: CONCEPT_RESPONSIBLE },

--- a/src/containers/SearchPage/components/form/SearchContentForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchContentForm.tsx
@@ -42,13 +42,10 @@ const SearchContentForm = ({ search: doSearch, searchObject: search, subjects, l
   const [queryInput, setQueryInput] = useState(search.query ?? '');
   const [isHasPublished, setIsHasPublished] = useState(false);
 
-  const { data: users } = useAuth0Editors(
-    { permission: DRAFT_WRITE_SCOPE },
-    {
-      select: (users) => users.map((u) => ({ id: `${u.app_metadata.ndla_id}`, name: u.name })),
-      placeholderData: [],
-    },
-  );
+  const { data: users } = useAuth0Editors({
+    select: (users) => users.map((u) => ({ id: `${u.app_metadata.ndla_id}`, name: u.name })),
+    placeholderData: [],
+  });
 
   const { data: responsibles } = useAuth0Responsibles(
     { permission: DRAFT_RESPONSIBLE },

--- a/src/modules/auth0/auth0Api.ts
+++ b/src/modules/auth0/auth0Api.ts
@@ -33,10 +33,8 @@ export const fetchAuth0UsersFromUserIds = async (
   return users;
 };
 
-export const fetchAuth0Editors = (permission: string): Promise<Auth0UserData[]> =>
-  fetchAuthorized(`/get_editors?permission=${permission}`).then((r) =>
-    resolveJsonOrRejectWithError<Auth0UserData[]>(r),
-  );
+export const fetchAuth0Editors = (): Promise<Auth0UserData[]> =>
+  fetchAuthorized(`/get_editors`).then((r) => resolveJsonOrRejectWithError<Auth0UserData[]>(r));
 
 export const fetchAuth0Responsibles = (permission: string): Promise<Auth0UserData[]> =>
   fetchAuthorized(`/get_responsibles?permission=${permission}`).then((r) =>

--- a/src/modules/auth0/auth0Queries.ts
+++ b/src/modules/auth0/auth0Queries.ts
@@ -27,14 +27,13 @@ export interface Auth0Editors {
   permission: string;
 }
 
-export const auth0EditorsQueryKey = (params?: Partial<Auth0Editors>) => [AUTH0_EDITORS, params];
+export const auth0EditorsQueryKey = [AUTH0_EDITORS];
 export const useAuth0Editors = <ReturnType>(
-  params: Auth0Editors,
   options: UseQueryOptions<Auth0UserData[], unknown, ReturnType>,
 ) =>
   useQuery<Auth0UserData[], unknown, ReturnType>(
-    auth0EditorsQueryKey(params),
-    () => fetchAuth0Editors(params.permission),
+    auth0EditorsQueryKey,
+    () => fetchAuth0Editors(),
     options,
   );
 

--- a/src/modules/draft/draftQueries.ts
+++ b/src/modules/draft/draftQueries.ts
@@ -65,13 +65,6 @@ export const useSearchDrafts = (
   );
 };
 
-export const useResponsibleUserData = (article?: IArticle) => {
-  return useAuth0Users(
-    { uniqueUserIds: article?.responsible?.responsibleId! },
-    { enabled: !!article?.responsible?.responsibleId },
-  );
-};
-
 export const licensesQueryKey = () => [LICENSES];
 
 export const useLicenses = <ReturnType = ILicense[]>(

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -80,8 +80,8 @@ async function fetchAuth0UsersByQuery(token: string, query: string, page: number
   }).then((res) => res.json());
 }
 
-export const getEditors = async (managementToken: ManagementToken, permission: string) => {
-  const query = `include_totals=true&q=app_metadata.roles:"${permission}"`;
+export const getEditors = async (managementToken: ManagementToken) => {
+  const query = `include_totals=true&q=app_metadata.isOrWasEdUser:true`;
 
   const firstPage = await fetchAuth0UsersByQuery(managementToken.access_token, query, 0);
   const numberOfPages = Math.ceil(firstPage.total / firstPage.length);

--- a/src/server/server.tsx
+++ b/src/server/server.tsx
@@ -191,13 +191,9 @@ app.get(
     algorithms: ['RS256'],
   }),
   async (req, res) => {
-    const {
-      query: { permission },
-    } = req;
-
     try {
       const managementToken = await getToken(`https://${config.auth0Domain}/api/v2/`);
-      const editors = await getEditors(managementToken, permission as string);
+      const editors = await getEditors(managementToken);
       res.status(OK).json(editors);
     } catch (err) {
       res.status(INTERNAL_SERVER_ERROR).send((err as NdlaError).message);


### PR DESCRIPTION
Depends on https://github.com/NDLANO/deploy/pull/521
Endrer til å bruke `app_metadata.isOrWasEdUser` for å søke authors i auth0.
Dette lar oss fortsette å oppdatere `permissions` objektet på samme måte i deploy, men vi kan fremdeles søke på folk som ikke lenger har tilganger.
 