### PR TITLE
Frontpage article sizing

### DIFF
--- a/src/components/ResourcePage.tsx
+++ b/src/components/ResourcePage.tsx
@@ -18,7 +18,10 @@ import Footer from '../containers/App/components/Footer';
 import Spinner from './Spinner';
 import { NynorskTranslateProvider } from './NynorskTranslateProvider';
 import { MAX_PAGE_WIDTH } from '../constants';
-import { MAX_WIDTH_FRONTPAGE_WITH_COMMENTS } from '../containers/ArticlePage/styles';
+import {
+  MAX_DEFAULT_WIDTH_FRONTPAGE_WITH_COMMENTS,
+  MAX_WIDTH_FRONTPAGE_WITH_COMMENTS,
+} from '../containers/ArticlePage/styles';
 import { useWideArticle } from './WideArticleEditorProvider';
 
 const NotFoundPage = loadable(() => import('../containers/NotFoundPage/NotFoundPage'));
@@ -36,8 +39,13 @@ const PageContent = styled.div`
   padding-right: 24px;
 
   &[data-wide='true'] {
-    max-width: ${MAX_WIDTH_FRONTPAGE_WITH_COMMENTS}px;
+    max-width: ${MAX_WIDTH_FRONTPAGE_WITH_COMMENTS}px !important;
   }
+
+  &[data-frontpage='true'] {
+    max-width: ${MAX_DEFAULT_WIDTH_FRONTPAGE_WITH_COMMENTS}px;
+  }
+
   max-width: ${MAX_PAGE_WIDTH}px;
 `;
 interface ResourceComponentProps {
@@ -58,6 +66,7 @@ interface Props<T extends BaseResource> {
   ) => UseQueryResult<T>;
   createUrl: string;
   titleTranslationKey?: string;
+  isFrontpageArticle?: boolean;
 }
 
 const ResourcePage = <T extends BaseResource>({
@@ -67,13 +76,18 @@ const ResourcePage = <T extends BaseResource>({
   createUrl,
   titleTranslationKey,
   className,
+  isFrontpageArticle,
 }: Props<T>) => {
   const { t } = useTranslation();
   const previousLocation = usePreviousLocation();
   const { isWideArticle } = useWideArticle();
   return (
     <Wrapper>
-      <PageContent className={className} data-wide={isWideArticle}>
+      <PageContent
+        className={className}
+        data-wide={isWideArticle}
+        data-frontpage={isFrontpageArticle}
+      >
         {titleTranslationKey && <HelmetWithTracker title={t(titleTranslationKey)} />}
         <Routes>
           <Route path="new" element={<CreateComponent />} />

--- a/src/components/ResourcePage.tsx
+++ b/src/components/ResourcePage.tsx
@@ -38,16 +38,17 @@ const PageContent = styled.div`
   padding-left: 24px;
   padding-right: 24px;
 
-  &[data-wide='true'] {
-    max-width: ${MAX_WIDTH_FRONTPAGE_WITH_COMMENTS}px !important;
-  }
+  max-width: ${MAX_PAGE_WIDTH}px;
 
   &[data-frontpage='true'] {
     max-width: ${MAX_DEFAULT_WIDTH_FRONTPAGE_WITH_COMMENTS}px;
   }
 
-  max-width: ${MAX_PAGE_WIDTH}px;
+  &[data-wide='true'] {
+    max-width: ${MAX_WIDTH_FRONTPAGE_WITH_COMMENTS}px;
+  }
 `;
+
 interface ResourceComponentProps {
   isNewlyCreated?: boolean;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,7 @@ export const MAX_IMAGE_UPLOAD_SIZE = 1024 * 1024 * 40; // 40MB.
 
 export const MAX_PAGE_WIDTH = 1024;
 export const MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH = 1100;
+export const DEFAULT_FRONTPAGE_ARTICLE_WIDTH = 773;
 
 export const LOCALE_VALUES = ['nb', 'nn', 'en', 'se', 'sma'] as const;
 

--- a/src/containers/ArticlePage/FrontpageArticlePage/FrontpageArticlePage.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/FrontpageArticlePage.tsx
@@ -20,6 +20,7 @@ const FrontpageArticlePage = () => (
       useHook={useDraft}
       createUrl="/subject-matter/frontpage-article/new"
       css={articleResourcePageStyle}
+      isFrontpageArticle={true}
     />
   </WideArticleEditorProvider>
 );

--- a/src/containers/ArticlePage/styles.ts
+++ b/src/containers/ArticlePage/styles.ts
@@ -9,14 +9,21 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { spacing } from '@ndla/core';
 import { COMMENT_WIDTH, SPACING_COMMENT } from './components/CommentSection';
-import { MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH, MAX_PAGE_WIDTH } from '../../constants';
+import {
+  DEFAULT_FRONTPAGE_ARTICLE_WIDTH,
+  MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH,
+  MAX_PAGE_WIDTH,
+} from '../../constants';
 
 // Calculate the max width of edit resource page with comments displayed
 export const MAX_WIDTH_WITH_COMMENTS = MAX_PAGE_WIDTH + COMMENT_WIDTH + SPACING_COMMENT;
 
 const SPACING_FRONTPAGE = parseInt(spacing.medium.replace('px', '')) * 2;
 export const MAX_WIDTH_FRONTPAGE_WITH_COMMENTS =
-  MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH + COMMENT_WIDTH + SPACING_FRONTPAGE;
+  MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH + COMMENT_WIDTH + SPACING_COMMENT + SPACING_FRONTPAGE;
+
+export const MAX_DEFAULT_WIDTH_FRONTPAGE_WITH_COMMENTS =
+  DEFAULT_FRONTPAGE_ARTICLE_WIDTH + COMMENT_WIDTH + SPACING_COMMENT + SPACING_FRONTPAGE;
 
 export const articleResourcePageStyle = css`
   max-width: ${MAX_WIDTH_WITH_COMMENTS}px;
@@ -29,8 +36,4 @@ export const FlexWrapper = styled.div`
 export const MainContent = styled.div`
   flex: 1;
   max-width: ${MAX_PAGE_WIDTH}px;
-
-  &[data-wide='true'] {
-    max-width: ${MAX_FRONTPAGE_ARTICLE_PAGE_WIDTH}px;
-  }
 `;


### PR DESCRIPTION
Remove unecessary css in maincontent. Added new size for default frontpage-articles.

Om ndla artikler skal ha størrelse `773px` når vi ikke er i `wide-view` som er på `1100px`.
 