### PR TITLE
show link to published concept in concept-form

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderStatusInformation.tsx
@@ -173,7 +173,7 @@ const HeaderStatusInformation = ({
             target="_blank"
             aria-label={t('form.workflow.published')}
             title={t('form.workflow.published')}
-            to={`${config.ndlaFrontendDomain}/article/${id}`}
+            to={`${config.ndlaFrontendDomain}/${type === 'concept' ? type : 'article'}/${id}`}
           >
             <StyledCheckIcon />
           </StyledLink>


### PR DESCRIPTION
Vi har begynt å vise lenke til artikkel med samme id i concept på grunn av omskriving av header.