### PR TITLE
Add ability to turn alt editing on and off for InlineImageSearch.

### DIFF
--- a/src/components/MetaInformation.tsx
+++ b/src/components/MetaInformation.tsx
@@ -23,14 +23,16 @@ const StyledStrong = styled.strong`
 interface Props {
   title?: string;
   copyright?: string;
+  alt?: string;
   translations: {
     title: string;
     copyright: string;
+    alt: string;
   };
   action: ReactNode;
 }
 
-const MetaInformation = ({ title, copyright, translations, action }: Props) => (
+const MetaInformation = ({ title, copyright, translations, action, alt }: Props) => (
   <StyleMetaInformation>
     <div>{action || null}</div>
     <div>
@@ -38,6 +40,12 @@ const MetaInformation = ({ title, copyright, translations, action }: Props) => (
       <span>{title}</span>
       <StyledStrong>{copyright ? translations.copyright : ''}</StyledStrong>
       <span>{copyright}</span>
+      {!!alt && (
+        <>
+          <StyledStrong>{translations.alt}</StyledStrong>
+          <span>{alt}</span>
+        </>
+      )}
     </div>
   </StyleMetaInformation>
 );

--- a/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
+++ b/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
@@ -159,7 +159,7 @@ const BlogPostForm = ({ initialData, onSave, onCancel }: Props) => {
           <StyledFormikField name="size" showError>
             {({ field }: FieldProps) => <SizeField field={field} />}
           </StyledFormikField>
-          <InlineImageSearch name={'metaImageId'} />
+          <InlineImageSearch name={'metaImageId'} disableAltEditing />
           <ButtonContainer>
             <ButtonV2 variant="outline" onClick={onCancel}>
               {t('cancel')}

--- a/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
@@ -237,7 +237,7 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
               />
             )}
           </StyledFormikField>
-          <InlineImageSearch name={'metaImageId'} />
+          <InlineImageSearch name={'metaImageId'} disableAltEditing />
           <ButtonContainer>
             <ButtonV2 variant="outline" onClick={onCancel}>
               {t('cancel')}

--- a/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
@@ -194,7 +194,7 @@ const ContactBlockForm = ({ initialData, onSave, onCancel }: Props) => {
               />
             )}
           </StyledFormikField>
-          <InlineImageSearch name={'metaImageId'} />
+          <InlineImageSearch name={'metaImageId'} disableAltEditing />
           <ButtonContainer>
             <ButtonV2 variant="outline" onClick={onCancel}>
               {t('cancel')}

--- a/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
@@ -104,7 +104,7 @@ const KeyFigureForm = ({ onSave, initialData, onCancel }: Props) => {
               <InputV2 customCss={inputStyle} label={t('form.name.subtitle')} {...field} />
             )}
           </StyledFormikField>
-          <InlineImageSearch name={'metaImageId'} />
+          <InlineImageSearch name={'metaImageId'} disableAltEditing />
           <ButtonContainer>
             <ButtonV2 variant="outline" onClick={onCancel}>
               {t('cancel')}

--- a/src/containers/ConceptPage/components/InlineImageSearch.tsx
+++ b/src/containers/ConceptPage/components/InlineImageSearch.tsx
@@ -27,9 +27,10 @@ const StyledTitleDiv = styled.div`
 
 interface Props {
   name: string;
+  disableAltEditing?: boolean;
 }
 
-const InlineImageSearch = ({ name }: Props) => {
+const InlineImageSearch = ({ name, disableAltEditing }: Props) => {
   const { t, i18n } = useTranslation();
   const { setFieldValue, values, setFieldTouched } = useFormikContext<ConceptFormValues>();
   const [image, setImage] = useState<IImageMetaInformationV3 | undefined>();
@@ -52,6 +53,7 @@ const InlineImageSearch = ({ name }: Props) => {
   if (image) {
     return (
       <MetaImageField
+        disableAltEditing={disableAltEditing}
         image={image}
         onImageRemove={() => {
           setFieldValue(name, undefined);

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageBannerImage.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageBannerImage.tsx
@@ -37,6 +37,7 @@ const SubjectpageBannerImage = ({ image, onImageSelectOpen }: Props) => {
   const metaInformationTranslations = {
     title: t('form.metaImage.imageTitle'),
     copyright: t('form.metaImage.copyright'),
+    alt: t('form.name.alttext'),
   };
   const src = `${config.ndlaApiUrl}/image-api/raw/id/${image.id}`;
   return (

--- a/src/containers/FormikForm/components/MetaImageField.tsx
+++ b/src/containers/FormikForm/components/MetaImageField.tsx
@@ -30,13 +30,14 @@ const StyledImage = styled.img`
 `;
 
 interface Props {
+  disableAltEditing?: boolean;
   image: IImageMetaInformationV3;
   onImageRemove: () => void;
   showRemoveButton: boolean;
   onImageLoad?: (width: number, height: number) => void;
 }
 
-const MetaImageField = ({ image, onImageRemove, onImageLoad }: Props) => {
+const MetaImageField = ({ image, onImageRemove, onImageLoad, disableAltEditing }: Props) => {
   const { t } = useTranslation();
   const copyright = image.copyright.creators.map((creator) => creator.name).join(', ');
   const title = convertFieldWithFallback<'title'>(image, 'title', '');
@@ -70,6 +71,7 @@ const MetaImageField = ({ image, onImageRemove, onImageLoad }: Props) => {
   const metaInformationTranslations = {
     title: t('form.metaImage.imageTitle'),
     copyright: t('form.metaImage.copyright'),
+    alt: t('form.name.alttext'),
   };
   const imageUrl = `${image.image.imageUrl}?width=400`;
   const { width, height } = image.image?.dimensions || { width: 0, height: 0 };
@@ -84,16 +86,19 @@ const MetaImageField = ({ image, onImageRemove, onImageLoad }: Props) => {
           title={title}
           copyright={copyright}
           action={imageAction}
+          alt={disableAltEditing ? alt : undefined}
           translations={metaInformationTranslations}
         />
       </MetaImageContainer>
-      <FormikField
-        label={t('topicArticleForm.fields.alt.label')}
-        name="metaImageAlt"
-        noBorder
-        placeholder={t('topicArticleForm.fields.alt.placeholder')}
-        maxLength={300}
-      />
+      {!disableAltEditing && (
+        <FormikField
+          label={t('topicArticleForm.fields.alt.label')}
+          name="metaImageAlt"
+          noBorder
+          placeholder={t('topicArticleForm.fields.alt.placeholder')}
+          maxLength={300}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
Disable it for Key figures, contact blocks, campaign blocks and blog posts
Fixes https://trello.com/c/95VmOOZV/415-kontaktblokk-og-alt-tekst