### PR TITLE
Removing isHeader data from cells as it escapes into tests

### DIFF
--- a/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
@@ -77,7 +77,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -95,7 +94,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -154,7 +152,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -174,7 +171,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -204,7 +200,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -223,7 +218,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -297,7 +291,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -326,7 +319,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -344,7 +336,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -403,7 +394,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -423,7 +413,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -453,7 +442,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -472,7 +460,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -530,7 +517,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -549,7 +535,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -578,7 +563,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -638,7 +622,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -658,7 +641,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -688,7 +670,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -707,7 +688,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -773,7 +753,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -792,7 +771,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -821,7 +799,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 2,
                           align: 'right',
@@ -840,7 +817,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -864,7 +840,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -924,7 +899,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -944,7 +918,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -974,7 +947,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 2,
                           scope: 'row',
@@ -994,7 +966,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',
@@ -1018,7 +989,6 @@ describe('table normalizer tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                           align: 'right',

--- a/src/components/SlateEditor/plugins/table/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/serializer-test.ts
@@ -53,7 +53,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -72,7 +71,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -101,7 +99,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -119,7 +116,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -142,7 +138,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -160,7 +155,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -217,7 +211,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -236,7 +229,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 1,
                           scope: 'col',
@@ -265,7 +257,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL_HEADER,
                         data: {
-                          isHeader: true,
                           colspan: 1,
                           rowspan: 2,
                           scope: 'row',
@@ -284,7 +275,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },
@@ -307,7 +297,6 @@ describe('table serializing tests', () => {
                       {
                         type: TYPE_TABLE_CELL,
                         data: {
-                          isHeader: false,
                           colspan: 1,
                           rowspan: 1,
                         },

--- a/src/components/SlateEditor/plugins/table/defaultBlocks.ts
+++ b/src/components/SlateEditor/plugins/table/defaultBlocks.ts
@@ -38,7 +38,6 @@ export const defaultTableCellBlock = () => {
     {
       type: TYPE_TABLE_CELL,
       data: {
-        isHeader: false,
         colspan: 1,
         rowspan: 1,
       },
@@ -56,7 +55,6 @@ export const defaultTableCellHeaderBlock = () => {
     {
       type: TYPE_TABLE_CELL_HEADER,
       data: {
-        isHeader: true,
         colspan: 1,
         rowspan: 1,
       },

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -53,6 +53,7 @@ import {
   isTableBody,
   isTableCaption,
   isTableCell,
+  isTableCellHeader,
   isTableHead,
   isTableRow,
 } from './slateHelpers';
@@ -151,7 +152,6 @@ export const tableSerializer: SlateSerializer = {
         ...attrs,
         colspan: colspan || 1,
         rowspan: rowspan || 1,
-        isHeader: tagName === 'th',
       };
       if (equals(children, [{ text: '' }])) {
         children = [
@@ -220,7 +220,7 @@ export const tableSerializer: SlateSerializer = {
         delete props.rowspan;
       }
 
-      if (node.type === TYPE_TABLE_CELL_HEADER || node.data.isHeader) {
+      if (node.type === TYPE_TABLE_CELL_HEADER) {
         return (
           <th {...props} scope={node.data.scope}>
             {children}
@@ -373,7 +373,7 @@ export const tablePlugin = (editor: Editor) => {
     }
 
     // C. TableCell normalizer
-    if (isTableCell(node)) {
+    if (isTableCell(node) || isTableCellHeader(node)) {
       // Cells should only contain elements. If not, wrap content in paragraph
       if (!Element.isElementList(node.children)) {
         return Transforms.wrapNodes(
@@ -404,16 +404,20 @@ export const tablePlugin = (editor: Editor) => {
       const [body, bodyPath] = Editor.node(editor, Path.parent(path));
       const [table] = Editor.node(editor, Path.parent(bodyPath));
 
-      // ii. Make sure cells in TableHead are marked as isHeader.
+      // ii. Make sure cells in TableHead are set to TYPE_TABLE_CELL_HEADER.
       //     Cells in TableBody will not be altered if rowHeaders=true on Table.
       if (isTableHead(body) && isTable(table)) {
         for (const [, cell] of node.children.entries()) {
-          if (isTableCell(cell) && !cell.data.isHeader) {
+          if (isTableCell(cell) && cell.type !== TYPE_TABLE_CELL_HEADER) {
             return HistoryEditor.withoutSaving(editor, () => {
-              updateCell(editor, cell, {
-                isHeader: true,
-                scope: 'col',
-              });
+              updateCell(
+                editor,
+                cell,
+                {
+                  scope: 'col',
+                },
+                TYPE_TABLE_CELL_HEADER,
+              );
             });
           }
         }

--- a/src/components/SlateEditor/plugins/table/interfaces.ts
+++ b/src/components/SlateEditor/plugins/table/interfaces.ts
@@ -50,7 +50,6 @@ interface TableCellData {
   valign?: string;
   class?: string;
   headers?: string;
-  isHeader?: boolean;
   scope?: 'row' | 'col';
 }
 

--- a/src/components/SlateEditor/plugins/table/matrixNormalizer.ts
+++ b/src/components/SlateEditor/plugins/table/matrixNormalizer.ts
@@ -91,21 +91,17 @@ const normalizeRow = (
 
     const row = matrix[rowIndex].entries();
     for (const [index, cell] of row) {
-      const { scope, isHeader } = cell.data;
+      const { scope } = cell.data;
       // A. Normalize table head
       if (isHead) {
         // i. If cell in header
         //    Make sure scope='col' and isHeader=true and type is correct
-        if (
-          isTableCell(cell) &&
-          (scope !== 'col' || !isHeader || cell.type !== TYPE_TABLE_CELL_HEADER)
-        ) {
+        if (isTableCell(cell) && (cell.type !== TYPE_TABLE_CELL_HEADER || scope !== 'col')) {
           updateCell(
             editor,
             cell,
             {
               scope: 'col',
-              isHeader: true,
             },
             TYPE_TABLE_CELL_HEADER,
           );
@@ -114,13 +110,12 @@ const normalizeRow = (
       } else {
         // i. If table does not have headers on rows
         //    Make sure cells in body has scope=undefined and isHeader=false
-        if (!rowHeaders && (scope || isHeader)) {
+        if (!rowHeaders && (scope || cell.type === TYPE_TABLE_CELL_HEADER)) {
           updateCell(
             editor,
             cell,
             {
               scope: undefined,
-              isHeader: false,
             },
             TYPE_TABLE_CELL,
           );
@@ -132,24 +127,30 @@ const normalizeRow = (
         //    Other cells should not be a header
         if (rowHeaders) {
           if (index === 0) {
-            if (scope !== 'row' || !isHeader) {
+            if (scope !== 'row' || cell.type !== TYPE_TABLE_CELL_HEADER) {
               updateCell(
                 editor,
                 cell,
                 {
                   scope: 'row',
-                  isHeader: true,
                 },
                 TYPE_TABLE_CELL_HEADER,
               );
               return true;
             }
           } else {
-            if ((scope || isHeader) && getPrevCell(matrix, rowIndex, index) !== cell) {
-              updateCell(editor, cell, {
-                scope: undefined,
-                isHeader: false,
-              });
+            if (
+              (scope || cell.type === TYPE_TABLE_CELL_HEADER) &&
+              getPrevCell(matrix, rowIndex, index) !== cell
+            ) {
+              updateCell(
+                editor,
+                cell,
+                {
+                  scope: undefined,
+                },
+                TYPE_TABLE_CELL,
+              );
               return true;
             }
           }

--- a/src/components/SlateEditor/plugins/table/slateHelpers.ts
+++ b/src/components/SlateEditor/plugins/table/slateHelpers.ts
@@ -47,16 +47,12 @@ export const isTableRow = (node?: Node): node is TableRowElement => {
   return Element.isElement(node) && node.type === TYPE_TABLE_ROW;
 };
 
-export const isTableCell = (node?: Node): node is TableCellElement => {
-  return (
-    Element.isElement(node) &&
-    (node.type === TYPE_TABLE_CELL || node.type === TYPE_TABLE_CELL_HEADER)
-  );
-};
+export const isTableCell = (node?: Node): node is TableCellElement =>
+  Element.isElement(node) &&
+  (node.type === TYPE_TABLE_CELL || node.type === TYPE_TABLE_CELL_HEADER);
 
-export const isTableCellHeader = (node?: Node): node is TableCellElement => {
-  return Element.isElement(node) && node.type === TYPE_TABLE_CELL_HEADER;
-};
+export const isTableCellHeader = (node?: Node): node is TableCellElement =>
+  Element.isElement(node) && node.type === TYPE_TABLE_CELL_HEADER;
 
 export const hasCellAlignOfType = (editor: Editor, type: string) => {
   // For all selected table cells


### PR DESCRIPTION
Removing isHeader from table as it now isn't necessary with the usage of th.

Kan sikkert være lurt å teste den litt, jeg klarte ikke å brekke den 