### PR TITLE
Move H5P out of DisplayExternal and SlateFigure

### DIFF
--- a/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
+++ b/src/components/DisplayEmbed/helpers/DisplayExternalModal.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
+import { H5pEmbedData } from '@ndla/types-embed';
 import VisualElementSearch from '../../../containers/VisualElement/VisualElementSearch';
 import VisualElementModalWrapper from '../../../containers/VisualElement/VisualElementModalWrapper';
-import { Embed, ExternalEmbed, H5pEmbed, WhitelistProvider } from '../../../interfaces';
+import { Embed, ExternalEmbed, WhitelistProvider } from '../../../interfaces';
 import { isEmbed } from '../../SlateEditor/plugins/blockPicker/SlateVisualElementPicker';
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
   type: string;
   onEditEmbed: (embed: Embed) => void;
   onClose: () => void;
-  embed: H5pEmbed | ExternalEmbed;
+  embed: H5pEmbedData | ExternalEmbed;
   isEditMode: boolean;
   allowedProvider: WhitelistProvider;
 }

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -24,7 +24,7 @@ const StyledIFrame = styled.iframe`
   overflow: hidden;
 `;
 
-interface OnSelectObject {
+export interface OnSelectObject {
   path?: string;
   title?: string;
 }

--- a/src/components/H5PElement/h5pApi.ts
+++ b/src/components/H5PElement/h5pApi.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { IAuthor } from '@ndla/types-backend/draft-api';
+import { H5pLicenseInformation } from '@ndla/types-embed';
 import config from '../../config';
 import { fetchReAuthorized, resolveJsonOrRejectWithError } from '../../util/apiHelpers';
 
@@ -48,6 +48,15 @@ export const editH5PiframeUrl = (url: string, locale: string = ''): Promise<{ ur
 
 export const getH5pLocale = (language: string) => {
   return language === 'en' ? 'en-gb' : 'nn' === language ? 'nn-no' : 'nb-no';
+};
+
+export const fetchH5pLicenseInformation = async (
+  resourceId: string,
+): Promise<H5pLicenseInformation | undefined> => {
+  const url = `${config.h5pApiUrl}/v2/resource/${resourceId}/copyright`;
+  return fetch(url)
+    .then((r) => resolveJsonOrRejectWithError<H5pLicenseInformation>(r))
+    .catch((_) => undefined);
 };
 
 export const fetchH5PInfo = async (resourceId: string): Promise<H5PInfo> => {

--- a/src/components/SlateEditor/helpers.ts
+++ b/src/components/SlateEditor/helpers.ts
@@ -10,12 +10,12 @@ import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_ERROR,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
   TYPE_EMBED_IMAGE,
 } from './plugins/embed/types';
 import { TYPE_FILE } from './plugins/file/types';
 import { TYPE_FOOTNOTE } from './plugins/footnote/types';
 import { TYPE_GRID } from './plugins/grid/types';
+import { TYPE_H5P } from './plugins/h5p/types';
 import { TYPE_KEY_FIGURE } from './plugins/keyFigure/types';
 import { TYPE_LINK, TYPE_CONTENT_LINK } from './plugins/link/types';
 import { TYPE_MATHML } from './plugins/mathml/types';
@@ -41,7 +41,7 @@ export const blocks = [
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_ERROR,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
+  TYPE_H5P,
   TYPE_EMBED_IMAGE,
   TYPE_FILE,
   TYPE_RELATED,

--- a/src/components/SlateEditor/interfaces.ts
+++ b/src/components/SlateEditor/interfaces.ts
@@ -37,7 +37,6 @@ import {
   BrightcoveEmbedElement,
   ErrorEmbedElement,
   ExternalEmbedElement,
-  H5PEmbedElement,
   ImageEmbedElement,
 } from './plugins/embed';
 import { BodyboxElement } from './plugins/bodybox';
@@ -58,6 +57,7 @@ import { CampaignBlockElement } from './plugins/campaignBlock';
 import { GridCellElement, GridElement } from './plugins/grid';
 import { LinkBlockListElement } from './plugins/linkBlockList/types';
 import { AudioElement } from './plugins/audio/types';
+import { H5pElement } from './plugins/h5p/types';
 
 export type SlatePlugin = (editor: Editor) => Editor;
 
@@ -113,7 +113,7 @@ declare module 'slate' {
       | AudioElement
       | ErrorEmbedElement
       | ExternalEmbedElement
-      | H5PEmbedElement
+      | H5pElement
       | BodyboxElement
       | DivElement
       | SpanElement

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -40,7 +40,6 @@ import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_ERROR,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
   TYPE_EMBED_IMAGE,
 } from '../embed/types';
 import { TYPE_RELATED } from '../related/types';
@@ -58,6 +57,7 @@ import { TYPE_CAMPAIGN_BLOCK } from '../campaignBlock/types';
 import { TYPE_LINK_BLOCK_LIST } from '../linkBlockList/types';
 import { defaultLinkBlockList } from '../linkBlockList';
 import { TYPE_AUDIO } from '../audio/types';
+import { TYPE_H5P } from '../h5p/types';
 
 interface Props {
   editor: Editor;
@@ -206,8 +206,12 @@ const SlateBlockPicker = ({
         setType(data.object);
         break;
       }
+      case TYPE_H5P: {
+        setVisualElementPickerOpen(true);
+        setType(data.object);
+        break;
+      }
       case TYPE_FILE:
-      case TYPE_EMBED_H5P:
       case TYPE_EMBED_IMAGE:
       case TYPE_EMBED_ERROR:
       case TYPE_EMBED_EXTERNAL:

--- a/src/components/SlateEditor/plugins/blockPicker/actions.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/actions.tsx
@@ -27,12 +27,7 @@ import { List } from '@ndla/icons/action';
 import HowToHelper from '../../../HowTo/HowToHelper';
 import { TYPE_CONCEPT_BLOCK } from '../concept/block/types';
 import { DRAFT_ADMIN_SCOPE } from '../../../../constants';
-import {
-  TYPE_EMBED_BRIGHTCOVE,
-  TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
-  TYPE_EMBED_IMAGE,
-} from '../embed/types';
+import { TYPE_EMBED_BRIGHTCOVE, TYPE_EMBED_EXTERNAL, TYPE_EMBED_IMAGE } from '../embed/types';
 import { TYPE_ASIDE } from '../aside/types';
 import { TYPE_DETAILS } from '../details/types';
 import { TYPE_TABLE } from '../table/types';
@@ -48,6 +43,7 @@ import { TYPE_CAMPAIGN_BLOCK } from '../campaignBlock/types';
 import { TYPE_GRID } from '../grid/types';
 import { TYPE_LINK_BLOCK_LIST } from '../linkBlockList/types';
 import { TYPE_AUDIO } from '../audio/types';
+import { TYPE_H5P } from '../h5p/types';
 
 const renderArticleInModal = (pageId: string) => <HowToHelper pageId={pageId} extraIconPadding />;
 
@@ -105,7 +101,7 @@ export const commonActions: Action[] = [
     helpIcon: renderArticleInModal('Podcasts'),
   },
   {
-    data: { type: TYPE_EMBED_H5P, object: 'h5p' },
+    data: { type: TYPE_H5P, object: 'h5p' },
     icon: <PresentationPlay />,
     helpIcon: renderArticleInModal('H5P'),
   },

--- a/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
@@ -18,7 +18,6 @@ import {
   BrightcoveEmbedElement,
   ErrorEmbedElement,
   ExternalEmbedElement,
-  H5PEmbedElement,
   ImageEmbedElement,
 } from '.';
 import { isSlateEmbed } from './utils';
@@ -26,12 +25,7 @@ import { isSlateEmbed } from './utils';
 interface Props {
   attributes: RenderElementProps['attributes'];
   editor: Editor;
-  element:
-    | H5PEmbedElement
-    | BrightcoveEmbedElement
-    | ErrorEmbedElement
-    | ExternalEmbedElement
-    | ImageEmbedElement;
+  element: BrightcoveEmbedElement | ErrorEmbedElement | ExternalEmbedElement | ImageEmbedElement;
   language: string;
   children: ReactNode;
   allowDecorative?: boolean;
@@ -113,8 +107,7 @@ const SlateFigure = ({
       );
     case 'external':
     case 'iframe':
-    case 'h5p':
-      if (embed.resource !== 'h5p' && embed.url?.includes('youtu')) {
+      if (embed.url?.includes('youtu')) {
         return (
           <SlateVideo
             attributes={attributes}

--- a/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
@@ -13,8 +13,9 @@ import withPlugins from '../../../utils/withPlugins';
 import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
-import { TYPE_EMBED_H5P, TYPE_EMBED_IMAGE } from '../types';
+import { TYPE_EMBED_IMAGE } from '../types';
 import { TYPE_AUDIO } from '../../audio/types';
+import { TYPE_H5P } from '../../h5p/types';
 
 const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
 
@@ -42,7 +43,7 @@ describe('embed normalizer tests', () => {
             },
           },
           {
-            type: TYPE_EMBED_H5P,
+            type: TYPE_H5P,
             children: [
               {
                 text: '',
@@ -102,7 +103,7 @@ describe('embed normalizer tests', () => {
             children: [{ text: '' }],
           },
           {
-            type: TYPE_EMBED_H5P,
+            type: TYPE_H5P,
             children: [
               {
                 text: '',

--- a/src/components/SlateEditor/plugins/embed/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/embed/__tests__/serializer-test.ts
@@ -13,13 +13,9 @@ import {
 } from '../../../../../util/articleContentConverter';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
-import {
-  TYPE_EMBED_BRIGHTCOVE,
-  TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
-  TYPE_EMBED_IMAGE,
-} from '../types';
+import { TYPE_EMBED_BRIGHTCOVE, TYPE_EMBED_EXTERNAL, TYPE_EMBED_IMAGE } from '../types';
 import { TYPE_AUDIO } from '../../audio/types';
+import { TYPE_H5P } from '../../h5p/types';
 
 describe('embed image serializing tests', () => {
   const editorWithImage: Descendant[] = [
@@ -229,7 +225,7 @@ describe('embed h5p serializing tests', () => {
         { type: TYPE_PARAGRAPH, children: [{ text: '' }] },
 
         {
-          type: TYPE_EMBED_H5P,
+          type: TYPE_H5P,
           data: {
             resource: 'h5p',
             path: '/resource/123',

--- a/src/components/SlateEditor/plugins/embed/index.tsx
+++ b/src/components/SlateEditor/plugins/embed/index.tsx
@@ -13,7 +13,6 @@ import { SlateSerializer } from '../../interfaces';
 import {
   Embed,
   ImageEmbed,
-  H5pEmbed,
   BrightcoveEmbed,
   ErrorEmbed,
   ExternalEmbed,
@@ -28,12 +27,6 @@ import { TYPE_NDLA_EMBED } from './types';
 export interface ImageEmbedElement {
   type: 'image-embed';
   data: ImageEmbed;
-  children: Descendant[];
-}
-
-export interface H5PEmbedElement {
-  type: 'h5p-embed';
-  data: H5pEmbed;
   children: Descendant[];
 }
 
@@ -57,7 +50,6 @@ export interface ExternalEmbedElement {
 
 export type EmbedElements =
   | ImageEmbedElement
-  | H5PEmbedElement
   | BrightcoveEmbedElement
   | ErrorEmbedElement
   | ExternalEmbedElement;

--- a/src/components/SlateEditor/plugins/embed/utils.ts
+++ b/src/components/SlateEditor/plugins/embed/utils.ts
@@ -13,7 +13,6 @@ import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_ERROR,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
   TYPE_EMBED_IMAGE,
 } from './types';
 import {
@@ -21,7 +20,6 @@ import {
   EmbedElements,
   ErrorEmbedElement,
   ExternalEmbedElement,
-  H5PEmbedElement,
   ImageEmbedElement,
 } from '.';
 
@@ -31,7 +29,6 @@ export const defaultEmbedBlock = (data: Partial<Embed>) =>
 export const isSlateEmbed = (
   node: Node,
 ): node is
-  | H5PEmbedElement
   | ImageEmbedElement
   | ErrorEmbedElement
   | ExternalEmbedElement
@@ -41,7 +38,6 @@ export const isSlateEmbed = (
     (node.type === TYPE_EMBED_BRIGHTCOVE ||
       node.type === TYPE_EMBED_ERROR ||
       node.type === TYPE_EMBED_EXTERNAL ||
-      node.type === TYPE_EMBED_H5P ||
       node.type === TYPE_EMBED_IMAGE)
   );
 };
@@ -51,8 +47,6 @@ export const defineTypeOfEmbed = (type?: string) => {
     return TYPE_EMBED_BRIGHTCOVE;
   } else if (type === 'external' || type === 'iframe') {
     return TYPE_EMBED_EXTERNAL;
-  } else if (type === 'h5p') {
-    return TYPE_EMBED_H5P;
   } else if (type === 'image') {
     return TYPE_EMBED_IMAGE;
   } else if (type === undefined) {
@@ -66,7 +60,6 @@ export const isSlateEmbedElement = (element: Element): element is EmbedElements 
 
 export const isEmbedType = (type: string) =>
   type === TYPE_EMBED_BRIGHTCOVE ||
-  type === TYPE_EMBED_H5P ||
   type === TYPE_EMBED_ERROR ||
   type === TYPE_EMBED_IMAGE ||
   type === TYPE_EMBED_EXTERNAL;

--- a/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
+++ b/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor, Path, Transforms } from 'slate';
+import { useTranslation } from 'react-i18next';
+import { useMemo, useState } from 'react';
+import styled from '@emotion/styled';
+import { Modal, ModalContent, ModalTrigger } from '@ndla/modal';
+import { H5pEmbed } from '@ndla/ui';
+import { ReactEditor, RenderElementProps } from 'slate-react';
+import { H5pEmbedData, H5pMetaData } from '@ndla/types-embed';
+import { Spinner } from '@ndla/icons';
+import { IconButtonV2 } from '@ndla/button';
+import { DeleteForever, Link } from '@ndla/icons/editor';
+import { spacing } from '@ndla/core';
+import { H5pElement } from './types';
+import { StyledDeleteEmbedButton, StyledFigureButtons } from '../embed/FigureButtons';
+import { useH5pMeta } from '../../../../modules/embed/queries';
+import H5PElement, { OnSelectObject } from '../../../H5PElement/H5PElement';
+import config from '../../../../config';
+import { getH5pLocale } from '../../../H5PElement/h5pApi';
+
+interface Props extends RenderElementProps {
+  element: H5pElement;
+  editor: Editor;
+  language: string;
+}
+
+const H5pWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledModalContent = styled(ModalContent)`
+  padding: 0;
+  width: 100% !important;
+  height: 100%;
+  max-height: 95%;
+  overflow: hidden;
+`;
+
+const FigureButtons = styled(StyledFigureButtons)`
+  right: ${spacing.small};
+  top: ${spacing.large};
+  z-index: 1;
+`;
+
+const StyledModalBody = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+const SlateH5p = ({ element, editor, attributes, children, language }: Props) => {
+  const { t } = useTranslation();
+  const [isEditing, setIsEditing] = useState(element.isFirstEdit);
+  const h5pMetaQuery = useH5pMeta(element?.data?.url!, {
+    enabled: !!element?.data?.url,
+  });
+
+  const handleRemove = () => {
+    Transforms.removeNodes(editor, { at: ReactEditor.findPath(editor, element), voids: true });
+  };
+
+  const onSave = (h5p: OnSelectObject) => {
+    setIsEditing(false);
+    const url = `${config.h5pApiUrl}${h5p.path}`;
+    const data: H5pEmbedData = {
+      url,
+      title: h5p.title,
+      path: h5p.path ?? '',
+      resource: 'h5p',
+    };
+    const properties = { data };
+    ReactEditor.focus(editor);
+    const path = ReactEditor.findPath(editor, element);
+    Transforms.setNodes(editor, properties, { at: path });
+    if (Editor.hasPath(editor, Path.next(path))) {
+      setTimeout(() => {
+        Transforms.select(editor, Path.next(path));
+      }, 0);
+    }
+  };
+
+  const embed: H5pMetaData | undefined = useMemo(() => {
+    if (!element.data) return undefined;
+    const lang = getH5pLocale(language);
+    const cssUrl = encodeURIComponent(`${config.ndlaFrontendDomain}/static/h5p-custom-css.css`);
+    const url = `${element.data.url}?locale=${lang}&cssUrl=${cssUrl}`;
+
+    return {
+      status: h5pMetaQuery.error || !h5pMetaQuery.data ? 'error' : 'success',
+      data: h5pMetaQuery.data!,
+      embedData: { ...element.data, url },
+      resource: 'h5p',
+    };
+  }, [element.data, h5pMetaQuery.data, h5pMetaQuery.error, language]);
+
+  return (
+    <Modal open={isEditing} onOpenChange={setIsEditing}>
+      <H5pWrapper {...attributes} contentEditable={false}>
+        {h5pMetaQuery.isInitialLoading ? (
+          <Spinner />
+        ) : embed ? (
+          <>
+            <FigureButtons data-white="true">
+              <ModalTrigger>
+                <IconButtonV2
+                  aria-label={t('form.external.edit', { type: 'h5p' })}
+                  title={t('form.external.edit', { type: 'h5p' })}
+                  colorTheme="light"
+                >
+                  <Link />
+                </IconButtonV2>
+              </ModalTrigger>
+              <StyledDeleteEmbedButton
+                aria-label={t('form.external.remove', { type: 'h5p' })}
+                title={t('form.external.remove', { type: 'h5p' })}
+                colorTheme="danger"
+                data-cy="remove-element"
+                onClick={handleRemove}
+              >
+                <DeleteForever />
+              </StyledDeleteEmbedButton>
+            </FigureButtons>
+            <H5pEmbed embed={embed} />
+          </>
+        ) : null}
+      </H5pWrapper>
+      <StyledModalContent>
+        <StyledModalBody>
+          <H5PElement
+            canReturnResources
+            h5pUrl={element.data?.url}
+            onClose={() => setIsEditing(false)}
+            locale={language}
+            onSelect={onSave}
+          />
+        </StyledModalBody>
+      </StyledModalContent>
+      {children}
+    </Modal>
+  );
+};
+
+export default SlateH5p;

--- a/src/components/SlateEditor/plugins/h5p/index.tsx
+++ b/src/components/SlateEditor/plugins/h5p/index.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { jsx as slatejsx } from 'slate-hyperscript';
+import { Descendant, Editor, Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
+import { SlateSerializer } from '../../interfaces';
+import { NormalizerConfig, defaultBlockNormalizer } from '../../utils/defaultNormalizer';
+import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
+import { TYPE_NDLA_EMBED } from '../embed/types';
+import { TYPE_PARAGRAPH } from '../paragraph/types';
+import { TYPE_H5P } from './types';
+import SlateH5p from './SlateH5p';
+
+const normalizerConfig: NormalizerConfig = {
+  previous: {
+    allowed: afterOrBeforeTextBlockElement,
+    defaultType: TYPE_PARAGRAPH,
+  },
+  next: {
+    allowed: afterOrBeforeTextBlockElement,
+    defaultType: TYPE_PARAGRAPH,
+  },
+};
+
+export const h5pSerializer: SlateSerializer = {
+  deserialize(el: HTMLElement) {
+    if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
+    const embed = el as HTMLEmbedElement;
+    const embedAttributes = reduceElementDataAttributesV2(Array.from(embed.attributes));
+    if (embedAttributes.resource !== TYPE_H5P) return;
+    return slatejsx('element', { type: TYPE_H5P, data: embedAttributes }, { text: '' });
+  },
+  serialize(node: Descendant) {
+    if (!Element.isElement(node) || node.type !== TYPE_H5P || !node.data) return;
+    return createEmbedTagV2(node.data);
+  },
+};
+
+export const h5pPlugin = (language: string, disableNormalize?: boolean) => (editor: Editor) => {
+  const {
+    renderElement: nextRenderElement,
+    normalizeNode: nextNormalizeNode,
+    isVoid: nextIsVoid,
+  } = editor;
+
+  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
+    if (element.type === TYPE_H5P) {
+      return (
+        <SlateH5p attributes={attributes} editor={editor} element={element} language={language}>
+          {children}
+        </SlateH5p>
+      );
+    }
+    return nextRenderElement?.({ attributes, children, element });
+  };
+
+  editor.normalizeNode = (entry) => {
+    const [node] = entry;
+    if (Element.isElement(node) && node.type === TYPE_H5P) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+        return;
+      }
+    }
+    nextNormalizeNode(entry);
+  };
+
+  editor.isVoid = (element: Element) => {
+    return element.type === TYPE_H5P ? true : nextIsVoid(element);
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/h5p/types.ts
+++ b/src/components/SlateEditor/plugins/h5p/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Descendant } from 'slate';
+import { H5pEmbedData } from '@ndla/types-embed';
+
+export const TYPE_H5P = 'h5p';
+
+export interface H5pElement {
+  type: 'h5p';
+  data?: H5pEmbedData;
+  children: Descendant[];
+  isFirstEdit?: boolean;
+}

--- a/src/components/SlateEditor/plugins/h5p/utils.ts
+++ b/src/components/SlateEditor/plugins/h5p/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { jsx as slatejsx } from 'slate-hyperscript';
+import { TYPE_H5P } from './types';
+export const defaultH5pBlock = () => slatejsx('element', { type: TYPE_H5P, isFirstEdit: true });

--- a/src/components/SlateEditor/utils/normalizationHelpers.ts
+++ b/src/components/SlateEditor/utils/normalizationHelpers.ts
@@ -11,7 +11,6 @@ import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_ERROR,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
 } from '../plugins/embed/types';
 import { TYPE_FILE } from '../plugins/file/types';
 import { TYPE_HEADING } from '../plugins/heading/types';
@@ -19,6 +18,7 @@ import { TYPE_LIST } from '../plugins/list/types';
 import { TYPE_PARAGRAPH } from '../plugins/paragraph/types';
 import { TYPE_TABLE } from '../plugins/table/types';
 import { TYPE_AUDIO } from '../plugins/audio/types';
+import { TYPE_H5P } from '../plugins/h5p/types';
 
 export const firstTextBlockElement: Element['type'][] = [TYPE_PARAGRAPH, TYPE_HEADING, TYPE_QUOTE];
 
@@ -32,7 +32,7 @@ export const textBlockElements: Element['type'][] = [
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_EXTERNAL,
   TYPE_EMBED_ERROR,
-  TYPE_EMBED_H5P,
+  TYPE_H5P,
   TYPE_FILE,
   TYPE_CODEBLOCK,
   TYPE_ASIDE,

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -58,7 +58,6 @@ import { definitionListPlugin } from '../../../../components/SlateEditor/plugins
 import { TYPE_TABLE } from '../../../../components/SlateEditor/plugins/table/types';
 import { TYPE_CODEBLOCK } from '../../../../components/SlateEditor/plugins/codeBlock/types';
 import {
-  TYPE_EMBED_H5P,
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_EXTERNAL,
   TYPE_EMBED_IMAGE,
@@ -80,6 +79,8 @@ import { linkBlockListPlugin } from '../../../../components/SlateEditor/plugins/
 import { TYPE_LINK_BLOCK_LIST } from '../../../../components/SlateEditor/plugins/linkBlockList/types';
 import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
 import { TYPE_AUDIO } from '../../../../components/SlateEditor/plugins/audio/types';
+import { TYPE_H5P } from '../../../../components/SlateEditor/plugins/h5p/types';
+import { h5pPlugin } from '../../../../components/SlateEditor/plugins/h5p';
 
 const StyledFormikField = styled(FormikField)`
   display: flex;
@@ -124,7 +125,7 @@ const StyledIconButton = styled(IconButtonV2)`
 `;
 
 const visualElements = [
-  TYPE_EMBED_H5P,
+  TYPE_H5P,
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_AUDIO,
   TYPE_EMBED_EXTERNAL,
@@ -158,6 +159,7 @@ export const plugins = (articleLanguage: string): SlatePlugin[] => {
     paragraphPlugin(articleLanguage),
     footnotePlugin,
     embedPlugin(articleLanguage),
+    h5pPlugin(articleLanguage),
     audioPlugin(articleLanguage),
     bodyboxPlugin,
     asidePlugin,

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -66,7 +66,6 @@ import { gridPlugin } from '../../../../components/SlateEditor/plugins/grid';
 import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_EXTERNAL,
-  TYPE_EMBED_H5P,
   TYPE_EMBED_IMAGE,
 } from '../../../../components/SlateEditor/plugins/embed/types';
 import { TYPE_TABLE } from '../../../../components/SlateEditor/plugins/table/types';
@@ -76,6 +75,8 @@ import { TYPE_GRID } from '../../../../components/SlateEditor/plugins/grid/types
 import { HandleSubmitFunc, LearningResourceFormType } from '../../../FormikForm/articleFormHooks';
 import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
 import { TYPE_AUDIO } from '../../../../components/SlateEditor/plugins/audio/types';
+import { TYPE_H5P } from '../../../../components/SlateEditor/plugins/h5p/types';
+import { h5pPlugin } from '../../../../components/SlateEditor/plugins/h5p';
 
 const StyledFormikField = styled(FormikField)`
   display: flex;
@@ -112,7 +113,7 @@ const findFootnotes = (content: Descendant[]): FootnoteType[] =>
     .map((footnoteElement) => footnoteElement.data);
 
 const visualElements = [
-  TYPE_EMBED_H5P,
+  TYPE_H5P,
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_AUDIO,
   TYPE_EMBED_EXTERNAL,
@@ -137,6 +138,7 @@ export const plugins = (articleLanguage: string): SlatePlugin[] => {
     paragraphPlugin(articleLanguage),
     footnotePlugin,
     audioPlugin(articleLanguage),
+    h5pPlugin(articleLanguage),
     embedPlugin(articleLanguage),
     bodyboxPlugin,
     asidePlugin,

--- a/src/containers/VisualElement/VisualElement.tsx
+++ b/src/containers/VisualElement/VisualElement.tsx
@@ -11,6 +11,7 @@ import { FormikHandlers } from 'formik';
 import VisualElementEditor from '../../components/SlateEditor/VisualElementEditor';
 import { EmbedElements, embedPlugin } from '../../components/SlateEditor/plugins/embed';
 import { audioPlugin } from '../../components/SlateEditor/plugins/audio';
+import { h5pPlugin } from '../../components/SlateEditor/plugins/h5p';
 
 interface Props {
   onChange: FormikHandlers['handleChange'];
@@ -34,7 +35,11 @@ const VisualElement = ({
   allowDecorative = false,
 }: Props) => {
   const plugins = useMemo(() => {
-    return [audioPlugin(language, true), embedPlugin(language, true, allowDecorative)];
+    return [
+      audioPlugin(language, true),
+      h5pPlugin(language, true),
+      embedPlugin(language, true, allowDecorative),
+    ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedResource]);
 

--- a/src/containers/VisualElement/VisualElementSearch.tsx
+++ b/src/containers/VisualElement/VisualElementSearch.tsx
@@ -11,8 +11,8 @@ import VideoSearch from '@ndla/video-search';
 import AudioSearch from '@ndla/audio-search';
 import { IAudioSummary } from '@ndla/types-backend/audio-api';
 import { IImageMetaInformationV3 } from '@ndla/types-backend/image-api';
+import { H5pEmbedData } from '@ndla/types-embed';
 import config from '../../config';
-import H5PElement from '../../components/H5PElement/H5PElement';
 import { EXTERNAL_WHITELIST_PROVIDERS } from '../../constants';
 import VisualElementUrlPreview from './VisualElementUrlPreview';
 import ImageSearchAndUploader from '../../components/ImageSearchAndUploader';
@@ -26,8 +26,9 @@ import {
   VideoSearchQuery,
 } from '../../modules/video/brightcoveApi';
 import { AudioSearchParams } from '../../modules/audio/audioApiInterfaces';
-import { Embed, ExternalEmbed, H5pEmbed } from '../../interfaces';
+import { Embed, ExternalEmbed } from '../../interfaces';
 import FileUploader from '../../components/FileUploader';
+import H5PElement from '../../components/H5PElement/H5PElement';
 
 const titles = (t: TFunction, resource: string) => ({
   [resource]: t(`form.visualElement.${resource.toLowerCase()}`),
@@ -42,7 +43,7 @@ interface Props {
   closeModal: () => void;
   showCheckbox?: boolean;
   checkboxAction?: (image: IImageMetaInformationV3) => void;
-  embed?: H5pEmbed | ExternalEmbed;
+  embed?: H5pEmbedData | ExternalEmbed;
 }
 
 interface LocalAudioSearchParams extends Omit<AudioSearchParams, 'audio-type' | 'page-size'> {
@@ -154,13 +155,16 @@ const VisualElementSearch = ({
         <H5PElement
           canReturnResources={true}
           h5pUrl={selectedResourceUrl}
-          onSelect={(h5p) =>
-            handleVisualElementChange({
-              resource: 'h5p',
-              path: h5p.path!,
+          onSelect={(h5p) => {
+            const url = `${config.h5pApiUrl}${h5p.path}`;
+            const data: H5pEmbedData = {
+              url,
               title: h5p.title,
-            })
-          }
+              path: h5p.path ?? '',
+              resource: 'h5p',
+            };
+            handleVisualElementChange(data);
+          }}
           onClose={closeModal}
           locale={articleLanguage ?? locale}
         />

--- a/src/containers/VisualElement/VisualElementUrlPreview.tsx
+++ b/src/containers/VisualElement/VisualElementUrlPreview.tsx
@@ -178,7 +178,7 @@ const VisualElementUrlPreview = ({
     if (whiteListedUrl) {
       try {
         const data = await fetchExternalOembed(url || '');
-        const src = getIframeSrcFromHtmlString(data.html);
+        const src = data.html ? getIframeSrcFromHtmlString(data.html) : undefined;
 
         if (preview) {
           setEmbedUrl(src ?? undefined);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@
 
 import { IAudioMetaInformation } from '@ndla/types-backend/audio-api';
 import { IArticle, IRelatedContentLink } from '@ndla/types-backend/draft-api';
-import { AudioEmbedData } from '@ndla/types-embed';
+import { AudioEmbedData, H5pEmbedData } from '@ndla/types-embed';
 import { SearchTypeValues, LOCALE_VALUES } from './constants';
 
 export interface FormikStatus {
@@ -130,13 +130,6 @@ export interface BrightcoveEmbed {
   metaData?: any;
 }
 
-export interface H5pEmbed {
-  resource: 'h5p';
-  path: string;
-  url?: string;
-  title?: string;
-}
-
 export interface ExternalEmbed {
   resource: 'external' | 'iframe';
   url: string;
@@ -159,7 +152,7 @@ export type Embed =
   | ImageEmbed
   | BrightcoveEmbed
   | AudioEmbedData
-  | H5pEmbed
+  | H5pEmbedData
   | ExternalEmbed
   | ErrorEmbed;
 
@@ -193,16 +186,6 @@ export interface BrightcoveAccessToken {
   access_token: string;
   token_type: string;
   expires_in: number;
-}
-
-export interface H5POembed {
-  height: number;
-  width: number;
-  html: string;
-  type: string;
-  providerName?: string;
-  version: string;
-  title: string;
 }
 
 export type SearchType = (typeof SearchTypeValues)[number];

--- a/src/modules/embed/queries.ts
+++ b/src/modules/embed/queries.ts
@@ -6,12 +6,14 @@
  *
  */
 
-import { AudioMeta } from '@ndla/types-embed';
+import { AudioMeta, H5pData } from '@ndla/types-embed';
 import { IImageMetaInformationV3 } from '@ndla/types-backend/build/image-api';
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { fetchAudio } from '../audio/audioApi';
 import { fetchImage } from '../image/imageApi';
-import { AUDIO_EMBED } from '../../queryKeys';
+import { AUDIO_EMBED, H5P_EMBED } from '../../queryKeys';
+import { fetchH5PInfo, fetchH5pLicenseInformation } from '../../components/H5PElement/h5pApi';
+import { fetchH5pOembed } from '../../util/apiHelpers';
 
 const fetchMeta = async (resourceId: string, language: string): Promise<AudioMeta> => {
   const audio = await fetchAudio(parseInt(resourceId), language);
@@ -34,6 +36,32 @@ export const useAudioMeta = (
   return useQuery<AudioMeta>(
     [AUDIO_EMBED, resourceId, language],
     () => fetchMeta(resourceId, language),
-    options,
+    { ...options, retry: false },
   );
+};
+
+export const fetchH5pMeta = async (url: string): Promise<H5pData> => {
+  const pathArr = url.split('/') || [];
+  const h5pId = pathArr[pathArr.length - 1];
+  const [oembedData, h5pLicenseInformation, h5pInfo] = await Promise.all([
+    fetchH5pOembed(url),
+    fetchH5pLicenseInformation(h5pId),
+    fetchH5PInfo(h5pId),
+  ]);
+
+  return {
+    h5pLicenseInformation: {
+      h5p: {
+        ...h5pLicenseInformation?.h5p,
+        authors: h5pLicenseInformation?.h5p.authors ?? [],
+        title: h5pInfo?.title ?? '',
+      },
+    },
+    h5pUrl: url,
+    oembed: oembedData,
+  };
+};
+
+export const useH5pMeta = (url: string, options?: UseQueryOptions<H5pData>) => {
+  return useQuery<H5pData>([H5P_EMBED, url], () => fetchH5pMeta(url), { ...options, retry: false });
 };

--- a/src/queryKeys.ts
+++ b/src/queryKeys.ts
@@ -25,6 +25,7 @@ export const IMAGE = 'image';
 export const AUDIO = 'audio';
 
 export const AUDIO_EMBED = 'audio';
+export const H5P_EMBED = 'h5p';
 
 export const PODCAST_SERIES = 'podcastSeries';
 

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -7,7 +7,8 @@
  */
 import fetch from 'cross-fetch';
 import queryString from 'query-string';
-import { BrightcoveAccessToken, H5POembed } from '../interfaces';
+import { H5pPreviewResponse, OembedProxyData } from '@ndla/types-embed';
+import { BrightcoveAccessToken } from '../interfaces';
 import config from '../config';
 import { apiBaseUrl, getAccessToken, isAccessTokenValid, renewAuth } from './authHelpers';
 import { resolveJsonOrRejectWithError, throwErrorPayload } from './resolveJsonOrRejectWithError';
@@ -147,23 +148,26 @@ export const fetchWithBrightCoveToken = (url: string) => {
   });
 };
 
-export const fetchOembed = async (url: string, options?: FetchConfigType): Promise<H5POembed> => {
-  const data = await fetchAuthorized(url, options);
+export const fetchH5pOembed = async (
+  url: string,
+  options?: FetchConfigType,
+): Promise<H5pPreviewResponse> => {
+  const data = await fetchAuthorized(
+    `${config.h5pApiUrl}/oembed/preview?${queryString.stringify({ url })}`,
+    options,
+  );
   return resolveJsonOrRejectWithError(data);
 };
 
-const setH5pOembedUrl = (query: { url: string }) =>
-  `${config.h5pApiUrl}/oembed/preview?${queryString.stringify(query)}`;
-
-const setOembedUrl = (query: { url: string }) =>
-  `${apiResourceUrl('/oembed-proxy/v1/oembed')}?${queryString.stringify(query)}`;
-
-export const fetchExternalOembed = (url: string, options?: FetchConfigType) => {
-  let setOembed = setOembedUrl({ url });
-  if (config.h5pApiUrl && url.includes(config.h5pApiUrl)) {
-    setOembed = setH5pOembedUrl({ url });
-  }
-  return fetchOembed(setOembed, options);
+export const fetchExternalOembed = async (
+  url: string,
+  options?: FetchConfigType,
+): Promise<OembedProxyData> => {
+  const data = await fetchAuthorized(
+    `${apiResourceUrl('/oembed-proxy/v1/oembed')}?${queryString.stringify({ url })}`,
+    options,
+  );
+  return resolveJsonOrRejectWithError(data);
 };
 
 export { resolveJsonOrRejectWithError, throwErrorPayload };

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -51,6 +51,7 @@ import { contactBlockSerializer } from '../components/SlateEditor/plugins/contac
 import { campaignBlockSerializer } from '../components/SlateEditor/plugins/campaignBlock';
 import { linkBlockListSerializer } from '../components/SlateEditor/plugins/linkBlockList';
 import { audioSerializer } from '../components/SlateEditor/plugins/audio';
+import { h5pSerializer } from '../components/SlateEditor/plugins/h5p';
 
 export const sectionSplitter = (html: string) => {
   const node = document.createElement('div');
@@ -108,6 +109,7 @@ const extendedRules: SlateSerializer[] = [
   campaignBlockSerializer,
   linkBlockListSerializer,
   audioSerializer,
+  h5pSerializer,
   embedSerializer,
   bodyboxSerializer,
   divSerializer,

--- a/src/util/formHelper.ts
+++ b/src/util/formHelper.ts
@@ -224,7 +224,7 @@ export const learningResourceRules: RulesType<LearningResourceFormType, IArticle
         values.content ?? [],
         'image-embed',
         'brightcove-embed',
-        'h5p-embed',
+        'h5p',
         'audio',
         'error-embed',
         'external-embed',


### PR DESCRIPTION
_Forhåpentligvis feilfri!_ 
Dette er ordentlig hårete kode å navigere, så prøver sakte men sikkert å gjøre den litt greiere å ha å gjøre med. Det fører i første omgang til mer kode. Tenker at vi kan se på å standardisere disse prosessene litt når `SlateFigure` ikke lenger finnes.

Neste steg etter dette vil være å separere `iframe` og `external`.