### PR TITLE
Add email validation for contact block

### DIFF
--- a/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
@@ -43,6 +43,7 @@ const rules: RulesType<ContactBlockFormValues> = {
   },
   email: {
     required: true,
+    email: true,
   },
   metaImageId: {
     required: true,

--- a/src/components/formikValidationSchema.ts
+++ b/src/components/formikValidationSchema.ts
@@ -21,6 +21,12 @@ import {
 import handleError from '../util/handleError';
 import { bytesToSensibleFormat } from '../util/fileSizeUtil';
 
+// Taken directly from https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+// We don't really need spec compliance, but why not include it?
+const EMAIL_REGEX =
+  // eslint-disable-next-line no-useless-escape
+  /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
 const appendError = (error: string, newError: string): string =>
   error ? `${error} \n ${newError}` : newError;
 
@@ -29,6 +35,7 @@ interface RuleObject<FormikValuesType, ApiType = any> {
   minLength?: number;
   maxLength?: number;
   required?: boolean;
+  email?: boolean;
   allObjectFieldsRequired?: boolean;
   dateBefore?: boolean;
   dateAfter?: boolean;
@@ -110,6 +117,18 @@ const validateFormik = <FormikValuesType>(
             t('validation.dateAfterInvalid', {
               label,
               beforeLabel: t('form.validDate.from.label').toLowerCase(),
+            }),
+          );
+        }
+      }
+
+      if (rules[ruleKey].email) {
+        const email = value;
+        if (!email.match(EMAIL_REGEX)) {
+          errors[ruleKey] = appendError(
+            errors[ruleKey],
+            t('validation.email', {
+              label,
             }),
           );
         }

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1363,6 +1363,7 @@ const phrases = {
     podcastImageSize: 'A meta image must be between 1400 and 3000 pixels wide.',
     unfinishedRevision: 'You must have at least one planned revision.',
     missingRevision: 'There must be at least one revision.',
+    email: 'The email address is not valid.',
   },
   errorMessage: {
     title: 'Oops, something went wrong',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1365,6 +1365,7 @@ const phrases = {
     podcastImageSize: 'Metabilde må være mellom 1400 og 3000 piksler bredt.',
     unfinishedRevision: 'Det må være minst en planlagt revisjon.',
     missingRevision: 'Det må være minst en revisjon.',
+    email: 'E-postadressen er ikke gyldig.',
   },
   errorMessage: {
     title: 'Oops, noe gikk galt',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1365,6 +1365,7 @@ const phrases = {
     podcastImageSize: 'Metabilete må være mellom 1400 og 3000 pikslar breitt.',
     unfinishedRevision: 'Det må være minst ein planlagd revisjon.',
     missingRevision: 'Det må være minst ein revisjon.',
+    email: 'E-postadressa er ikkje gyldig.',
   },
   errorMessage: {
     title: 'Oops, noko gjekk gale',


### PR DESCRIPTION
https://trello.com/c/5HTPtGn2/414-kontaktperson-blokk-mangler-validering-av-epost-adresse

Kan sikkert krangle i all evighet om hvilken epost-regex man skal bruke. Jeg valgte denne.

Edit: Lars slo meg visst.