### PR TITLE
Replace hardcoded value with article-type

### DIFF
--- a/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateVideo.tsx
@@ -200,8 +200,8 @@ const SlateVideo = ({
           <Modal open={editMode} onOpenChange={setEditMode}>
             <ModalTrigger>
               <IconButtonV2
-                aria-label={t('form.image.editVideo')}
-                title={t('form.image.editVideo')}
+                aria-label={t('form.video.editVideo')}
+                title={t('form.video.editVideo')}
                 colorTheme="light"
               >
                 <Pencil />

--- a/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
@@ -128,8 +128,8 @@ const WorkListTabContent = ({
             {
               id: `contentType_${res.id}`,
               data:
-                res.learningResourceType === 'topic-article'
-                  ? 'Emne'
+                res.learningResourceType !== 'standard'
+                  ? t(`articleType.${res.learningResourceType}`)
                   : res.contexts?.[0]?.resourceTypes?.map((context) => context.name).join(' - '),
             },
             {


### PR DESCRIPTION
Viser om en artikkel er om-ndla-artikkel og ikkje berre emne.
Fant også ut at knapp for redigering av video hadde feil tekst.

Test:
* Sett deg som ansvarlig på en om-ndla-artikkel og sjekk at den har artikkeltype på forsida
* Finn artikkel med brightcove og sjå at blyantknapp har title Rediger video.