### PR TITLE
Added return when normalizing alignment numbers

### DIFF
--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -388,7 +388,9 @@ export const tablePlugin = (editor: Editor) => {
 
       // Numbers need to be right aligned default
       if (!isNaN(Number(Node.string(node))) && !node.data?.align && Node.string(node) !== '') {
-        updateCell(editor, node, { align: 'right' });
+        return HistoryEditor.withoutSaving(editor, () =>
+          updateCell(editor, node, { align: 'right' }),
+        );
       }
     }
 


### PR DESCRIPTION
Merket at tall på tomme celler var veldig treigt plutselig legger til return i normaliseringen som vi gjør på andre celler normaliseringer. 