### PR TITLE
Removes grid from frontpageActions since in commonActions

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -73,6 +73,9 @@ const StyledBlockPickerWrapper = styled.div`
   z-index: 15;
 `;
 
+const isDuplicateAction = (action: Action, index: number, actions: Action[]) =>
+  actions.findIndex(({ data: { type } }) => type === action.data.type) === index;
+
 const SlateBlockPicker = ({
   editor,
   actionsToShowInAreas,
@@ -340,13 +343,15 @@ const SlateBlockPicker = ({
               isOpen={blockPickerOpen}
               heading={t('editorBlockpicker.heading')}
               actions={getActionsForArea()
-                .filter((action) => {
-                  return !action.requiredScope || userPermissions?.includes(action.requiredScope);
-                })
+                .filter(
+                  (action) =>
+                    !action.requiredScope || userPermissions?.includes(action.requiredScope),
+                )
                 .map((action) => ({
                   ...action,
                   label: t(`editorBlockpicker.actions.${action.data.object}`),
-                }))}
+                }))
+                .filter(isDuplicateAction)}
               onToggleOpen={(open) => {
                 ReactEditor.focus(editor);
                 setBlockPickerOpen(open);

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -73,9 +73,6 @@ const StyledBlockPickerWrapper = styled.div`
   z-index: 15;
 `;
 
-const isDuplicateAction = (action: Action, index: number, actions: Action[]) =>
-  actions.findIndex(({ data: { type } }) => type === action.data.type) === index;
-
 const SlateBlockPicker = ({
   editor,
   actionsToShowInAreas,
@@ -350,8 +347,7 @@ const SlateBlockPicker = ({
                 .map((action) => ({
                   ...action,
                   label: t(`editorBlockpicker.actions.${action.data.object}`),
-                }))
-                .filter(isDuplicateAction)}
+                }))}
               onToggleOpen={(open) => {
                 ReactEditor.focus(editor);
                 setBlockPickerOpen(open);

--- a/src/components/SlateEditor/plugins/blockPicker/actions.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/actions.tsx
@@ -150,6 +150,11 @@ export const commonActions: Action[] = [
 
 export const frontpageActions = commonActions.concat(
   {
+    data: { type: TYPE_GRID, object: 'grid' },
+    icon: <Grid />,
+    helpIcon: renderArticleInModal('Grid'),
+  },
+  {
     data: { type: TYPE_BLOGPOST, object: 'blogPost' },
     icon: <BlogPost />,
     helpIcon: renderArticleInModal('BlogPost'),

--- a/src/components/SlateEditor/plugins/blockPicker/actions.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/actions.tsx
@@ -140,12 +140,6 @@ export const commonActions: Action[] = [
     helpIcon: renderArticleInModal('ConceptList'),
     requiredScope: DRAFT_ADMIN_SCOPE,
   },
-  {
-    data: { type: TYPE_GRID, object: 'grid' },
-    icon: <Grid />,
-    helpIcon: renderArticleInModal('Grid'),
-    requiredScope: DRAFT_ADMIN_SCOPE,
-  },
 ];
 
 export const frontpageActions = commonActions.concat(
@@ -180,3 +174,10 @@ export const frontpageActions = commonActions.concat(
     helpIcon: renderArticleInModal('LinkBlockList'),
   },
 );
+
+export const learningResourceActions = commonActions.concat({
+  data: { type: TYPE_GRID, object: 'grid' },
+  icon: <Grid />,
+  helpIcon: renderArticleInModal('Grid'),
+  requiredScope: DRAFT_ADMIN_SCOPE,
+});

--- a/src/components/SlateEditor/plugins/blockPicker/actions.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/actions.tsx
@@ -150,11 +150,6 @@ export const commonActions: Action[] = [
 
 export const frontpageActions = commonActions.concat(
   {
-    data: { type: TYPE_GRID, object: 'grid' },
-    icon: <Grid />,
-    helpIcon: renderArticleInModal('Grid'),
-  },
-  {
     data: { type: TYPE_BLOGPOST, object: 'blogPost' },
     icon: <BlogPost />,
     helpIcon: renderArticleInModal('BlogPost'),

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -76,6 +76,7 @@ import { TYPE_GRID } from '../../../../components/SlateEditor/plugins/grid/types
 import { HandleSubmitFunc, LearningResourceFormType } from '../../../FormikForm/articleFormHooks';
 import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
 import { TYPE_AUDIO } from '../../../../components/SlateEditor/plugins/audio/types';
+import { learningResourceActions } from '../../../../components/SlateEditor/plugins/blockPicker/actions';
 
 const StyledFormikField = styled(FormikField)`
   display: flex;
@@ -267,6 +268,7 @@ const ContentField = ({
         )}
       </FieldHeader>
       <RichTextEditor
+        actions={learningResourceActions}
         language={articleLanguage}
         blockpickerOptions={blockPickerOptions}
         placeholder={t('form.content.placeholder')}


### PR DESCRIPTION
Ser vi har dobbelt opp med grid i blockpicker i OmNDLA artikkelene våre. Fjerner den i frontpage actions da vi allerede har den i common.  Kan testes ut ved å åpne blockpicker i de ulike editorene vi har. 