### PR TITLE
Only restore focus to slate when saving an article with save hotkey

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -100,7 +100,9 @@ const RichTextEditor = ({
       editor.mathjaxInitialized = false;
       window.MathJax?.typesetClear();
       Editor.normalize(editor, { force: true });
-      ReactEditor.focus(editor);
+      if (editor.lastSelection || editor.lastSelectedBlock) {
+        ReactEditor.focus(editor);
+      }
       // Try to select previous selection if it exists
       if (editor.lastSelection) {
         const edges = Range.edges(editor.lastSelection);


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3656

Editor skal nå bevare fokus der det var dersom du lagrer med MOD+s, men ikke når du klikker på lagreknappen. Dette sørger for at fokus ikke plasseres først i editoren når du lagrer med knapp. Slenger med en liten forklaring på hvorfor dette skjer:

`RichTextEditor` fokuserte alltid react-editoren, og satt deretter cursor basert på `lastSelection`, en custom-attributt som vi setter når man trykker på lagre-hotkeyen (MOD+s). Dersom `lastSelection` ikke er satt fokuserer man første elementet i slate-editoren, altså helt øverst i content-feltet. Det er ikke kjempelett å få Slate til å vite om at man har klikket på lagre-knappen, og derfor også ganske vanskelig å sette `lastSelection` basert på når man klikker på lagreknappen. Man kan eventuelt kontinuerlig oppdatere `lastSelection` på `onBlur`, men inntil videre føler jeg at denne løsningen er god nok.