### PR TITLE
Make audio manuscript editor look more like ndla-frontend

### DIFF
--- a/src/components/SlateEditor/PlainTextEditor.tsx
+++ b/src/components/SlateEditor/PlainTextEditor.tsx
@@ -70,6 +70,7 @@ const PlainTextEditor = ({
   return (
     <Slate editor={editor} value={value} onChange={onSlateChange}>
       <Editable
+        id={id}
         // Forcing slate field to be deselected before selecting new field.
         // Fixes a problem where slate field is not properly focused on click.
         onBlur={onBlur}

--- a/src/containers/AudioUploader/components/AudioManuscript.tsx
+++ b/src/containers/AudioUploader/components/AudioManuscript.tsx
@@ -7,8 +7,9 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import { fonts } from '@ndla/core';
 import { connect } from 'formik';
-
+import styled from '@emotion/styled';
 import FormikField from '../../../components/FormikField';
 import PlainTextEditor from '../../../components/SlateEditor/PlainTextEditor';
 import { textTransformPlugin } from '../../../components/SlateEditor/plugins/textTransform';
@@ -16,21 +17,33 @@ import { AudioFormikType } from './AudioForm';
 
 const plugins = [textTransformPlugin];
 
+const StyledFormikField = styled(FormikField)`
+  label {
+    font-weight: ${fonts.weight.semibold};
+    ${fonts.sizes('30px', '38px')};
+  }
+`;
+
+const StyledPlainTextEditor = styled(PlainTextEditor)`
+  white-space: pre-wrap;
+  ${fonts.sizes('16px', '30px')};
+  font-family: ${fonts.sans};
+`;
+
 const AudioManuscript = () => {
   const { t } = useTranslation();
 
   return (
-    <FormikField label={t('podcastForm.fields.manuscript')} name="manuscript">
+    <StyledFormikField label={t('podcastForm.fields.manuscript')} name="manuscript">
       {({ field }) => (
-        <PlainTextEditor
+        <StyledPlainTextEditor
           id={field.name}
           {...field}
-          className={'manuscript'}
           placeholder={t('podcastForm.fields.manuscript')}
           plugins={plugins}
         />
       )}
-    </FormikField>
+    </StyledFormikField>
   );
 };
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3666, tror jeg? Stjålet stylingen fra frontend-packages. Har også fikset en feil der vi ikke sendte ID videre til Editable, som førte til at labelet ikke var knyttet opp mot selve inputet.