### PR TITLE
Refactor HeaderStatusInformation for performance reasons

### DIFF
--- a/src/components/ControlledImageSearchAndUploader.tsx
+++ b/src/components/ControlledImageSearchAndUploader.tsx
@@ -116,6 +116,7 @@ const ImageSearchAndUploader = ({
               onSubmitFunc={updateImage}
               closeModal={closeModal}
               licenses={imageLicenses}
+              supportedLanguages={image?.supportedLanguages ?? [locale]}
             />
           ) : (
             <EditorErrorMessage msg={t('errorMessage.description')} />

--- a/src/components/HeaderWithLanguage/EmbedInformation/EmbedConnection.tsx
+++ b/src/components/HeaderWithLanguage/EmbedInformation/EmbedConnection.tsx
@@ -12,7 +12,6 @@ import { colors } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { SubjectMaterial } from '@ndla/icons/contentType';
 import { ModalHeader, ModalCloseButton, ModalBody, Modal, ModalTitle } from '@ndla/modal';
-import Tooltip from '@ndla/tooltip';
 import { ButtonV2 } from '@ndla/button';
 import { IConceptSummary } from '@ndla/types-backend/concept-api';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
@@ -81,11 +80,12 @@ const EmbedConnection = ({ id, type, articles, setArticles, concepts, setConcept
 
   return (
     <Modal
-      wrapperFunctionForButton={(activateButton: any) => (
-        <Tooltip tooltip={t(`form.embedConnections.info.${type}`)}>{activateButton}</Tooltip>
-      )}
       activateButton={
-        <ButtonV2 variant="stripped">
+        <ButtonV2
+          variant="stripped"
+          aria-label={t(`form.embedConnections.info.${type}`)}
+          title={t(`form.embedConnections.info.${type}`)}
+        >
           <ImageInformationIcon css={normalPaddingCSS} />
         </ButtonV2>
       }

--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -11,6 +11,7 @@ import { FileCompare } from '@ndla/icons/action';
 import { useTranslation } from 'react-i18next';
 import { IConcept } from '@ndla/types-backend/concept-api';
 import { IArticle } from '@ndla/types-backend/draft-api';
+import { useCallback, useMemo } from 'react';
 import StyledFilledButton from '../StyledFilledButton';
 import { StyledSplitter } from './HeaderInformation';
 import HeaderLanguagePicker from './HeaderLanguagePicker';
@@ -20,6 +21,16 @@ import HeaderSupportedLanguages from './HeaderSupportedLanguages';
 import HeaderLanguagePill from './HeaderLanguagePill';
 import { useIsTranslatableToNN } from '../NynorskTranslateProvider';
 import PreviewDraftLightboxV2 from '../PreviewDraft/PreviewDraftLightboxV2';
+import {
+  toEditAudio,
+  toEditConcept,
+  toEditFrontPageArticle,
+  toEditImage,
+  toEditLearningResource,
+  toEditPodcast,
+  toEditPodcastSeries,
+  toEditTopicArticle,
+} from '../../util/routeHelpers';
 
 interface PreviewLightBoxProps {
   article?: IArticle;
@@ -63,108 +74,132 @@ const PreviewLightBox = ({ type, currentLanguage, article, concept }: PreviewLig
 };
 
 interface Props {
-  editUrl?: (url: string) => string;
+  id: number;
   isNewLanguage: boolean;
   article?: IArticle;
   concept?: IConcept;
   isSubmitting?: boolean;
   noStatus: boolean;
   disableDelete: boolean;
-  type: string;
-  values: {
-    articleType?: string;
-    id?: number;
-    language: string;
-    supportedLanguages: string[];
-  };
+  language: string;
+  type: keyof typeof toMapping;
+  supportedLanguages?: string[];
 }
 
+const toMapping = {
+  concept: toEditConcept,
+  audio: toEditAudio,
+  'podcast-series': toEditPodcastSeries,
+  podcast: toEditPodcast,
+  image: toEditImage,
+  'frontpage-article': toEditFrontPageArticle,
+  standard: toEditLearningResource,
+  'topic-article': toEditTopicArticle,
+};
+
+const translatableTypes = [
+  'audio',
+  'concept',
+  'standard',
+  'topic-article',
+  'podcast',
+  'image',
+  'podcast-series',
+  'frontpage-article',
+];
+
 const HeaderActions = ({
-  editUrl,
   isNewLanguage,
   isSubmitting,
   noStatus,
   type,
+  id,
+  language,
   disableDelete,
   article,
   concept,
-  values,
+  supportedLanguages = [],
 }: Props) => {
   const { t } = useTranslation();
   const showTranslate = useIsTranslatableToNN();
-  const { id, language, supportedLanguages = [] } = values;
 
-  const languages = [
-    { key: 'nn', title: t('language.nn'), include: true },
-    { key: 'en', title: t('language.en'), include: true },
-    { key: 'nb', title: t('language.nb'), include: true },
-    { key: 'sma', title: t('language.sma'), include: true },
-    { key: 'se', title: t('language.se'), include: true },
-    { key: 'und', title: t('language.und'), include: false },
-    { key: 'de', title: t('language.de'), include: true },
-    { key: 'es', title: t('language.es'), include: true },
-    { key: 'ukr', title: t('language.ukr'), include: true },
-  ];
-  const emptyLanguages = languages.filter(
-    (lang) => lang.key !== language && !supportedLanguages.includes(lang.key) && lang.include,
+  const editUrl = useCallback(
+    (id: number, locale: string) => {
+      return toMapping[type](id, locale);
+    },
+    [type],
   );
-  const translatableTypes = [
-    'audio',
-    'concept',
-    'standard',
-    'topic-article',
-    'podcast',
-    'image',
-    'podcast-series',
-    'frontpage-article',
-  ];
-  if (id && editUrl) {
-    return (
-      <>
-        <HeaderSupportedLanguages
-          id={id}
-          editUrl={editUrl}
-          language={language}
-          supportedLanguages={supportedLanguages}
-          isSubmitting={isSubmitting}
-        />
-        {isNewLanguage && (
-          <HeaderLanguagePill current key={`types_${language}`}>
-            <Check />
-            {t(`language.${language}`)}
-          </HeaderLanguagePill>
-        )}
-        <StyledSplitter />
-        {!noStatus && (
+
+  const languages = useMemo(
+    () => [
+      { key: 'nn', title: t('language.nn'), include: true },
+      { key: 'en', title: t('language.en'), include: true },
+      { key: 'nb', title: t('language.nb'), include: true },
+      { key: 'sma', title: t('language.sma'), include: true },
+      { key: 'se', title: t('language.se'), include: true },
+      { key: 'und', title: t('language.und'), include: false },
+      { key: 'de', title: t('language.de'), include: true },
+      { key: 'es', title: t('language.es'), include: true },
+      { key: 'ukr', title: t('language.ukr'), include: true },
+    ],
+    [t],
+  );
+
+  const emptyLanguages = useMemo(
+    () =>
+      languages.filter(
+        (lang) => lang.key !== language && !supportedLanguages.includes(lang.key) && lang.include,
+      ),
+    [language, languages, supportedLanguages],
+  );
+
+  return (
+    <>
+      <HeaderSupportedLanguages
+        id={id}
+        editUrl={editUrl}
+        language={language}
+        supportedLanguages={supportedLanguages}
+        isSubmitting={isSubmitting}
+      />
+      {isNewLanguage && (
+        <HeaderLanguagePill current key={`types_${language}`}>
+          <Check />
+          {t(`language.${language}`)}
+        </HeaderLanguagePill>
+      )}
+      <StyledSplitter />
+      {!noStatus && (
+        <>
+          <PreviewLightBox
+            article={article}
+            concept={concept}
+            type={type}
+            currentLanguage={language}
+          />
+          <StyledSplitter />
+        </>
+      )}
+      <HeaderLanguagePicker id={id} emptyLanguages={emptyLanguages} editUrl={editUrl} />
+      {translatableTypes.includes(type) &&
+        language === 'nb' &&
+        showTranslate &&
+        !supportedLanguages.includes('nn') && (
           <>
-            <PreviewLightBox
-              article={article}
-              concept={concept}
-              type={type}
-              currentLanguage={values.language}
-            />
             <StyledSplitter />
+            <TranslateNbToNn id={id} editUrl={editUrl} />
           </>
         )}
-        <HeaderLanguagePicker emptyLanguages={emptyLanguages} editUrl={editUrl} />
-        {translatableTypes.includes(type) &&
-          language === 'nb' &&
-          showTranslate &&
-          !supportedLanguages.includes('nn') && (
-            <>
-              <StyledSplitter />
-              <TranslateNbToNn editUrl={editUrl} />
-            </>
-          )}
-        {<DeleteLanguageVersion values={values} type={type} disabled={disableDelete} />}
-      </>
-    );
-  }
-  return (
-    <HeaderLanguagePill current>
-      <Check />
-      {t(`language.${language}`)}
-    </HeaderLanguagePill>
+      {
+        <DeleteLanguageVersion
+          id={id}
+          language={language}
+          supportedLanguages={supportedLanguages}
+          type={type}
+          disabled={disableDelete}
+        />
+      }
+    </>
   );
 };
 

--- a/src/components/HeaderWithLanguage/HeaderLanguagePicker.tsx
+++ b/src/components/HeaderWithLanguage/HeaderLanguagePicker.tsx
@@ -16,7 +16,7 @@ import { styledListElement } from '../StyledListElement/StyledListElement';
 import Overlay from '../Overlay';
 import { StyledDropdownOverlay } from '../Dropdown';
 
-const LanguagePicker = ({ emptyLanguages, editUrl }: Props) => {
+const LanguagePicker = ({ id, emptyLanguages, editUrl }: Props) => {
   const { t } = useTranslation();
   const [display, setDisplay] = useState(false);
   return (
@@ -43,7 +43,7 @@ const LanguagePicker = ({ emptyLanguages, editUrl }: Props) => {
                 <Link
                   css={styledListElement}
                   key={language.key}
-                  to={editUrl(language.key)}
+                  to={editUrl(id, language.key)}
                   onClick={() => setDisplay(false)}
                 >
                   {language.title}
@@ -59,11 +59,12 @@ const LanguagePicker = ({ emptyLanguages, editUrl }: Props) => {
 };
 
 interface Props {
+  id: number;
   emptyLanguages: {
     key: string;
     title: string;
   }[];
-  editUrl: (url: string) => string;
+  editUrl: (id: number, url: string) => string;
 }
 
 export default LanguagePicker;

--- a/src/components/HeaderWithLanguage/HeaderLanguagePill.tsx
+++ b/src/components/HeaderWithLanguage/HeaderLanguagePill.tsx
@@ -4,7 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ElementType, ReactNode } from 'react';
+import { ElementType, HTMLProps, ReactNode } from 'react';
 import { css } from '@emotion/react';
 import { colors, fonts, spacing } from '@ndla/core';
 
@@ -41,7 +41,7 @@ const languagePillStyle = css`
   }
 `;
 
-interface Props {
+interface Props extends HTMLProps<HTMLElement> {
   children: ReactNode;
   component?: ElementType;
   isSubmitting?: boolean;

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -4,7 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Children, isValidElement, ReactElement, ReactNode, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import SafeLink from '@ndla/safelink';
@@ -18,7 +18,6 @@ import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import config from '../../config';
 import LearningpathConnection from './LearningpathConnection';
 import EmbedConnection from './EmbedInformation/EmbedConnection';
-import { unreachable } from '../../util/guards';
 import formatDate from '../../util/formatDate';
 
 export const StyledSplitter = styled.div`
@@ -34,26 +33,6 @@ const StyledStatusWrapper = styled.div`
   white-space: nowrap;
 `;
 
-/** Helper component to only render splitter if children are rendering */
-const Splitter = ({
-  children,
-  disableSplitter,
-}: {
-  children?: ReactNode;
-  disableSplitter?: boolean;
-}) => {
-  const validChildren = Children.toArray(children).filter((child) =>
-    isValidElement(child),
-  ) as ReactElement[];
-  if (!Children.count(validChildren)) return null;
-  return (
-    <>
-      {children && !disableSplitter && <StyledSplitter />}
-      {children}
-    </>
-  );
-};
-
 export const getWarnStatus = (date?: string): 'warn' | 'expired' | undefined => {
   if (!date) return undefined;
   const parsedDate = new Date(date);
@@ -67,33 +46,24 @@ export const getWarnStatus = (date?: string): 'warn' | 'expired' | undefined => 
   if (warnDate > parsedDate) return 'warn';
 };
 
-export const StyledTimeIcon = styled(Time)<{
-  status: 'warn' | 'expired';
-  height?: string;
-  width?: string;
-}>`
-  height: ${(p) => (p.height ? p.height : spacing.normal)};
-  width: ${(p) => (p.width ? p.width : spacing.normal)};
-  fill: ${(p) => {
-    switch (p.status) {
-      case 'warn':
-        return '#c77623';
-      case 'expired':
-        return colors.support.red;
-      default:
-        unreachable(p.status);
-    }
-  }};
+export const StyledTimeIcon = styled(Time)`
+  &[data-status='warn'] {
+    fill: #c77623;
+  }
+  &[data-status='expired'] {
+    fill: ${colors.support.red};
+  }
+  width: 24px;
+  height: 24px;
 `;
 
 interface Props {
+  compact?: boolean;
   noStatus?: boolean;
   statusText?: string;
   isNewLanguage?: boolean;
   published: boolean;
   taxonomyPaths?: string[];
-  indentLeft?: boolean;
-  fontSize?: number;
   type?: string;
   id?: number;
   setHasConnections?: (hasConnections: boolean) => void;
@@ -102,14 +72,58 @@ interface Props {
   hasRSS?: boolean;
 }
 
+const StyledStatus = styled.p`
+  ${fonts.sizes('16', '1.1')};
+  font-weight: ${fonts.weight.semibold};
+  margin: 0 ${spacing.small} 0;
+  color: ${colors.brand.primary};
+  &[data-compact='true'] {
+    ${fonts.sizes('10', '1.1')};
+    margin: 0 ${spacing.xsmall} 0;
+  }
+`;
+
+const StyledSmallText = styled.small`
+  color: ${colors.text.light};
+  ${fonts.sizes('16', '1.1')};
+  padding-right: ${spacing.xsmall};
+  font-weight: ${fonts.weight.normal};
+  color: ${colors.brand.primary};
+  &[data-compact='true'] {
+    color: #000;
+    ${fonts.sizes('9', '1.1')};
+  }
+`;
+
+const StyledCheckIcon = styled(Check)`
+  height: ${spacing.normal};
+  width: ${spacing.normal};
+  fill: ${colors.support.green};
+`;
+
+const StyledWarnIcon = styled(AlertCircle)`
+  height: ${spacing.normal};
+  width: ${spacing.normal};
+  fill: ${colors.support.yellow};
+`;
+
+const StyledRssIcon = styled(RssFeed)`
+  height: ${spacing.normal};
+  width: ${spacing.normal};
+  fill: ${colors.support.green};
+`;
+
+const StyledLink = styled(SafeLink)`
+  box-shadow: inset 0 0;
+`;
+
 const HeaderStatusInformation = ({
   noStatus,
   statusText,
   isNewLanguage,
   published,
   taxonomyPaths,
-  indentLeft = false,
-  fontSize,
+  compact,
   type,
   id,
   setHasConnections,
@@ -123,183 +137,105 @@ const HeaderStatusInformation = ({
   const [concepts, setConcepts] = useState<IConceptSummary[]>([]);
 
   useEffect(() => {
-    const allConnections = [...learningpaths, ...articles, ...concepts];
-    setHasConnections?.(allConnections.length > 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [learningpaths, articles, concepts]);
+    setHasConnections?.(!!learningpaths?.length ?? !!articles?.length ?? !!concepts?.length);
+  }, [learningpaths, articles, concepts, setHasConnections]);
 
-  const StyledStatus = styled.p`
-    ${fonts.sizes(fontSize || 16, 1.1)};
-    font-weight: ${fonts.weight.semibold};
-    margin: 0 ${fontSize && fontSize <= 12 ? spacing.xsmall : spacing.small} 0;
-    ${indentLeft ? 0 : spacing.small};
-    color: ${colors.brand.primary};
-  `;
+  const expirationColor = useMemo(() => getWarnStatus(expirationDate), [expirationDate]);
 
-  const StyledSmallText = styled.small`
-    color: ${fontSize && fontSize <= 12 ? '#000' : colors.text.light};
-    padding-right: ${spacing.xsmall};
-    ${fonts.sizes((fontSize && fontSize - 1) || 16, 1.1)};
-    font-weight: ${fonts.weight.normal};
-    color: ${colors.brand.primary};
-  `;
-
-  const StyledCheckIcon = styled(Check)`
-    height: ${spacing.normal};
-    width: ${spacing.normal};
-    fill: ${colors.support.green};
-  `;
-
-  const StyledWarnIcon = styled(AlertCircle)`
-    height: ${spacing.normal};
-    width: ${spacing.normal};
-    fill: ${colors.support.yellow};
-  `;
-
-  const StyledRssIcon = styled(RssFeed)`
-    height: ${spacing.normal};
-    width: ${spacing.normal};
-    fill: ${colors.support.green};
-  `;
-
-  const StyledLink = styled(SafeLink)`
-    box-shadow: inset 0 0;
-  `;
-
-  const expirationColor = getWarnStatus(expirationDate);
-  const revisionDateExpiration =
-    (type === 'standard' || type === 'topic-article') && expirationColor && expirationDate ? (
-      <Tooltip
-        tooltip={t(`form.workflow.expiration.${expirationColor}`, {
-          date: formatDate(expirationDate),
-        })}
-      >
-        <div>
-          <StyledTimeIcon status={expirationColor} />
-        </div>
-      </Tooltip>
-    ) : null;
-
-  const multipleTaxonomyIcon = taxonomyPaths && taxonomyPaths?.length > 2 && (
-    <Tooltip tooltip={t('form.workflow.multipleTaxonomy')}>
-      <div>
-        <StyledWarnIcon />
-      </div>
-    </Tooltip>
-  );
-
-  const publishedIcon = (
-    <Tooltip tooltip={t('form.workflow.published')}>
-      <div>
-        <StyledCheckIcon />
-      </div>
-    </Tooltip>
-  );
-
-  const publishedIconLink = (
-    <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/article/${id}`}>
-      {publishedIcon}
-    </StyledLink>
-  );
-
-  const rssLink = hasRSS && id !== undefined && (
-    <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/podkast/${id}/feed.xml`}>
-      <StyledRssIcon title={t('podcastSeriesForm.rss')} />
-    </StyledLink>
-  );
-
-  const learningpathConnections =
-    type === 'standard' || type === 'topic-article' ? (
-      <LearningpathConnection
-        id={id}
-        learningpaths={learningpaths}
-        setLearningpaths={setLearningpaths}
-      />
-    ) : null;
-
-  const imageConnections = type === 'image' && (
-    <EmbedConnection
-      id={id}
-      type="image"
-      articles={articles}
-      setArticles={setArticles}
-      concepts={concepts}
-      setConcepts={setConcepts}
-    />
-  );
-  const audioConnections =
-    type === 'audio' || type === 'podcast' ? (
-      <EmbedConnection id={id} type="audio" articles={articles} setArticles={setArticles} />
-    ) : null;
-  const conceptConnecions =
-    type === 'concept' ? (
-      <EmbedConnection id={id} type="concept" articles={articles} setArticles={setArticles} />
-    ) : null;
-  const articleConnections =
-    type === 'standard' || type === 'topic-article' ? (
-      <EmbedConnection id={id} type="article" articles={articles} setArticles={setArticles} />
-    ) : null;
-
-  const hideSplitter =
-    (!articleConnections || !conceptConnecions || !learningpathConnections) &&
-    !revisionDateExpiration &&
-    !published &&
-    !multipleTaxonomyIcon;
-
-  const StatusIcons = (
-    <>
-      <Splitter disableSplitter={indentLeft || hideSplitter}>
-        {articleConnections}
-        {conceptConnecions}
-        {learningpathConnections}
-        {revisionDateExpiration}
+  if (!noStatus || isNewLanguage) {
+    return (
+      <StyledStatusWrapper>
+        {type === 'standard' || type === 'topic-article' ? (
+          <>
+            <EmbedConnection id={id} type="article" articles={articles} setArticles={setArticles} />
+            <LearningpathConnection
+              id={id}
+              learningpaths={learningpaths}
+              setLearningpaths={setLearningpaths}
+            />
+            {!!expirationColor && !!expirationDate && (
+              <Tooltip
+                tooltip={t(`form.workflow.expiration.${expirationColor}`, {
+                  date: formatDate(expirationDate),
+                })}
+              >
+                <div>
+                  <StyledTimeIcon data-status={expirationColor} />
+                </div>
+              </Tooltip>
+            )}
+          </>
+        ) : type === 'concept' ? (
+          <EmbedConnection id={id} type="concept" articles={articles} setArticles={setArticles} />
+        ) : null}
         {published &&
-          (taxonomyPaths && taxonomyPaths?.length > 0 ? publishedIconLink : publishedIcon)}
-        {multipleTaxonomyIcon}
-      </Splitter>
-    </>
-  );
-
-  const ResponsibleInfo = (
-    <div>
-      <StyledSmallText>{`${t('form.responsible.label')}:`}</StyledSmallText>
-      {responsibleName || t('form.responsible.noResponsible')}
-    </div>
-  );
-
-  if (noStatus && isNewLanguage) {
-    return (
-      <StyledStatusWrapper>
-        {StatusIcons}
-        <Splitter>
-          <StyledStatus>
-            {ResponsibleInfo}
-            {t('form.status.new_language')}
-          </StyledStatus>
-        </Splitter>
-      </StyledStatusWrapper>
-    );
-  } else if (!noStatus) {
-    return (
-      <StyledStatusWrapper>
-        {StatusIcons}
-        <Splitter>
-          <StyledStatus>
-            {ResponsibleInfo}
+          (taxonomyPaths && taxonomyPaths?.length > 0 ? (
+            <Tooltip tooltip={t('form.workflow.published')}>
+              <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/article/${id}`}>
+                <StyledCheckIcon />
+              </StyledLink>
+            </Tooltip>
+          ) : (
+            <Tooltip tooltip={t('form.workflow.published')}>
+              <div>
+                <StyledCheckIcon />
+              </div>
+            </Tooltip>
+          ))}
+        {taxonomyPaths && taxonomyPaths?.length > 2 && (
+          <Tooltip tooltip={t('form.workflow.multipleTaxonomy')}>
             <div>
-              <StyledSmallText>{t('form.workflow.statusLabel')}:</StyledSmallText>
+              <StyledWarnIcon />
+            </div>
+          </Tooltip>
+        )}
+        <StyledStatus data-compact={compact}>
+          <div>
+            <StyledSmallText data-compact={compact}>{`${t(
+              'form.responsible.label',
+            )}:`}</StyledSmallText>
+            {responsibleName || t('form.responsible.noResponsible')}
+          </div>
+          {noStatus ? (
+            t('form.status.new_language')
+          ) : (
+            <div>
+              <StyledSmallText data-compact={compact}>
+                {t('form.workflow.statusLabel')}:
+              </StyledSmallText>
               {isNewLanguage ? t('form.status.new_language') : statusText || t('form.status.new')}
             </div>
-          </StyledStatus>
-        </Splitter>
+          )}
+        </StyledStatus>
       </StyledStatusWrapper>
     );
   } else if (type === 'image') {
-    return <StyledStatusWrapper>{imageConnections}</StyledStatusWrapper>;
+    return (
+      <StyledStatusWrapper>
+        <EmbedConnection
+          id={id}
+          type="image"
+          articles={articles}
+          setArticles={setArticles}
+          concepts={concepts}
+          setConcepts={setConcepts}
+        />
+      </StyledStatusWrapper>
+    );
   } else if (type === 'audio' || type === 'podcast') {
-    return <StyledStatusWrapper>{audioConnections}</StyledStatusWrapper>;
-  } else if (type === 'podcast-series') {
-    return <StyledStatusWrapper>{rssLink}</StyledStatusWrapper>;
+    return (
+      <StyledStatusWrapper>
+        <EmbedConnection id={id} type="audio" articles={articles} setArticles={setArticles} />
+      </StyledStatusWrapper>
+    );
+  } else if (type === 'podcast-series' && hasRSS && id !== undefined) {
+    return (
+      <StyledStatusWrapper>
+        <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/podkast/${id}/feed.xml`}>
+          <StyledRssIcon title={t('podcastSeriesForm.rss')} />
+        </StyledLink>
+      </StyledStatusWrapper>
+    );
   }
   return null;
 };

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -48,7 +48,7 @@ export const getWarnStatus = (date?: string): 'warn' | 'expired' | undefined => 
 
 export const StyledTimeIcon = styled(Time)`
   &[data-status='warn'] {
-    fill: #c77623;
+    fill: ${colors.tasksAndActivities.dark};
   }
   &[data-status='expired'] {
     fill: ${colors.support.red};

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -170,24 +170,25 @@ const HeaderStatusInformation = ({
         ) : null}
         {published &&
           (taxonomyPaths && taxonomyPaths?.length > 0 ? (
-            <Tooltip tooltip={t('form.workflow.published')}>
-              <StyledLink target="_blank" to={`${config.ndlaFrontendDomain}/article/${id}`}>
-                <StyledCheckIcon />
-              </StyledLink>
-            </Tooltip>
+            <StyledLink
+              target="_blank"
+              aria-label={t('form.workflow.published')}
+              title={t('form.workflow.published')}
+              to={`${config.ndlaFrontendDomain}/article/${id}`}
+            >
+              <StyledCheckIcon />
+            </StyledLink>
           ) : (
-            <Tooltip tooltip={t('form.workflow.published')}>
-              <div>
-                <StyledCheckIcon />
-              </div>
-            </Tooltip>
+            <StyledCheckIcon
+              aria-label={t('form.workflow.published')}
+              title={t('form.workflow.published')}
+            />
           ))}
         {taxonomyPaths && taxonomyPaths?.length > 2 && (
-          <Tooltip tooltip={t('form.workflow.multipleTaxonomy')}>
-            <div>
-              <StyledWarnIcon />
-            </div>
-          </Tooltip>
+          <StyledWarnIcon
+            aria-label={t('form.workflow.multipleTaxonomy')}
+            title={t('form.workflow.multipleTaxonomy')}
+          />
         )}
         <StyledStatus data-compact={compact}>
           <div>

--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -11,7 +11,6 @@ import SafeLink from '@ndla/safelink';
 import { colors, fonts, spacing } from '@ndla/core';
 import { RssFeed, Time } from '@ndla/icons/common';
 import { Check, AlertCircle } from '@ndla/icons/editor';
-import Tooltip from '@ndla/tooltip';
 import { IConceptSummary } from '@ndla/types-backend/concept-api';
 import { IMultiSearchSummary } from '@ndla/types-backend/search-api';
 import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
@@ -154,15 +153,16 @@ const HeaderStatusInformation = ({
               setLearningpaths={setLearningpaths}
             />
             {!!expirationColor && !!expirationDate && (
-              <Tooltip
-                tooltip={t(`form.workflow.expiration.${expirationColor}`, {
+              <StyledTimeIcon
+                data-status={expirationColor}
+                title={t(`form.workflow.expiration.${expirationColor}`, {
                   date: formatDate(expirationDate),
                 })}
-              >
-                <div>
-                  <StyledTimeIcon data-status={expirationColor} />
-                </div>
-              </Tooltip>
+                aria-label={t(`form.workflow.expiration.${expirationColor}`, {
+                  date: formatDate(expirationDate),
+                })}
+                aria-hidden={false}
+              />
             )}
           </>
         ) : type === 'concept' ? (
@@ -182,12 +182,14 @@ const HeaderStatusInformation = ({
             <StyledCheckIcon
               aria-label={t('form.workflow.published')}
               title={t('form.workflow.published')}
+              aria-hidden={false}
             />
           ))}
         {taxonomyPaths && taxonomyPaths?.length > 2 && (
           <StyledWarnIcon
             aria-label={t('form.workflow.multipleTaxonomy')}
             title={t('form.workflow.multipleTaxonomy')}
+            aria-hidden={false}
           />
         )}
         <StyledStatus data-compact={compact}>

--- a/src/components/HeaderWithLanguage/HeaderSupportedLanguages.tsx
+++ b/src/components/HeaderWithLanguage/HeaderSupportedLanguages.tsx
@@ -7,7 +7,6 @@
 import { useTranslation } from 'react-i18next';
 import SafeLink from '@ndla/safelink';
 import { Check } from '@ndla/icons/editor';
-import Tooltip from '@ndla/tooltip';
 import HeaderLanguagePill from './HeaderLanguagePill';
 
 interface LinkWithReplaceProps {
@@ -21,7 +20,7 @@ const LinkWithReplace = ({ to, ...rest }: LinkWithReplaceProps) => {
 interface Props {
   id: number;
   language: string;
-  editUrl: (url: string) => string;
+  editUrl: (id: number, url: string) => string;
   supportedLanguages?: string[];
   isSubmitting?: boolean;
   replace?: boolean;
@@ -29,6 +28,7 @@ interface Props {
 
 const HeaderSupportedLanguages = ({
   supportedLanguages = [],
+  id,
   editUrl,
   isSubmitting,
   language,
@@ -44,22 +44,19 @@ const HeaderSupportedLanguages = ({
             {t(`language.${supportedLanguage}`)}
           </HeaderLanguagePill>
         ) : (
-          <Tooltip
-            key={`types_${supportedLanguage}`}
-            tooltip={t('language.change', {
-              language: t(`language.${supportedLanguage}`).toLowerCase(),
+          <HeaderLanguagePill
+            aria-label={t('language.change', {
+              language: t(`language.${supportedLanguage}`),
             })}
+            title={t('language.change', {
+              language: t(`language.${supportedLanguage}`),
+            })}
+            to={editUrl(id, supportedLanguage)}
+            component={replace ? LinkWithReplace : SafeLink}
+            isSubmitting={isSubmitting}
           >
-            <div>
-              <HeaderLanguagePill
-                to={editUrl(supportedLanguage)}
-                component={replace ? LinkWithReplace : SafeLink}
-                isSubmitting={isSubmitting}
-              >
-                {t(`language.${supportedLanguage}`)}
-              </HeaderLanguagePill>
-            </div>
-          </Tooltip>
+            {t(`language.${supportedLanguage}`)}
+          </HeaderLanguagePill>
         ),
       )}
     </>

--- a/src/components/HeaderWithLanguage/LearningpathConnection.tsx
+++ b/src/components/HeaderWithLanguage/LearningpathConnection.tsx
@@ -12,7 +12,6 @@ import { colors } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { LearningPath } from '@ndla/icons/contentType';
 import { ModalCloseButton, ModalBody, Modal, ModalTitle, ModalHeader } from '@ndla/modal';
-import Tooltip from '@ndla/tooltip';
 import { ButtonV2 } from '@ndla/button';
 import { ILearningPathV2 } from '@ndla/types-backend/learningpath-api';
 import { normalPaddingCSS } from '../HowTo';
@@ -46,11 +45,12 @@ const LearningpathConnection = ({ id, learningpaths, setLearningpaths }: Props) 
 
   return (
     <Modal
-      wrapperFunctionForButton={(button) => (
-        <Tooltip tooltip={t('form.learningpathConnections.sectionTitle')}>{button}</Tooltip>
-      )}
       activateButton={
-        <ButtonV2 variant="stripped">
+        <ButtonV2
+          variant="stripped"
+          aria-label={t('form.learningpathConnections.sectionTitle')}
+          title={t('form.learningpathConnections.sectionTitle')}
+        >
           <LearningpathIcon css={normalPaddingCSS} />
         </ButtonV2>
       }

--- a/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
+++ b/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
@@ -16,7 +16,7 @@ import HeaderLanguagePicker from './HeaderLanguagePicker';
 
 interface Props {
   articleType: string;
-  editUrl: (lang: string) => string;
+  editUrl: (id: number, lang: string) => string;
   id: number;
   isSubmitting: boolean;
   language: string;
@@ -77,7 +77,7 @@ const SimpleLanguageHeader = ({
               </HeaderLanguagePill>
             )}
             <StyledSplitter />
-            <HeaderLanguagePicker emptyLanguages={emptyLanguages} editUrl={editUrl} />
+            <HeaderLanguagePicker id={id} emptyLanguages={emptyLanguages} editUrl={editUrl} />
           </>
         ) : (
           <>

--- a/src/components/HeaderWithLanguage/TranslateNbToNn.tsx
+++ b/src/components/HeaderWithLanguage/TranslateNbToNn.tsx
@@ -13,14 +13,15 @@ import { useTranslateToNN } from '../NynorskTranslateProvider';
 const StyledLink = StyledFilledButton.withComponent(Link);
 
 interface Props {
-  editUrl: (lang: string) => string;
+  id: number;
+  editUrl: (id: number, lang: string) => string;
 }
 
-const TranslateNbToNn = ({ editUrl }: Props) => {
+const TranslateNbToNn = ({ id, editUrl }: Props) => {
   const { setShouldTranslate } = useTranslateToNN();
   const { t } = useTranslation();
   return (
-    <StyledLink to={editUrl('nn')} onClick={() => setShouldTranslate(true)}>
+    <StyledLink to={editUrl(id, 'nn')} onClick={() => setShouldTranslate(true)}>
       {t('form.variant.translate')}
     </StyledLink>
   );

--- a/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModal.tsx
@@ -173,6 +173,7 @@ const ConceptModal = ({
                       concept={concept}
                       conceptArticles={conceptArticles}
                       initialTitle={selectedText}
+                      supportedLanguages={concept?.supportedLanguages ?? [locale]}
                     />
                   ),
                 },

--- a/src/containers/ArticlePage/FrontpageArticlePage/CreateFrontpageArticle.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/CreateFrontpageArticle.tsx
@@ -34,6 +34,7 @@ const CreateFrontpageArticle = () => {
         articleChanged={false}
         isNewlyCreated={false}
         articleLanguage={i18n.language}
+        supportedLanguages={[i18n.language]}
       />
     </>
   );

--- a/src/containers/ArticlePage/FrontpageArticlePage/EditFrontpageArticle.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/EditFrontpageArticle.tsx
@@ -86,6 +86,7 @@ const EditFrontpageArticle = ({ isNewlyCreated }: Props) => {
         articleChanged={articleChanged || newLanguage}
         isNewlyCreated={!!isNewlyCreated}
         updateArticle={updateArticle}
+        supportedLanguages={article.supportedLanguages}
       />
     </>
   );

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
@@ -13,7 +13,6 @@ import { IArticle, IUpdatedArticle, IStatus } from '@ndla/types-backend/draft-ap
 import { AlertModalWrapper } from '../../../FormikForm';
 import validateFormik, { getWarnings } from '../../../../components/formikValidationSchema';
 import { frontPageArticleRules, isFormikFormDirty } from '../../../../util/formHelper';
-import { toEditArticle } from '../../../../util/routeHelpers';
 import HeaderWithLanguage from '../../../../components/HeaderWithLanguage';
 import EditorFooter from '../../../../components/SlateEditor/EditorFooter';
 import {
@@ -40,6 +39,7 @@ interface Props {
   articleStatus?: IStatus;
   isNewlyCreated: boolean;
   articleChanged: boolean;
+  supportedLanguages: string[];
   updateArticle: (updatedArticle: IUpdatedArticle) => Promise<IArticle>;
   articleLanguage: string;
 }
@@ -51,6 +51,7 @@ const FrontpageArticleForm = ({
   updateArticle,
   articleChanged,
   articleLanguage,
+  supportedLanguages,
 }: Props) => {
   const { t } = useTranslation();
 
@@ -85,15 +86,14 @@ const FrontpageArticleForm = ({
     usePreventWindowUnload(formIsDirty);
     const getArticle = () =>
       frontpageArticleFormTypeToDraftApiType(values, initialValues, licenses!, false);
-    const editUrl = values.id
-      ? (lang: string) => toEditArticle(values.id!, values.articleType, lang)
-      : undefined;
     return (
       <StyledForm>
         <HeaderWithLanguage
-          values={values}
-          content={{ ...article, title: article?.title?.title, language: articleLanguage }}
-          editUrl={editUrl}
+          id={article?.id}
+          title={article?.title?.title}
+          language={articleLanguage}
+          supportedLanguages={supportedLanguages}
+          status={article?.status}
           isSubmitting={isSubmitting}
           type="frontpage-article"
           expirationDate={getExpirationDate(article)}

--- a/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/CreateLearningResource.tsx
@@ -34,6 +34,7 @@ const CreateLearningResource = () => {
         articleChanged={false}
         isNewlyCreated={false}
         articleLanguage={i18n.language}
+        supportedLanguages={[i18n.language]}
       />
     </>
   );

--- a/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/EditLearningResource.tsx
@@ -87,6 +87,7 @@ const EditLearningResource = ({ isNewlyCreated }: Props) => {
         articleChanged={articleChanged || newLanguage}
         isNewlyCreated={!!isNewlyCreated}
         updateArticle={updateArticle}
+        supportedLanguages={article.supportedLanguages}
       />
     </>
   );

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -41,6 +41,7 @@ interface Props {
   article?: IArticle;
   articleTaxonomy?: ArticleTaxonomy;
   articleStatus?: IStatus;
+  supportedLanguages: string[];
   isNewlyCreated: boolean;
   articleChanged: boolean;
   updateArticle: (updatedArticle: IUpdatedArticle) => Promise<IArticle>;
@@ -53,6 +54,7 @@ const LearningResourceForm = ({
   articleStatus,
   isNewlyCreated = false,
   updateArticle,
+  supportedLanguages,
   articleChanged,
   articleLanguage,
 }: Props) => {
@@ -89,18 +91,17 @@ const LearningResourceForm = ({
     usePreventWindowUnload(formIsDirty);
     const getArticle = () =>
       learningResourceFormTypeToDraftApiType(values, initialValues, licenses!, false);
-    const editUrl = values.id
-      ? (lang: string) => toEditArticle(values.id!, values.articleType, lang)
-      : undefined;
 
     return (
       <StyledForm>
         <HeaderWithLanguage
+          id={article?.id}
+          language={articleLanguage}
           article={article}
-          values={values}
+          status={article?.status}
+          supportedLanguages={supportedLanguages}
           taxonomy={articleTaxonomy}
-          content={{ ...article, title: article?.title?.title, language: articleLanguage }}
-          editUrl={editUrl}
+          title={article?.title?.title}
           isSubmitting={isSubmitting}
           type="standard"
           expirationDate={getExpirationDate(article)}

--- a/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/CreateTopicArticle.tsx
@@ -34,6 +34,7 @@ const CreateTopicArticle = () => {
         updateArticle={createArticleAndPushRoute}
         isNewlyCreated={false}
         articleChanged={false}
+        supportedLanguages={[i18n.language]}
       />
     </>
   );

--- a/src/containers/ArticlePage/TopicArticlePage/EditTopicArticle.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/EditTopicArticle.tsx
@@ -86,6 +86,7 @@ const EditTopicArticle = ({ isNewlyCreated }: Props) => {
         article={article}
         isNewlyCreated={!!isNewlyCreated}
         updateArticle={updateArticle}
+        supportedLanguages={article.supportedLanguages}
       />
     </>
   );

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from 'react-i18next';
 import { Formik, FormikProps } from 'formik';
 import { IUpdatedArticle, IArticle, IStatus } from '@ndla/types-backend/draft-api';
 import { AlertModalWrapper } from '../../../FormikForm';
-import { toEditArticle } from '../../../../util/routeHelpers';
 import validateFormik, { getWarnings } from '../../../../components/formikValidationSchema';
 import TopicArticleAccordionPanels from './TopicArticleAccordionPanels';
 import HeaderWithLanguage from '../../../../components/HeaderWithLanguage';
@@ -42,6 +41,7 @@ interface Props {
   articleStatus?: IStatus;
   articleChanged: boolean;
   isNewlyCreated: boolean;
+  supportedLanguages: string[];
   articleLanguage: string;
 }
 
@@ -51,6 +51,7 @@ const TopicArticleForm = ({
   updateArticle,
   articleChanged,
   isNewlyCreated,
+  supportedLanguages,
   articleLanguage,
   articleStatus,
 }: Props) => {
@@ -87,23 +88,17 @@ const TopicArticleForm = ({
     });
     usePreventWindowUnload(formIsDirty);
     const getArticle = () => topicArticleFormTypeToDraftApiType(values, initialValues, licenses!);
-    const editUrl = values.id
-      ? (lang: string) => toEditArticle(values.id!, values.articleType, lang)
-      : undefined;
 
     return (
       <StyledForm>
         <HeaderWithLanguage
+          id={article?.id}
+          language={articleLanguage}
           taxonomy={articleTaxonomy}
           article={article}
-          values={values}
-          content={{
-            ...article,
-            title: article?.title?.title,
-            language: articleLanguage,
-            supportedLanguages: values.supportedLanguages,
-          }}
-          editUrl={editUrl}
+          status={article?.status}
+          supportedLanguages={supportedLanguages}
+          title={article?.title?.title}
           isSubmitting={isSubmitting}
           type="topic-article"
           expirationDate={getExpirationDate(article)}

--- a/src/containers/AudioUploader/CreateAudio.tsx
+++ b/src/containers/AudioUploader/CreateAudio.tsx
@@ -25,7 +25,13 @@ const CreateAudio = () => {
     navigate(toEditAudio(createdAudio.id, newAudio.language));
   };
 
-  return <AudioForm onCreateAudio={onCreateAudio} audioLanguage={i18n.language} />;
+  return (
+    <AudioForm
+      onCreateAudio={onCreateAudio}
+      audioLanguage={i18n.language}
+      supportedLanguages={[i18n.language]}
+    />
+  );
 };
 
 export default CreateAudio;

--- a/src/containers/AudioUploader/EditAudio.tsx
+++ b/src/containers/AudioUploader/EditAudio.tsx
@@ -15,7 +15,6 @@ import Spinner from '../../components/Spinner';
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { fetchAudio, updateAudio } from '../../modules/audio/audioApi';
 import { TranslateType, useTranslateToNN } from '../../components/NynorskTranslateProvider';
-import handleError from '../../util/handleError';
 
 interface Props {
   isNewlyCreated?: boolean;
@@ -88,6 +87,7 @@ const EditAudio = ({ isNewlyCreated }: Props) => {
       audioLanguage={audioLanguage}
       isNewlyCreated={isNewlyCreated}
       isNewLanguage={isNewLanguage}
+      supportedLanguages={audio.supportedLanguages}
     />
   );
 };

--- a/src/containers/AudioUploader/components/AudioForm.tsx
+++ b/src/containers/AudioUploader/components/AudioForm.tsx
@@ -26,7 +26,6 @@ import { AlertModalWrapper } from '../../FormikForm';
 import AudioMetaData from './AudioMetaData';
 import AudioContent from './AudioContent';
 import AudioManuscript from './AudioManuscript';
-import { toCreateAudioFile, toEditAudio } from '../../../util/routeHelpers';
 import validateFormik, { getWarnings, RulesType } from '../../../components/formikValidationSchema';
 import HeaderWithLanguage from '../../../components/HeaderWithLanguage';
 import { audioApiTypeToFormType } from '../../../util/audioHelpers';
@@ -104,6 +103,7 @@ interface Props {
   onUpdateAudio?: (audio: IUpdatedAudioMetaInformation, file?: string | Blob) => Promise<void>;
   audio?: IAudioMetaInformation;
   audioLanguage: string;
+  supportedLanguages: string[];
   isNewlyCreated?: boolean;
   isNewLanguage?: boolean;
 }
@@ -115,6 +115,7 @@ const AudioForm = ({
   onCreateAudio,
   onUpdateAudio,
   isNewLanguage,
+  supportedLanguages,
 }: Props) => {
   const { t } = useTranslation();
   const [savedToServer, setSavedToServer] = useState(false);
@@ -199,14 +200,12 @@ const AudioForm = ({
         return (
           <FormWrapper>
             <HeaderWithLanguage
+              id={audio?.id}
+              language={audioLanguage}
               noStatus
-              values={values}
+              supportedLanguages={supportedLanguages}
               type="audio"
-              content={{ ...audio, language: audioLanguage, title: audio?.title.title }}
-              editUrl={(lang: string) => {
-                if (values.id) return toEditAudio(values.id, lang);
-                else return toCreateAudioFile();
-              }}
+              title={audio?.title.title}
             />
             <FormAccordions defaultOpen={['audio-upload-content']}>
               <FormAccordion

--- a/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
@@ -17,7 +17,6 @@ import {
 import { IArticle } from '@ndla/types-backend/draft-api';
 import { Formik, FormikProps, FormikHelpers } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { toEditConcept } from '../../../util/routeHelpers';
 import { ARCHIVED, PUBLISHED, UNPUBLISHED } from '../../../constants';
 import HeaderWithLanguage from '../../../components/HeaderWithLanguage';
 import validateFormik, { getWarnings, RulesType } from '../../../components/formikValidationSchema';
@@ -61,6 +60,7 @@ interface Props {
   subjects: SubjectType[];
   initialTitle?: string;
   onUpserted?: (concept: IConceptSummary | IConcept) => void;
+  supportedLanguages: string[];
 }
 
 const conceptFormRules: RulesType<ConceptFormValues, IConcept> = {
@@ -129,6 +129,7 @@ const ConceptForm = ({
   conceptArticles,
   initialTitle,
   onUpserted,
+  supportedLanguages,
 }: Props) => {
   const [savedToServer, setSavedToServer] = useState(false);
   const { t } = useTranslation();
@@ -206,15 +207,16 @@ const ConceptForm = ({
         const getEntity = requirements
           ? () => conceptFormTypeToApiType(values, licenses, concept?.updatedBy)
           : undefined;
-        const editUrl = values.id ? (lang: string) => toEditConcept(values.id!, lang) : undefined;
         return (
           <FormWrapper inModal={inModal}>
             <HeaderWithLanguage
+              id={concept?.id}
+              language={language}
               concept={concept}
-              content={{ ...concept, title: concept?.title?.title, language }}
-              editUrl={editUrl}
+              status={concept?.status}
+              title={concept?.title.title ?? initialTitle}
               type="concept"
-              values={values}
+              supportedLanguages={supportedLanguages}
             />
             <FormAccordions defaultOpen={['content']}>
               <FormAccordion

--- a/src/containers/ConceptPage/CreateConcept.tsx
+++ b/src/containers/ConceptPage/CreateConcept.tsx
@@ -47,6 +47,7 @@ const CreateConcept = ({ inModal = false, addConceptInModal }: Props) => {
         inModal={inModal}
         subjects={subjects}
         conceptArticles={conceptArticles}
+        supportedLanguages={[i18n.language]}
       />
     </>
   );

--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -86,6 +86,7 @@ const EditConcept = ({ isNewlyCreated }: Props) => {
         }}
         language={selectedLanguage!}
         subjects={subjects}
+        supportedLanguages={concept.supportedLanguages}
       />
     </>
   );

--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -213,7 +213,7 @@ const EditMarkupPage = () => {
         <HeaderSupportedLanguages
           supportedLanguages={draft?.supportedLanguages}
           language={language}
-          editUrl={(lang: string) => toEditMarkup(draftId, lang)}
+          editUrl={toEditMarkup}
           id={draftId}
           isSubmitting={isSubmitting}
           replace={true}

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -171,7 +171,7 @@ const SubjectpageForm = ({
           <StyledForm>
             <SimpleLanguageHeader
               articleType={values.articleType!}
-              editUrl={(lang: string) => toEditSubjectpage(values.elementId!, lang, values.id)}
+              editUrl={(_, lang: string) => toEditSubjectpage(values.elementId!, lang, values.id)}
               id={values.id!}
               isSubmitting={isSubmitting}
               language={values.language}

--- a/src/containers/ImageUploader/CreateImage.tsx
+++ b/src/containers/ImageUploader/CreateImage.tsx
@@ -53,6 +53,7 @@ const CreateImage = ({
       licenses={imageLicenses}
       onSubmitFunc={onCreateImage}
       closeModal={closeModal}
+      supportedLanguages={[locale]}
     />
   );
 };

--- a/src/containers/ImageUploader/EditImage.tsx
+++ b/src/containers/ImageUploader/EditImage.tsx
@@ -8,7 +8,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { unstable_batchedUpdates } from 'react-dom';
 import {
   IImageMetaInformationV3,
   IUpdateImageMetaInformation,
@@ -112,6 +111,7 @@ const EditImage = ({ isNewlyCreated }: Props) => {
       isNewlyCreated={isNewlyCreated}
       licenses={imageLicenses}
       isNewLanguage={isNewLanguage}
+      supportedLanguages={image.supportedLanguages}
     />
   );
 };

--- a/src/containers/ImageUploader/components/ImageForm.tsx
+++ b/src/containers/ImageUploader/components/ImageForm.tsx
@@ -23,7 +23,6 @@ import validateFormik, { RulesType, getWarnings } from '../../../components/form
 import ImageMetaData from './ImageMetaData';
 import ImageContent from './ImageContent';
 import { AlertModalWrapper } from '../../FormikForm';
-import { toCreateImage, toEditImage } from '../../../util/routeHelpers';
 import HeaderWithLanguage from '../../../components/HeaderWithLanguage/HeaderWithLanguage';
 import ImageVersionNotes from './ImageVersionNotes';
 import { MAX_IMAGE_UPLOAD_SIZE } from '../../../constants';
@@ -94,6 +93,7 @@ interface Props {
   isSaving?: boolean;
   isNewLanguage?: boolean;
   language: string;
+  supportedLanguages: string[];
 }
 
 export type ImageFormErrorFields =
@@ -117,6 +117,7 @@ const ImageForm = ({
   isNewlyCreated,
   isSaving,
   isNewLanguage,
+  supportedLanguages,
 }: Props) => {
   const { t } = useTranslation();
   const [savedToServer, setSavedToServer] = useState(false);
@@ -191,19 +192,12 @@ const ImageForm = ({
         return (
           <FormWrapper inModal={inModal}>
             <HeaderWithLanguage
+              id={image?.id ? parseInt(image.id) : undefined}
+              language={language}
               noStatus
-              values={values}
+              supportedLanguages={supportedLanguages}
               type="image"
-              content={{
-                ...image,
-                language,
-                title: image?.title.title,
-                id: image?.id ? parseInt(image.id) : undefined,
-              }}
-              editUrl={(lang: string) => {
-                if (values.id) return toEditImage(values.id, lang);
-                else return toCreateImage();
-              }}
+              title={image?.title.title}
             />
             <FormAccordions defaultOpen={['content']}>
               <FormAccordion

--- a/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
+++ b/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
@@ -88,7 +88,7 @@ const NdlaFilmForm = ({ filmFrontpage, selectedLanguage }: Props) => {
           <StyledForm>
             <SimpleLanguageHeader
               articleType={values.articleType}
-              editUrl={(lang: string) => toEditNdlaFilm(lang)}
+              editUrl={(_, lang) => toEditNdlaFilm(lang)}
               id={20}
               isSubmitting={isSubmitting}
               language={selectedLanguage}

--- a/src/containers/Podcast/CreatePodcast.tsx
+++ b/src/containers/Podcast/CreatePodcast.tsx
@@ -27,7 +27,14 @@ const CreatePodcast = () => {
     navigate(toEditPodcast(createdPodcast.id, newPodcast.language));
   };
 
-  return <PodcastForm onCreatePodcast={onCreatePodcast} isNewlyCreated={false} language={locale} />;
+  return (
+    <PodcastForm
+      onCreatePodcast={onCreatePodcast}
+      supportedLanguages={[locale]}
+      isNewlyCreated={false}
+      language={locale}
+    />
+  );
 };
 
 export default CreatePodcast;

--- a/src/containers/Podcast/EditPodcast.tsx
+++ b/src/containers/Podcast/EditPodcast.tsx
@@ -99,14 +99,14 @@ const EditPodcast = ({ isNewlyCreated }: Props) => {
     return <NotFoundPage />;
   }
 
-  if (podcast?.audioType === 'standard') {
+  if (podcast.audioType === 'standard') {
     return <Navigate replace to={toEditAudio(podcastId, podcastLanguage)} />;
   }
-  const newLanguage = !podcast?.supportedLanguages.includes(podcastLanguage);
+  const newLanguage = !podcast.supportedLanguages.includes(podcastLanguage);
   const language = podcastLanguage || locale;
   return (
     <PodcastForm
-      supportedLanguages={podcast?.supportedLanguages || [language]}
+      supportedLanguages={podcast.supportedLanguages}
       audio={podcast}
       language={language}
       podcastChanged={podcastChanged || newLanguage}

--- a/src/containers/Podcast/EditPodcast.tsx
+++ b/src/containers/Podcast/EditPodcast.tsx
@@ -15,6 +15,7 @@ import { toEditAudio } from '../../util/routeHelpers';
 import PodcastForm from './components/PodcastForm';
 import Spinner from '../../components/Spinner';
 import { TranslateType, useTranslateToNN } from '../../components/NynorskTranslateProvider';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
 
 interface Props {
   isNewlyCreated?: boolean;
@@ -94,6 +95,10 @@ const EditPodcast = ({ isNewlyCreated }: Props) => {
     return <Spinner withWrapper />;
   }
 
+  if (!podcastId || !podcast) {
+    return <NotFoundPage />;
+  }
+
   if (podcast?.audioType === 'standard') {
     return <Navigate replace to={toEditAudio(podcastId, podcastLanguage)} />;
   }
@@ -101,6 +106,7 @@ const EditPodcast = ({ isNewlyCreated }: Props) => {
   const language = podcastLanguage || locale;
   return (
     <PodcastForm
+      supportedLanguages={podcast?.supportedLanguages || [language]}
       audio={podcast}
       language={language}
       podcastChanged={podcastChanged || newLanguage}

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -26,7 +26,6 @@ import SaveButton from '../../../components/SaveButton';
 import Field from '../../../components/Field';
 import Spinner from '../../../components/Spinner';
 import { isFormikFormDirty } from '../../../util/formHelper';
-import { toCreatePodcastFile, toEditPodcast } from '../../../util/routeHelpers';
 import { PodcastFormValues } from '../../../modules/audio/audioApiInterfaces';
 import { editorValueToPlainText } from '../../../util/articleContentConverter';
 import PodcastSeriesInformation from './PodcastSeriesInformation';
@@ -106,6 +105,7 @@ interface Props {
   onCreatePodcast?: (newPodcast: INewAudioMetaInformation, file?: string | Blob) => void;
   onUpdatePodcast?: (updatedPodcast: IUpdatedAudioMetaInformation, file?: string | Blob) => void;
   translating?: boolean;
+  supportedLanguages: string[];
 }
 
 const PodcastForm = ({
@@ -117,6 +117,7 @@ const PodcastForm = ({
   onCreatePodcast,
   onUpdatePodcast,
   translating,
+  supportedLanguages,
 }: Props) => {
   const { data: licenses } = useLicenses({ placeholderData: [] });
   const { t } = useTranslation();
@@ -235,17 +236,15 @@ const PodcastForm = ({
           dirty,
           changed: podcastChanged,
         });
-        const content = { ...audio, title: audio?.title.title ?? '', language };
         return (
           <FormWrapper inModal={inModal}>
             <HeaderWithLanguage
+              id={audio?.id}
+              language={language}
               noStatus
-              values={values}
+              supportedLanguages={supportedLanguages}
               type="podcast"
-              content={content}
-              editUrl={(lang: string) => {
-                return values.id ? toEditPodcast(values.id, lang) : toCreatePodcastFile();
-              }}
+              title={audio?.title.title}
             />
             {translating ? (
               <Spinner withWrapper />

--- a/src/containers/PodcastSeries/CreatePodcastSeries.tsx
+++ b/src/containers/PodcastSeries/CreatePodcastSeries.tsx
@@ -22,7 +22,14 @@ const CreatePodcastSeries = () => {
     navigate(toEditPodcastSeries(createdSeries.id, newSeries.language));
   };
 
-  return <PodcastSeriesForm language={locale} onUpdate={onUpdate} isNewlyCreated={false} />;
+  return (
+    <PodcastSeriesForm
+      language={locale}
+      onUpdate={onUpdate}
+      isNewlyCreated={false}
+      supportedLanguages={[locale]}
+    />
+  );
 };
 
 export default CreatePodcastSeries;

--- a/src/containers/PodcastSeries/EditPodcastSeries.tsx
+++ b/src/containers/PodcastSeries/EditPodcastSeries.tsx
@@ -82,6 +82,7 @@ const EditPodcastSeries = ({ isNewlyCreated }: Props) => {
       onUpdate={onUpdate}
       isNewlyCreated={!!isNewlyCreated}
       isNewLanguage={isNewLanguage}
+      supportedLanguages={podcastSeries.supportedLanguages}
     />
   );
 };

--- a/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
@@ -20,7 +20,6 @@ import validateFormik, { getWarnings, RulesType } from '../../../components/form
 import SaveButton from '../../../components/SaveButton';
 import Field from '../../../components/Field';
 import { isFormikFormDirty } from '../../../util/formHelper';
-import { toCreatePodcastSeries, toEditPodcastSeries } from '../../../util/routeHelpers';
 import { editorValueToPlainText } from '../../../util/articleContentConverter';
 import PodcastSeriesMetaData from './PodcastSeriesMetaData';
 import PodcastEpisodes from './PodcastEpisodes';
@@ -87,6 +86,7 @@ interface Props {
   onUpdate: (newPodcastSeries: INewSeries) => void;
   revision?: number;
   isNewLanguage?: boolean;
+  supportedLanguages: string[];
 }
 
 const PodcastSeriesForm = ({
@@ -96,6 +96,7 @@ const PodcastSeriesForm = ({
   onUpdate,
   language,
   isNewLanguage,
+  supportedLanguages,
 }: Props) => {
   const { t } = useTranslation();
   const [savedToServer, setSavedToServer] = useState(false);
@@ -176,23 +177,16 @@ const PodcastSeriesForm = ({
           changed: isNewLanguage,
         });
 
-        const content = {
-          ...podcastSeries,
-          title: podcastSeries?.title.title ?? '',
-          language,
-          hasRSS: values.hasRSS,
-        };
         return (
           <FormWrapper inModal={inModal}>
             <HeaderWithLanguage
+              id={podcastSeries?.id}
+              language={language}
               noStatus
-              values={values}
+              supportedLanguages={supportedLanguages}
               type="podcast-series"
-              content={content}
-              editUrl={(lang: string) => {
-                if (values.id) return toEditPodcastSeries(values.id, lang);
-                else return toCreatePodcastSeries();
-              }}
+              title={podcastSeries?.title.title}
+              hasRSS={podcastSeries?.hasRSS}
             />
             <FormAccordions defaultOpen={['podcast-series-podcastmeta']}>
               <FormAccordion

--- a/src/containers/SearchPage/components/results/SearchConcept/ContentView.tsx
+++ b/src/containers/SearchPage/components/results/SearchConcept/ContentView.tsx
@@ -104,8 +104,7 @@ const ContentView = ({
           published={
             concept.status?.current === 'PUBLISHED' || concept.status?.other.includes('PUBLISHED')
           }
-          indentLeft
-          fontSize={10}
+          compact
           responsibleName={responsibleName}
         />
       </StyledBreadcrumbs>

--- a/src/containers/SearchPage/components/results/SearchContent.tsx
+++ b/src/containers/SearchPage/components/results/SearchContent.tsx
@@ -169,8 +169,7 @@ const SearchContent = ({ content, locale, responsibleName }: Props) => {
                 content.status?.other.includes('PUBLISHED')
               )
             }
-            indentLeft
-            fontSize={10}
+            compact
             expirationDate={expirationDate}
             type={content.learningResourceType}
             responsibleName={responsibleName}

--- a/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
+++ b/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
@@ -96,9 +96,7 @@ const StatusIcons = ({ contentMetaLoading, resource, path }: Props) => {
             >
               <TimeIconWrapper>
                 <StyledTimeIcon
-                  status={expirationColor}
-                  width="24px"
-                  height="24px"
+                  data-status={expirationColor}
                   aria-label={t(`form.workflow.expiration.${expirationColor}`, {
                     date: formatDate(expirationDate),
                   })}

--- a/src/util/routeHelpers.ts
+++ b/src/util/routeHelpers.ts
@@ -23,6 +23,14 @@ export function toEditArticle(articleId: number | string, articleType: string, l
   return locale ? `${path}/${locale}` : path;
 }
 
+export function toEditTopicArticle(id: number, locale: string) {
+  return `/subject-matter/topic-article/${id}/edit/${locale}`;
+}
+
+export function toEditLearningResource(id: number, locale: string) {
+  return `/subject-matter/learning-resource/${id}/edit/${locale}`;
+}
+
 export const toEditGenericArticle = (articleId: number | string) => {
   return `/subject-matter/article/${articleId}`;
 };
@@ -61,6 +69,10 @@ export function toCreateTopicArticle() {
 
 export function toCreateFrontPageArticle() {
   return '/subject-matter/frontpage-article/new';
+}
+
+export function toEditFrontPageArticle(id: number, locale: string) {
+  return `subject-matter/frontpage-article/${id}/edit/${locale}`;
 }
 
 export function toCreateSubjectpage(subjectId: string, locale: string) {


### PR DESCRIPTION
* Fjernet splitteren. Den var så keitete å ha å gjøre med, og gir ikke så mye merverdi at det gjør noe. Påvirker også søkeresultater.
* Gikk vekk fra tooltips, og over til en kombinasjon av aria-label og title. Usikker på om det er vår implementasjon av tooltips som er treg, eller om det er radix sin. Gjorde en ganske stor forskjell.
* RSS oppdaterer seg ikke lenger i header mens en redigerer. Synes dette var en helt grei løsning, i og med at vi f.eks ikke oppdaterer tittel mens man redigerer uansett.

Etter loading viser profileren at hele header-komponenten nå rendrer på 3-4ms etter at den er ferdig med å sette opp og laste inn data. Dette er ned fra et snitt på litt over 10ms.

Dersom vi ønsker å optimere komponenten videre må vi dra den ut av FormikContext.