### PR TITLE
Saved search optimalization: Do not refetch saved search data when menuOpen changes

### DIFF
--- a/src/containers/Masthead/SavedSearchDropdown.tsx
+++ b/src/containers/Masthead/SavedSearchDropdown.tsx
@@ -74,14 +74,11 @@ interface Props {
 
 const SearchDropdown = ({ onClose }: Props) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { t } = useTranslation();
-  const enableUserData = useMemo(
-    () => isValid(getAccessToken()) && getAccessTokenPersonal() && menuOpen,
-    [menuOpen],
-  );
+  const [enableUserData, setEnableUserData] = useState(false);
 
+  const { t } = useTranslation();
   const { data: userData } = useUserData({
-    enabled: isValid(getAccessToken()) && getAccessTokenPersonal() && menuOpen,
+    enabled: isValid(getAccessToken()) && getAccessTokenPersonal() && enableUserData,
     select: (data) => (enableUserData ? data : undefined),
   });
 
@@ -95,10 +92,12 @@ const SearchDropdown = ({ onClose }: Props) => {
 
   const onMenuOpen = useCallback(
     (open: boolean): void => {
+      if (!enableUserData)
+        setEnableUserData(isValid(getAccessToken()) && getAccessTokenPersonal() && open);
       setMenuOpen(open);
       onClose();
     },
-    [onClose],
+    [enableUserData, onClose],
   );
 
   const { searchObjects, getSavedSearchData, loading, error } = useSavedSearchUrl(userData);


### PR DESCRIPTION
Liten oppdatering av denne: https://github.com/NDLANO/editorial-frontend/pull/1907

Endrer sånn at vi ikke refetcher hver gang man åpner menyen, dette fører til færre nettverkskall og bedre brukeropplevelse da man slipper loading hver gang lagret søk åpnes. Venter fortsatt med å fetche lagret søk til man åpner menyen første gang.