### PR TITLE
Query keys as objects

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
@@ -292,14 +292,14 @@ const LearningResourceTaxonomy = ({
         taxonomyVersion,
       });
       await updateNotes({ revision: article.revision, notes: ['Oppdatert taksonomi.'] });
-      await qc.invalidateQueries(
-        nodeQueryKeys.nodes({
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.nodes({
           contentURI: `urn:article:${article.id}`,
           taxonomyVersion,
           language: articleLanguage,
           includeContexts: true,
         }),
-      );
+      });
       setIsSaving(false);
     },
     [

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
@@ -39,7 +39,7 @@ import VersionSelect from '../../components/VersionSelect';
 import { useVersions } from '../../../../modules/taxonomy/versions/versionQueries';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 import { useAllResourceTypes } from '../../../../modules/taxonomy/resourcetypes/resourceTypesQueries';
-import { nodesQueryKey, useNodes } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useNodes } from '../../../../modules/nodes/nodeQueries';
 import { useUpdateTaxonomyMutation } from '../../../../modules/taxonomy/taxonomyMutations';
 import { fetchChildNodes, postNode } from '../../../../modules/nodes/nodeApi';
 import { NodeWithChildren } from '../../../../components/Taxonomy/TaxonomyBlockNode';
@@ -293,7 +293,7 @@ const LearningResourceTaxonomy = ({
       });
       await updateNotes({ revision: article.revision, notes: ['Oppdatert taksonomi.'] });
       await qc.invalidateQueries(
-        nodesQueryKey({
+        nodeQueryKeys.nodes({
           contentURI: `urn:article:${article.id}`,
           taxonomyVersion,
           language: articleLanguage,

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -32,7 +32,7 @@ import { useSession } from '../../../Session/SessionProvider';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 import VersionSelect from '../../components/VersionSelect';
 import { useVersions } from '../../../../modules/taxonomy/versions/versionQueries';
-import { nodesQueryKey, useNodes } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useNodes } from '../../../../modules/nodes/nodeQueries';
 import { fetchChildNodes } from '../../../../modules/nodes/nodeApi';
 import { NodeWithChildren } from '../../../../components/Taxonomy/TaxonomyBlockNode';
 import { useCreateTopicNodeConnectionsMutation } from '../../../../modules/taxonomy/taxonomyMutations';
@@ -189,7 +189,7 @@ const TopicArticleTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEnt
         notes: ['Oppdatert taksonomi.'],
       });
       await qc.invalidateQueries(
-        nodesQueryKey({
+        nodeQueryKeys.nodes({
           contentURI: `urn:article:${article.id}`,
           taxonomyVersion,
           language: articleLanguage,
@@ -198,7 +198,7 @@ const TopicArticleTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEnt
       );
       setIsSaving(false);
       qc.invalidateQueries(
-        nodesQueryKey({
+        nodeQueryKeys.nodes({
           language: articleLanguage,
           taxonomyVersion,
           nodeType: 'SUBJECT',

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -188,22 +188,22 @@ const TopicArticleTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEnt
         language: article.title?.language,
         notes: ['Oppdatert taksonomi.'],
       });
-      await qc.invalidateQueries(
-        nodeQueryKeys.nodes({
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.nodes({
           contentURI: `urn:article:${article.id}`,
           taxonomyVersion,
           language: articleLanguage,
           includeContexts: true,
         }),
-      );
+      });
       setIsSaving(false);
-      qc.invalidateQueries(
-        nodeQueryKeys.nodes({
+      qc.invalidateQueries({
+        queryKey: nodeQueryKeys.nodes({
           language: articleLanguage,
           taxonomyVersion,
           nodeType: 'SUBJECT',
         }),
-      );
+      });
     } catch (err) {
       handleError(err);
       setStatus('error');

--- a/src/containers/NodeDiff/NodeDiffContainer.tsx
+++ b/src/containers/NodeDiff/NodeDiffContainer.tsx
@@ -20,7 +20,7 @@ import { NodeChild, Node } from '@ndla/types-taxonomy';
 import AlertModal from '../../components/AlertModal';
 import { TAXONOMY_ADMIN_SCOPE } from '../../constants';
 import { usePublishNodeMutation } from '../../modules/nodes/nodeMutations';
-import { nodeTreeQueryKeys, useNodeTree } from '../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useNodeTree } from '../../modules/nodes/nodeQueries';
 import { fetchVersions } from '../../modules/taxonomy/versions/versionApi';
 import { useSession } from '../Session/SessionProvider';
 import { diffTrees, DiffType, DiffTypeWithChildren, RootDiffType } from './diffUtils';
@@ -87,7 +87,7 @@ const NodeDiffcontainer = ({ originalHash, otherHash, nodeId }: Props) => {
 
   const publishNodeMutation = usePublishNodeMutation({
     onSettled: () =>
-      qc.invalidateQueries(nodeTreeQueryKeys({ id: nodeId, taxonomyVersion: originalHash })),
+      qc.invalidateQueries(nodeQueryKeys.tree({ id: nodeId, taxonomyVersion: originalHash })),
   });
 
   useEffect(() => {

--- a/src/containers/NodeDiff/NodeDiffContainer.tsx
+++ b/src/containers/NodeDiff/NodeDiffContainer.tsx
@@ -87,7 +87,9 @@ const NodeDiffcontainer = ({ originalHash, otherHash, nodeId }: Props) => {
 
   const publishNodeMutation = usePublishNodeMutation({
     onSettled: () =>
-      qc.invalidateQueries(nodeQueryKeys.tree({ id: nodeId, taxonomyVersion: originalHash })),
+      qc.invalidateQueries({
+        queryKey: nodeQueryKeys.tree({ id: nodeId, taxonomyVersion: originalHash }),
+      }),
   });
 
   useEffect(() => {

--- a/src/containers/StructurePage/AddNodeModalContent.tsx
+++ b/src/containers/StructurePage/AddNodeModalContent.tsx
@@ -18,7 +18,7 @@ import {
   useAddNodeMutation,
   usePostNodeConnectionMutation,
 } from '../../modules/nodes/nodeMutations';
-import { childNodesWithArticleTypeQueryKey } from '../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../modules/nodes/nodeQueries';
 import handleError from '../../util/handleError';
 import { useTaxonomyVersion } from '../StructureVersion/TaxonomyVersionProvider';
 
@@ -46,7 +46,7 @@ interface Props {
 const AddNodeModalContent = ({ onClose, nodeType, rootId, parentNode }: Props) => {
   const { t } = useTranslation();
   const addNodeMutation = useAddNodeMutation();
-  const compkey = childNodesWithArticleTypeQueryKey({ id: rootId });
+  const compkey = nodeQueryKeys.childNodes({ id: rootId });
   const addNodeToParentMutation = usePostNodeConnectionMutation({
     onSuccess: (_) => {
       qc.invalidateQueries(compkey);

--- a/src/containers/StructurePage/AddNodeModalContent.tsx
+++ b/src/containers/StructurePage/AddNodeModalContent.tsx
@@ -49,7 +49,7 @@ const AddNodeModalContent = ({ onClose, nodeType, rootId, parentNode }: Props) =
   const compkey = nodeQueryKeys.childNodes({ id: rootId });
   const addNodeToParentMutation = usePostNodeConnectionMutation({
     onSuccess: (_) => {
-      qc.invalidateQueries(compkey);
+      qc.invalidateQueries({ queryKey: compkey });
     },
   });
   const { taxonomyVersion } = useTaxonomyVersion();

--- a/src/containers/StructurePage/RootNode.tsx
+++ b/src/containers/StructurePage/RootNode.tsx
@@ -63,7 +63,7 @@ const RootNode = ({
   const qc = useQueryClient();
 
   const onUpdateRank = async (id: string, newRank: number) => {
-    await qc.cancelQueries(compKey);
+    await qc.cancelQueries({ queryKey: compKey });
     const prevData = qc.getQueryData<NodeChild[]>(compKey);
     const [toUpdate, other] = partition(prevData, (t) => t.connectionId === id);
     const updatedNode: NodeChild = { ...toUpdate[0], rank: newRank };
@@ -75,7 +75,7 @@ const RootNode = ({
 
   const { mutateAsync: updateNodeConnection } = useUpdateNodeConnectionMutation({
     onMutate: ({ id, body }) => onUpdateRank(id, body.rank!),
-    onSettled: () => qc.invalidateQueries(compKey),
+    onSettled: () => qc.invalidateQueries({ queryKey: compKey }),
   });
 
   const onDragEnd = async ({ active, over }: DragEndEvent, nodes: NodeChild[]) => {

--- a/src/containers/StructurePage/RootNode.tsx
+++ b/src/containers/StructurePage/RootNode.tsx
@@ -13,15 +13,12 @@ import sortBy from 'lodash/sortBy';
 import { IUserData } from '@ndla/types-backend/draft-api';
 import { NodeChild, Node, NodeType } from '@ndla/types-taxonomy';
 import { DragEndEvent } from '@dnd-kit/core';
-import {
-  childNodesWithArticleTypeQueryKey,
-  useChildNodesWithArticleType,
-} from '../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useChildNodesWithArticleType } from '../../modules/nodes/nodeQueries';
 import { groupChildNodes } from '../../util/taxonomyHelpers';
 import NodeItem, { RenderBeforeFunction } from './NodeItem';
 import { useUpdateNodeConnectionMutation } from '../../modules/nodes/nodeMutations';
 import { useTaxonomyVersion } from '../StructureVersion/TaxonomyVersionProvider';
-import { userDataQueryKey, useUpdateUserDataMutation } from '../../modules/draft/draftQueries';
+import { draftQueryKeys, useUpdateUserDataMutation } from '../../modules/draft/draftQueries';
 
 interface Props {
   node: Node;
@@ -56,7 +53,7 @@ const RootNode = ({
       select: (childNodes) => groupChildNodes(childNodes),
     },
   );
-  const compKey = childNodesWithArticleTypeQueryKey({
+  const compKey = nodeQueryKeys.childNodes({
     taxonomyVersion,
     id: node.id,
     language: locale,
@@ -97,7 +94,7 @@ const RootNode = ({
   };
 
   const toggleFavorite = () => {
-    const favorites = qc.getQueryData<IUserData>(userDataQueryKey())?.favoriteSubjects ?? [];
+    const favorites = qc.getQueryData<IUserData>(draftQueryKeys.userData)?.favoriteSubjects ?? [];
     const updatedFavs = favorites.includes(node.id)
       ? favorites.filter((s) => s !== node.id)
       : favorites.concat(node.id);

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/ConnectExistingNode.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/ConnectExistingNode.tsx
@@ -98,12 +98,12 @@ const ConnectExistingNode = ({
       },
       {
         onSuccess: () => {
-          qc.invalidateQueries(
-            nodeQueryKeys.childNodes({
+          qc.invalidateQueries({
+            queryKey: nodeQueryKeys.childNodes({
               taxonomyVersion,
               language: i18n.language,
             }),
-          );
+          });
           setSuccess(true);
           setLoading(false);
         },

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/ConnectExistingNode.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/ConnectExistingNode.tsx
@@ -17,7 +17,7 @@ import { Done } from '@ndla/icons/editor';
 import { Node, NodeType } from '@ndla/types-taxonomy';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 import { usePostNodeConnectionMutation } from '../../../../modules/nodes/nodeMutations';
-import { childNodesWithArticleTypeQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 import RoundIcon from '../../../../components/RoundIcon';
 import MenuItemButton from './components/MenuItemButton';
 import NodeSearchDropdown from './components/NodeSearchDropdown';
@@ -99,7 +99,7 @@ const ConnectExistingNode = ({
       {
         onSuccess: () => {
           qc.invalidateQueries(
-            childNodesWithArticleTypeQueryKey({
+            nodeQueryKeys.childNodes({
               taxonomyVersion,
               language: i18n.language,
             }),

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/DisconnectFromParent.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/DisconnectFromParent.tsx
@@ -57,12 +57,12 @@ const DisconnectFromParent = ({
         },
         {
           onSuccess: () => {
-            qc.invalidateQueries(
-              nodeQueryKeys.childNodes({
+            qc.invalidateQueries({
+              queryKey: nodeQueryKeys.childNodes({
                 taxonomyVersion,
                 language: i18n.language,
               }),
-            );
+            });
             navigate(location.pathname.split(node.id)[0], { replace: true });
             onCurrentNodeChanged(undefined);
           },

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/DisconnectFromParent.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/DisconnectFromParent.tsx
@@ -15,7 +15,7 @@ import { Node, NodeChild } from '@ndla/types-taxonomy';
 import AlertModal from '../../../../components/AlertModal';
 import RoundIcon from '../../../../components/RoundIcon';
 import { useDeleteNodeConnectionMutation } from '../../../../modules/nodes/nodeMutations';
-import { childNodesWithArticleTypeQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 import { EditModeHandler } from '../SettingsMenuDropdownType';
 import MenuItemButton from './components/MenuItemButton';
@@ -58,7 +58,7 @@ const DisconnectFromParent = ({
         {
           onSuccess: () => {
             qc.invalidateQueries(
-              childNodesWithArticleTypeQueryKey({
+              nodeQueryKeys.childNodes({
                 taxonomyVersion,
                 language: i18n.language,
               }),

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/MoveExistingNode.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/MoveExistingNode.tsx
@@ -112,12 +112,12 @@ const MoveExistingNode = ({
       });
 
       // Invalidate all childNode-queries, since we don't know where the added node is from
-      qc.invalidateQueries(
-        nodeQueryKeys.childNodes({
+      qc.invalidateQueries({
+        queryKey: nodeQueryKeys.childNodes({
           taxonomyVersion,
           language: i18n.language,
         }),
-      );
+      });
       setSuccess(true);
     } catch (e) {
       setError('taxonomy.errorMessage');

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/MoveExistingNode.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/MoveExistingNode.tsx
@@ -21,7 +21,7 @@ import {
   usePostNodeConnectionMutation,
 } from '../../../../modules/nodes/nodeMutations';
 import { fetchConnectionsForNode } from '../../../../modules/nodes/nodeApi';
-import { childNodesWithArticleTypeQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 import RoundIcon from '../../../../components/RoundIcon';
 import MenuItemButton from './components/MenuItemButton';
 import NodeSearchDropdown from './components/NodeSearchDropdown';
@@ -113,7 +113,7 @@ const MoveExistingNode = ({
 
       // Invalidate all childNode-queries, since we don't know where the added node is from
       qc.invalidateQueries(
-        childNodesWithArticleTypeQueryKey({
+        nodeQueryKeys.childNodes({
           taxonomyVersion,
           language: i18n.language,
         }),

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
@@ -19,7 +19,7 @@ import { useUpdateNodeMetadataMutation } from '../../../../modules/nodes/nodeMut
 import RoundIcon from '../../../../components/RoundIcon';
 import MenuItemButton from './components/MenuItemButton';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
-import { nodesQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 
 interface Props {
   node: Node;
@@ -50,7 +50,7 @@ const ToggleVisibility = ({
   const { mutateAsync: updateMetadata } = useUpdateNodeMetadataMutation();
 
   const qc = useQueryClient();
-  const compKey = nodesQueryKey({
+  const compKey = nodeQueryKeys.nodes({
     language: i18n.language,
     nodeType: rootNodeType,
     taxonomyVersion,

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/ToggleVisibility.tsx
@@ -64,7 +64,7 @@ const ToggleVisibility = ({
         rootId: rootNodeId !== node.id ? rootNodeId : undefined,
         taxonomyVersion,
       },
-      { onSuccess: () => qc.invalidateQueries(compKey) },
+      { onSuccess: () => qc.invalidateQueries({ queryKey: compKey }) },
     );
     setVisible(!visible);
   };

--- a/src/containers/StructurePage/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
+++ b/src/containers/StructurePage/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
@@ -22,7 +22,7 @@ import { EditModeHandler } from '../SettingsMenuDropdownType';
 import MenuItemButton from '../sharedMenuOptions/components/MenuItemButton';
 import RoundIcon from '../../../../components/RoundIcon';
 import handleError from '../../../../util/handleError';
-import { nodeQueryKey, nodesQueryKey, useNode } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useNode } from '../../../../modules/nodes/nodeQueries';
 import {
   useDeleteNodeTranslationMutation,
   usePutNodeMutation,
@@ -192,15 +192,19 @@ const ChangeNodeNameContent = ({ onClose, node, nodeType = 'SUBJECT' }: ModalPro
       console.error(e);
       handleError(e);
       setUpdateError(t('taxonomy.changeName.updateError'));
-      await qc.invalidateQueries(nodesQueryKey({ nodeType: nodeType, taxonomyVersion }));
-      await qc.invalidateQueries(nodeQueryKey({ id, language: BOGUS_LANGUAGE, taxonomyVersion }));
+      await qc.invalidateQueries(nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }));
+      await qc.invalidateQueries(
+        nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
+      );
       formik.setSubmitting(false);
       return;
     }
 
     if (promises.length > 0) {
-      await qc.invalidateQueries(nodesQueryKey({ nodeType: nodeType, taxonomyVersion }));
-      await qc.invalidateQueries(nodeQueryKey({ id, language: BOGUS_LANGUAGE, taxonomyVersion }));
+      await qc.invalidateQueries(nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }));
+      await qc.invalidateQueries(
+        nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
+      );
     }
     formik.resetForm({ values: formik.values, isSubmitting: false });
     setSaved(true);

--- a/src/containers/StructurePage/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
+++ b/src/containers/StructurePage/folderComponents/subjectMenuOptions/ChangeNodeName.tsx
@@ -192,19 +192,25 @@ const ChangeNodeNameContent = ({ onClose, node, nodeType = 'SUBJECT' }: ModalPro
       console.error(e);
       handleError(e);
       setUpdateError(t('taxonomy.changeName.updateError'));
-      await qc.invalidateQueries(nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }));
-      await qc.invalidateQueries(
-        nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
-      );
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }),
+      });
+
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
+      });
       formik.setSubmitting(false);
       return;
     }
 
     if (promises.length > 0) {
-      await qc.invalidateQueries(nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }));
-      await qc.invalidateQueries(
-        nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
-      );
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.nodes({ nodeType: nodeType, taxonomyVersion }),
+      });
+
+      await qc.invalidateQueries({
+        queryKey: nodeQueryKeys.node({ id, language: BOGUS_LANGUAGE, taxonomyVersion }),
+      });
     }
     formik.resetForm({ values: formik.values, isSubmitting: false });
     setSaved(true);

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
@@ -115,7 +115,9 @@ const CopyNodeResources = ({
     const action = type === 'cloneResources' ? clone : copy;
     await Promise.all(resources.map(async (res) => await doAction(res, action)));
     setDone(true);
-    qc.invalidateQueries(nodeQueryKeys.resources({ id: currentNode.id, taxonomyVersion }));
+    qc.invalidateQueries({
+      queryKey: nodeQueryKeys.resources({ id: currentNode.id, taxonomyVersion }),
+    });
   };
 
   const doAction = async (res: NodeChild, action: (res: NodeChild) => Promise<string>) => {

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
@@ -30,7 +30,7 @@ import { learningpathCopy } from '../../../../modules/learningpath/learningpathA
 import { EditMode } from '../../../../interfaces';
 import AlertModal from '../../../../components/AlertModal';
 import ResourceItemLink from '../../resourceComponents/ResourceItemLink';
-import { resourcesWithNodeConnectionQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 
 type ActionType = Extract<EditMode, 'copyResources' | 'cloneResources'>;
 interface Props {
@@ -115,9 +115,7 @@ const CopyNodeResources = ({
     const action = type === 'cloneResources' ? clone : copy;
     await Promise.all(resources.map(async (res) => await doAction(res, action)));
     setDone(true);
-    qc.invalidateQueries(
-      resourcesWithNodeConnectionQueryKey({ id: currentNode.id, taxonomyVersion }),
-    );
+    qc.invalidateQueries(nodeQueryKeys.resources({ id: currentNode.id, taxonomyVersion }));
   };
 
   const doAction = async (res: NodeChild, action: (res: NodeChild) => Promise<string>) => {

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/GroupTopicResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/GroupTopicResources.tsx
@@ -22,7 +22,7 @@ import { StyledMenuItemEditField, StyledMenuItemInputField } from '../styles';
 import { useUpdateNodeMetadataMutation } from '../../../../modules/nodes/nodeMutations';
 import { getRootIdForNode, isRootNode } from '../../../../modules/nodes/nodeUtil';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
-import { childNodesWithArticleTypeQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 
 interface Props {
   node: Node;
@@ -40,7 +40,7 @@ const GroupTopicResources = ({ node, hideIcon, onChanged }: Props) => {
   const qc = useQueryClient();
   const rootNodeId = getRootIdForNode(node);
   const { taxonomyVersion } = useTaxonomyVersion();
-  const compKey = childNodesWithArticleTypeQueryKey({
+  const compKey = nodeQueryKeys.childNodes({
     taxonomyVersion,
     id: rootNodeId,
     language: i18n.language,

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/GroupTopicResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/GroupTopicResources.tsx
@@ -60,7 +60,7 @@ const GroupTopicResources = ({ node, hideIcon, onChanged }: Props) => {
         taxonomyVersion,
       },
       {
-        onSettled: () => qc.invalidateQueries(compKey),
+        onSettled: () => qc.invalidateQueries({ queryKey: compKey }),
         onSuccess: () => onChanged?.({ customFields }),
       },
     );

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/PublishChildNodeResources.tsx
@@ -135,7 +135,7 @@ const PublishChildNodeResources = ({ node }: Props) => {
         ),
     );
     await Promise.all([...draftPromises, ...learningpathPromises]);
-    await qc.invalidateQueries([RESOURCE_META, {}]);
+    await qc.invalidateQueries({ queryKey: [RESOURCE_META, {}] });
     setDone(true);
   };
 

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/SwapTopicArticle.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/SwapTopicArticle.tsx
@@ -20,7 +20,7 @@ import RoundIcon from '../../../../components/RoundIcon';
 import { fetchDraft, updateDraft } from '../../../../modules/draft/draftApi';
 import { TOPIC_NODE } from '../../../../modules/nodes/nodeApiTypes';
 import { usePutNodeMutation } from '../../../../modules/nodes/nodeMutations';
-import { childNodesWithArticleTypeQueryKey } from '../../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../../modules/nodes/nodeQueries';
 import { useSearch } from '../../../../modules/search/searchQueries';
 import { useTaxonomyVersion } from '../../../StructureVersion/TaxonomyVersionProvider';
 import { EditModeHandler } from '../SettingsMenuDropdownType';
@@ -94,7 +94,7 @@ const SwapTopicArticle = ({
         taxonomyVersion,
       });
       qc.invalidateQueries(
-        childNodesWithArticleTypeQueryKey({
+        nodeQueryKeys.childNodes({
           taxonomyVersion,
           language: i18n.language,
           id: rootNodeId,

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/SwapTopicArticle.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/SwapTopicArticle.tsx
@@ -93,13 +93,13 @@ const SwapTopicArticle = ({
         contentUri: `urn:article:${topic.id}`,
         taxonomyVersion,
       });
-      qc.invalidateQueries(
-        nodeQueryKeys.childNodes({
+      qc.invalidateQueries({
+        queryKey: nodeQueryKeys.childNodes({
           taxonomyVersion,
           language: i18n.language,
           id: rootNodeId,
         }),
-      );
+      });
       const draft = await fetchDraft(topic.id, i18n.language);
       await updateDraft(
         draft.id,

--- a/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
+++ b/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
@@ -104,7 +104,7 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
   const { taxonomyVersion } = useTaxonomyVersion();
   const compKey = nodeQueryKeys.resources({ id: nodeId, language: i18n.language });
   const { mutateAsync: createNodeResource } = usePostResourceForNodeMutation({
-    onSuccess: (_) => qc.invalidateQueries(compKey),
+    onSuccess: (_) => qc.invalidateQueries({ queryKey: compKey }),
   });
   const { data: articleSearchData } = useNodes({
     contentURI: `urn:article:${articleInputId}`,

--- a/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
+++ b/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
@@ -31,7 +31,7 @@ import { getArticle } from '../../../modules/article/articleApi';
 import handleError from '../../../util/handleError';
 import { usePostResourceForNodeMutation } from '../../../modules/nodes/nodeMutations';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
-import { resourcesWithNodeConnectionQueryKey, useNodes } from '../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys, useNodes } from '../../../modules/nodes/nodeQueries';
 import Spinner from '../../../components/Spinner';
 import {
   ButtonWrapper,
@@ -102,7 +102,7 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
   const [articleInputId, setArticleInputId] = useState<string | undefined>();
   const qc = useQueryClient();
   const { taxonomyVersion } = useTaxonomyVersion();
-  const compKey = resourcesWithNodeConnectionQueryKey({ id: nodeId, language: i18n.language });
+  const compKey = nodeQueryKeys.resources({ id: nodeId, language: i18n.language });
   const { mutateAsync: createNodeResource } = usePostResourceForNodeMutation({
     onSuccess: (_) => qc.invalidateQueries(compKey),
   });

--- a/src/containers/StructurePage/plannedResource/PlannedResourceForm.tsx
+++ b/src/containers/StructurePage/plannedResource/PlannedResourceForm.tsx
@@ -159,13 +159,13 @@ const PlannedResourceForm = ({ articleType, node, onClose }: Props) => {
   const { mutateAsync: createNodeResource, isLoading: postResourceLoading } =
     usePostResourceForNodeMutation({
       onSuccess: (_) => {
-        qc.invalidateQueries(compKey);
-        qc.invalidateQueries(compKeyChildNodes);
+        qc.invalidateQueries({ queryKey: compKey });
+        qc.invalidateQueries({ queryKey: compKeyChildNodes });
       },
     });
   const { mutateAsync: createResourceResourceType, isLoading: createResourceTypeLoading } =
     useCreateResourceResourceTypeMutation({
-      onSuccess: (_) => qc.invalidateQueries(compKey),
+      onSuccess: (_) => qc.invalidateQueries({ queryKey: compKey }),
     });
   const initialValues = useMemo(() => toInitialValues(ndlaId, articleType), [ndlaId, articleType]);
   const isTopicArticle = articleType === 'topic-article';

--- a/src/containers/StructurePage/plannedResource/PlannedResourceForm.tsx
+++ b/src/containers/StructurePage/plannedResource/PlannedResourceForm.tsx
@@ -26,10 +26,7 @@ import {
   useCreateResourceResourceTypeMutation,
   usePostResourceForNodeMutation,
 } from '../../../modules/nodes/nodeMutations';
-import {
-  childNodesWithArticleTypeQueryKey,
-  resourcesWithNodeConnectionQueryKey,
-} from '../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 import { RESOURCE_NODE, TOPIC_NODE } from '../../../modules/nodes/nodeApiTypes';
 import FormikField from '../../../components/FormikField';
@@ -153,8 +150,8 @@ const PlannedResourceForm = ({ articleType, node, onClose }: Props) => {
   const { taxonomyVersion } = useTaxonomyVersion();
   const qc = useQueryClient();
   const nodeId = useMemo(() => node && getRootIdForNode(node), [node]);
-  const compKey = resourcesWithNodeConnectionQueryKey({ id: node?.id, language: i18n.language });
-  const compKeyChildNodes = childNodesWithArticleTypeQueryKey({
+  const compKey = nodeQueryKeys.resources({ id: node?.id, language: i18n.language });
+  const compKeyChildNodes = nodeQueryKeys.childNodes({
     taxonomyVersion,
     id: nodeId,
     language: i18n.language,

--- a/src/containers/StructurePage/resourceComponents/GrepCodesModal.tsx
+++ b/src/containers/StructurePage/resourceComponents/GrepCodesModal.tsx
@@ -24,8 +24,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUpdateDraftMutation } from '../../../modules/draft/draftMutations';
-import { draftQueryKey } from '../../../modules/draft/draftQueries';
-import { NodeResourceMeta, nodeResourceMetasQueryKey } from '../../../modules/nodes/nodeQueries';
+import { draftQueryKeys } from '../../../modules/draft/draftQueries';
+import { NodeResourceMeta, nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 import { getIdFromUrn } from '../../../util/taxonomyHelpers';
 import GrepCodesForm from './GrepCodesForm';
 
@@ -101,11 +101,11 @@ const GrepCodeContent = ({
   const { t, i18n } = useTranslation();
   const qc = useQueryClient();
   const key = useMemo(
-    () => draftQueryKey({ id: draftId, language: i18n.language }),
+    () => draftQueryKeys.draft({ id: draftId, language: i18n.language }),
     [i18n.language, draftId],
   );
   const nodeKey = useMemo(
-    () => nodeResourceMetasQueryKey({ nodeId: currentNodeId, language: i18n.language }),
+    () => nodeQueryKeys.resourceMetas({ nodeId: currentNodeId, language: i18n.language }),
     [i18n.language, currentNodeId],
   );
 

--- a/src/containers/StructurePage/resourceComponents/GrepCodesModal.tsx
+++ b/src/containers/StructurePage/resourceComponents/GrepCodesModal.tsx
@@ -115,9 +115,9 @@ const GrepCodeContent = ({
         { id: draftId, body: { grepCodes, revision } },
         {
           onSuccess: (data) => {
-            qc.cancelQueries(key);
+            qc.cancelQueries({ queryKey: key });
             qc.setQueryData<IArticle>(key, data);
-            qc.invalidateQueries(key);
+            qc.invalidateQueries({ queryKey: key });
             qc.setQueriesData<NodeResourceMeta[]>(
               { queryKey: nodeKey },
               (data) =>

--- a/src/containers/StructurePage/resourceComponents/GroupResourcesSwitch.tsx
+++ b/src/containers/StructurePage/resourceComponents/GroupResourcesSwitch.tsx
@@ -19,7 +19,7 @@ import {
   TAXONOMY_CUSTOM_FIELD_UNGROUPED_RESOURCE,
 } from '../../../constants';
 import { useUpdateNodeMetadataMutation } from '../../../modules/nodes/nodeMutations';
-import { childNodesWithArticleTypeQueryKey } from '../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 import { getRootIdForNode, isRootNode } from '../../../modules/nodes/nodeUtil';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
 
@@ -45,7 +45,7 @@ const GroupResourceSwitch = ({ node, onChanged }: Props) => {
   const { taxonomyVersion } = useTaxonomyVersion();
   const qc = useQueryClient();
 
-  const compKey = childNodesWithArticleTypeQueryKey({
+  const compKey = nodeQueryKeys.childNodes({
     taxonomyVersion,
     id: rootNodeId,
     language: i18n.language,

--- a/src/containers/StructurePage/resourceComponents/GroupResourcesSwitch.tsx
+++ b/src/containers/StructurePage/resourceComponents/GroupResourcesSwitch.tsx
@@ -66,7 +66,7 @@ const GroupResourceSwitch = ({ node, onChanged }: Props) => {
         taxonomyVersion,
       },
       {
-        onSettled: () => qc.invalidateQueries(compKey),
+        onSettled: () => qc.invalidateQueries({ queryKey: compKey }),
         onSuccess: () => onChanged({ customFields }),
       },
     );

--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -23,7 +23,7 @@ import { getContentTypeFromResourceTypes } from '../../../util/resourceHelpers';
 import RelevanceOption from '../../../components/Taxonomy/RelevanceOption';
 import ResourceItemLink from './ResourceItemLink';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
-import { resourcesWithNodeConnectionQueryKey } from '../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
 import StatusIcons from './StatusIcons';
 import GrepCodesModal from './GrepCodesModal';
@@ -124,7 +124,7 @@ const Resource = ({
 
   const qc = useQueryClient();
   const { taxonomyVersion } = useTaxonomyVersion();
-  const compKey = resourcesWithNodeConnectionQueryKey({
+  const compKey = nodeQueryKeys.resources({
     id: currentNodeId,
     language: i18n.language,
   });

--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -130,7 +130,7 @@ const Resource = ({
   });
 
   const onUpdateConnection = async (id: string, { relevanceId }: NodeConnectionPUT) => {
-    await qc.cancelQueries(compKey);
+    await qc.cancelQueries({ queryKey: compKey });
     const resources = qc.getQueryData<NodeChild[]>(compKey) ?? [];
     if (relevanceId) {
       const newResources = resources.map((res) => {
@@ -145,11 +145,11 @@ const Resource = ({
 
   const { mutateAsync: updateNodeConnection } = useUpdateNodeConnectionMutation({
     onMutate: async ({ id, body }) => onUpdateConnection(id, body),
-    onSettled: () => qc.invalidateQueries(compKey),
+    onSettled: () => qc.invalidateQueries({ queryKey: compKey }),
   });
   const { mutateAsync: updateResourceConnection } = usePutResourceForNodeMutation({
     onMutate: async ({ id, body }) => onUpdateConnection(id, body),
-    onSettled: () => qc.invalidateQueries(compKey),
+    onSettled: () => qc.invalidateQueries({ queryKey: compKey }),
   });
 
   const contentType =

--- a/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
@@ -73,7 +73,7 @@ const ResourceItems = ({
   });
   const deleteNodeResource = useDeleteResourceForNodeMutation({
     onMutate: async ({ id }) => {
-      await qc.cancelQueries(compKey);
+      await qc.cancelQueries({ queryKey: compKey });
       const prevData = qc.getQueryData<NodeChild[]>(compKey) ?? [];
       const withoutDeleted = prevData.filter((res) => res.connectionId !== id);
       qc.setQueryData<NodeChild[]>(compKey, withoutDeleted);
@@ -82,7 +82,7 @@ const ResourceItems = ({
   });
 
   const onUpdateRank = async (id: string, newRank: number) => {
-    await qc.cancelQueries(compKey);
+    await qc.cancelQueries({ queryKey: compKey });
     const prevData = qc.getQueryData<NodeChild[]>(compKey) ?? [];
     const updated = prevData.map((r) => {
       if (r.connectionId === id) {
@@ -98,14 +98,14 @@ const ResourceItems = ({
   const { mutateAsync: updateNodeResource } = usePutResourceForNodeMutation({
     onMutate: ({ id, body }) => onUpdateRank(id, body.rank as number),
     onError: (e) => handleError(e),
-    onSuccess: () => qc.invalidateQueries(compKey),
+    onSuccess: () => qc.invalidateQueries({ queryKey: compKey }),
   });
 
   const onDelete = async (deleteId: string) => {
     setDeleteId('');
     await deleteNodeResource.mutateAsync(
       { id: deleteId, taxonomyVersion },
-      { onSuccess: () => qc.invalidateQueries(compKey) },
+      { onSuccess: () => qc.invalidateQueries({ queryKey: compKey }) },
     );
   };
 

--- a/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
@@ -23,10 +23,7 @@ import {
 } from '../../../modules/nodes/nodeMutations';
 import AlertModal from '../../../components/AlertModal';
 import { useTaxonomyVersion } from '../../StructureVersion/TaxonomyVersionProvider';
-import {
-  NodeResourceMeta,
-  resourcesWithNodeConnectionQueryKey,
-} from '../../../modules/nodes/nodeQueries';
+import { NodeResourceMeta, nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 import { ResourceWithNodeConnectionAndMeta } from './StructureResources';
 import { Auth0UserData, Dictionary } from '../../../interfaces';
 import DndList from '../../../components/DndList';
@@ -69,7 +66,7 @@ const ResourceItems = ({
   const { taxonomyVersion } = useTaxonomyVersion();
 
   const qc = useQueryClient();
-  const compKey = resourcesWithNodeConnectionQueryKey({
+  const compKey = nodeQueryKeys.resources({
     id: currentNodeId,
     language: i18n.language,
     taxonomyVersion,

--- a/src/containers/TaxonomyVersions/components/DeletePublishRequests.tsx
+++ b/src/containers/TaxonomyVersions/components/DeletePublishRequests.tsx
@@ -25,13 +25,13 @@ import {
 import { Node } from '@ndla/types-taxonomy';
 import { TAXONOMY_CUSTOM_FIELD_REQUEST_PUBLISH } from '../../../constants';
 import { useUpdateNodeMetadataMutation } from '../../../modules/nodes/nodeMutations';
-import { nodesQueryKey } from '../../../modules/nodes/nodeQueries';
+import { nodeQueryKeys } from '../../../modules/nodes/nodeQueries';
 
 interface Props {
   nodes: Node[];
 }
 
-const queryKey = nodesQueryKey({
+const queryKey = nodeQueryKeys.nodes({
   key: TAXONOMY_CUSTOM_FIELD_REQUEST_PUBLISH,
   value: 'true',
   taxonomyVersion: 'default',

--- a/src/containers/TaxonomyVersions/components/DeletePublishRequests.tsx
+++ b/src/containers/TaxonomyVersions/components/DeletePublishRequests.tsx
@@ -57,7 +57,7 @@ const DeletePublishRequests = ({ nodes }: Props) => {
         await mutateAsync({ id, metadata: newMeta, taxonomyVersion: 'default' });
       });
       await Promise.all(promises);
-      qc.invalidateQueries(queryKey);
+      qc.invalidateQueries({ queryKey: queryKey });
       qc.setQueryData(queryKey, []);
     },
     [mutateAsync, qc],

--- a/src/containers/TaxonomyVersions/components/Version.tsx
+++ b/src/containers/TaxonomyVersions/components/Version.tsx
@@ -22,7 +22,7 @@ import VersionForm from './VersionForm';
 import { useDeleteVersionMutation } from '../../../modules/taxonomy/versions/versionMutations';
 import AlertModal from '../../../components/AlertModal';
 import config from '../../../config';
-import { versionsQueryKey } from '../../../modules/taxonomy/versions/versionQueries';
+import { versionQueryKeys } from '../../../modules/taxonomy/versions/versionQueries';
 import { StyledErrorMessage } from './StyledErrorMessage';
 
 interface Props {
@@ -108,7 +108,7 @@ const Version = ({ version }: Props) => {
   const [error, setError] = useState<string | undefined>(undefined);
   const [isEditing, setIsEditing] = useState(false);
   const qc = useQueryClient();
-  const key = versionsQueryKey();
+  const key = versionQueryKeys.versions();
 
   const deleteVersionMutation = useDeleteVersionMutation({
     onMutate: async ({ id }) => {

--- a/src/containers/TaxonomyVersions/components/Version.tsx
+++ b/src/containers/TaxonomyVersions/components/Version.tsx
@@ -113,12 +113,12 @@ const Version = ({ version }: Props) => {
   const deleteVersionMutation = useDeleteVersionMutation({
     onMutate: async ({ id }) => {
       setError(undefined);
-      await qc.cancelQueries(key);
+      await qc.cancelQueries({ queryKey: key });
       const existingVersions = qc.getQueryData<TaxVersion[]>(key) ?? [];
       const withoutDeleted = existingVersions.filter((version) => version.id !== id);
       qc.setQueryData<TaxVersion[]>(key, withoutDeleted);
     },
-    onSuccess: () => qc.invalidateQueries(key),
+    onSuccess: () => qc.invalidateQueries({ queryKey: key }),
     onError: () => setError(t('taxonomyVersions.deleteError')),
   });
 

--- a/src/containers/TaxonomyVersions/components/VersionForm.tsx
+++ b/src/containers/TaxonomyVersions/components/VersionForm.tsx
@@ -24,7 +24,7 @@ import {
   usePublishVersionMutation,
   usePutVersionMutation,
 } from '../../../modules/taxonomy/versions/versionMutations';
-import { versionsQueryKey } from '../../../modules/taxonomy/versions/versionQueries';
+import { versionQueryKeys } from '../../../modules/taxonomy/versions/versionQueries';
 import { StyledErrorMessage } from './StyledErrorMessage';
 import Fade from '../../../components/Taxonomy/Fade';
 import {
@@ -66,7 +66,7 @@ const VersionForm = ({ version, existingVersions, onClose }: Props) => {
   const [error, setError] = useState<string | undefined>(undefined);
   const initialValues = versionTypeToVersionFormType(version);
   const qc = useQueryClient();
-  const versionsKey = versionsQueryKey();
+  const versionsKey = versionQueryKeys.versions();
 
   const versionPostMutation = usePostVersionMutation({
     onMutate: async ({ body }) => {

--- a/src/containers/TaxonomyVersions/components/VersionForm.tsx
+++ b/src/containers/TaxonomyVersions/components/VersionForm.tsx
@@ -71,7 +71,7 @@ const VersionForm = ({ version, existingVersions, onClose }: Props) => {
   const versionPostMutation = usePostVersionMutation({
     onMutate: async ({ body }) => {
       setError(undefined);
-      await qc.cancelQueries(versionsKey);
+      await qc.cancelQueries({ queryKey: versionsKey });
       const optimisticVersion: Version = {
         id: '',
         versionType: 'BETA',
@@ -83,14 +83,14 @@ const VersionForm = ({ version, existingVersions, onClose }: Props) => {
       const existingVersions = qc.getQueryData<Version[]>(versionsKey) ?? [];
       qc.setQueryData<Version[]>(versionsKey, existingVersions.concat(optimisticVersion));
     },
-    onSuccess: () => qc.invalidateQueries(versionsKey),
+    onSuccess: () => qc.invalidateQueries({ queryKey: versionsKey }),
     onError: () => setError(t('taxonomyVersions.postError')),
   });
 
   const versionPutMutation = usePutVersionMutation({
     onMutate: async ({ id, body }) => {
       setError(undefined);
-      await qc.cancelQueries(versionsKey);
+      await qc.cancelQueries({ queryKey: versionsKey });
       const existingVersions = qc.getQueryData<Version[]>(versionsKey) ?? [];
       const newVersions = existingVersions.map((version) => {
         if (version.id === id) {
@@ -103,14 +103,14 @@ const VersionForm = ({ version, existingVersions, onClose }: Props) => {
       });
       qc.setQueryData<Version[]>(versionsKey, newVersions);
     },
-    onSuccess: () => qc.invalidateQueries(versionsKey),
+    onSuccess: () => qc.invalidateQueries({ queryKey: versionsKey }),
     onError: () => setError(t('taxonomyVersions.putError')),
   });
 
   const publishVersionMutation = usePublishVersionMutation({
     onMutate: async ({ id }) => {
       setError(undefined);
-      await qc.cancelQueries(versionsKey);
+      await qc.cancelQueries({ queryKey: versionsKey });
       const existingVersions = qc.getQueryData<Version[]>(versionsKey) ?? [];
       const updatedVersions: Version[] = existingVersions.map((version) => {
         if (version.id === id) {
@@ -119,7 +119,7 @@ const VersionForm = ({ version, existingVersions, onClose }: Props) => {
       });
       qc.setQueryData<Version[]>(versionsKey, updatedVersions);
     },
-    onSuccess: () => qc.invalidateQueries(versionsKey),
+    onSuccess: () => qc.invalidateQueries({ queryKey: versionsKey }),
     onError: () => setError(t('taxonomyVersions.publishError')),
   });
 

--- a/src/modules/article/articleGqlQueries.ts
+++ b/src/modules/article/articleGqlQueries.ts
@@ -10,6 +10,7 @@ import { request, gql, Variables } from 'graphql-request';
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import config from '../../config';
 import { apiResourceUrl } from '../../util/apiHelpers';
+import { TRANFSFORM_ARTICLE } from '../../queryKeys';
 
 const gqlEndpoint = config.localConverter
   ? 'http://localhost:4000/graphql-api/graphql'
@@ -25,10 +26,10 @@ interface UseTransformArticle extends Variables {
   absoluteUrl?: boolean;
 }
 
-export const transformArticleQueryKey = (params?: Partial<UseTransformArticle>) => [
-  'TRANSFORM_ARTICLE',
-  params,
-];
+export const transformArticleQueryKeys = {
+  transformArticle: (params?: Partial<UseTransformArticle>) =>
+    [TRANFSFORM_ARTICLE, params] as const,
+};
 
 export const usePreviewArticle = (
   content: string,
@@ -78,7 +79,7 @@ export const useTransformArticle = (
   options?: UseQueryOptions<string>,
 ): UseQueryResult<string> => {
   return useQuery<string>(
-    ['TRANSFORM_ARTICLE', params],
+    transformArticleQueryKeys.transformArticle(params),
     async (): Promise<string> => {
       const res = await request<ReturnData, UseTransformArticle>(
         gqlEndpoint,

--- a/src/modules/article/articleQueries.ts
+++ b/src/modules/article/articleQueries.ts
@@ -11,14 +11,16 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { ARTICLE } from '../../queryKeys';
 import { ArticleSearchParams, searchArticles } from './articleApi';
 
-const articleSearchQueryKey = (params?: Partial<ArticleSearchParams>) => [ARTICLE, params];
+export const articleQueryKeys = {
+  search: (params?: Partial<ArticleSearchParams>) => [ARTICLE, params] as const,
+};
 
 export const useArticleSearch = (
   params: ArticleSearchParams,
   options?: UseQueryOptions<ISearchResultV2>,
 ) => {
   return useQuery<ISearchResultV2>(
-    articleSearchQueryKey(params),
+    articleQueryKeys.search(params),
     () => searchArticles(params),
     options,
   );

--- a/src/modules/audio/audioQueries.ts
+++ b/src/modules/audio/audioQueries.ts
@@ -22,11 +22,16 @@ export interface UseAudio {
   language?: string;
 }
 
-export const audioQueryKeys = (params?: Partial<UseAudio>) => [AUDIO, params];
+export const audioQueryKeys = {
+  audio: (params?: Partial<UseAudio>) => [AUDIO, params] as const,
+  search: (params?: Partial<AudioSearchParams>) => [SEARCH_AUDIO, params] as const,
+  podcastSeries: (params?: Partial<UseSeries>) => [PODCAST_SERIES, params] as const,
+  podcastSeriesSearch: (params?: Partial<SeriesSearchParams>) => [SEARCH_SERIES, params] as const,
+};
 
 export const useAudio = (params: UseAudio, options?: UseQueryOptions<IAudioMetaInformation>) =>
   useQuery<IAudioMetaInformation>(
-    audioQueryKeys(params),
+    audioQueryKeys.audio(params),
     () => fetchAudio(params.id, params.language),
     options,
   );
@@ -36,32 +41,29 @@ export interface UseSeries {
   language?: string;
 }
 
-export const seriesQueryKey = (params?: Partial<UseSeries>) => [PODCAST_SERIES, params];
-
 export const useSeries = (params: UseSeries, options?: UseQueryOptions<ISeries>) =>
-  useQuery<ISeries>(seriesQueryKey(params), () => fetchSeries(params.id, params.language), options);
+  useQuery<ISeries>(
+    audioQueryKeys.podcastSeries(params),
+    () => fetchSeries(params.id, params.language),
+    options,
+  );
 
-export const searchSeriesQueryKey = (params?: Partial<SeriesSearchParams>) => [
-  SEARCH_SERIES,
-  params,
-];
 export const useSearchSeries = (
   query: SeriesSearchParams,
   options?: UseQueryOptions<ISeriesSummarySearchResult>,
 ) =>
   useQuery<ISeriesSummarySearchResult>(
-    searchSeriesQueryKey(query),
+    audioQueryKeys.podcastSeriesSearch(query),
     () => searchSeries(query),
     options,
   );
 
-export const searchAudioQueryKey = (params?: Partial<AudioSearchParams>) => [SEARCH_AUDIO, params];
 export const useSearchAudio = (
   query: AudioSearchParams,
   options?: UseQueryOptions<IAudioSummarySearchResult>,
 ) =>
   useQuery<IAudioSummarySearchResult>(
-    searchAudioQueryKey(query),
+    audioQueryKeys.search(query),
     () => searchAudio(query),
     options,
   );

--- a/src/modules/auth0/auth0Queries.ts
+++ b/src/modules/auth0/auth0Queries.ts
@@ -15,10 +15,15 @@ export interface Auth0Users {
   uniqueUserIds: string;
 }
 
-export const auth0UsersQueryKey = (params?: Partial<Auth0Users>) => [AUTH0_USERS, params];
+export const auth0QueryKeys = {
+  users: (params?: Partial<Auth0Users>) => [AUTH0_USERS, params] as const,
+  editors: [AUTH0_EDITORS] as const,
+  responsibles: (params?: Partial<Auth0Editors>) => [AUTH0_RESPONSIBLES, params] as const,
+};
+
 export const useAuth0Users = (params: Auth0Users, options: UseQueryOptions<Auth0UserData[]>) =>
   useQuery<Auth0UserData[]>(
-    auth0UsersQueryKey(params),
+    auth0QueryKeys.users(params),
     () => fetchAuth0Users(params.uniqueUserIds),
     options,
   );
@@ -27,26 +32,21 @@ export interface Auth0Editors {
   permission: string;
 }
 
-export const auth0EditorsQueryKey = [AUTH0_EDITORS];
 export const useAuth0Editors = <ReturnType>(
   options: UseQueryOptions<Auth0UserData[], unknown, ReturnType>,
 ) =>
   useQuery<Auth0UserData[], unknown, ReturnType>(
-    auth0EditorsQueryKey,
+    auth0QueryKeys.editors,
     () => fetchAuth0Editors(),
     options,
   );
 
-export const auth0ResponsiblesQueryKey = (params?: Partial<Auth0Editors>) => [
-  AUTH0_RESPONSIBLES,
-  params,
-];
 export const useAuth0Responsibles = <ReturnType>(
   params: Auth0Editors,
   options: UseQueryOptions<Auth0UserData[], unknown, ReturnType>,
 ) =>
   useQuery<Auth0UserData[], unknown, ReturnType>(
-    auth0ResponsiblesQueryKey(params),
+    auth0QueryKeys.responsibles(params),
     () => fetchAuth0Responsibles(params.permission),
     options,
   );

--- a/src/modules/concept/conceptQueries.ts
+++ b/src/modules/concept/conceptQueries.ts
@@ -18,35 +18,35 @@ export interface UseConcept {
   language?: string;
 }
 
-export const conceptQueryKey = (params?: Partial<UseConcept>) => [CONCEPT, params];
+export const conceptQueryKeys = {
+  concept: (params?: Partial<UseConcept>) => [CONCEPT, params] as const,
+  searchConcepts: (params?: Partial<ConceptQuery>) => [SEARCH_CONCEPTS, params] as const,
+  statusStateMachine: [CONCEPT_STATE_MACHINE] as const,
+};
 
 export const useConcept = (params: UseConcept, options?: UseQueryOptions<IConcept>) => {
   return useQuery<IConcept>(
-    conceptQueryKey(params),
+    conceptQueryKeys.concept(params),
     () => fetchConcept(params.id, params.language),
     options,
   );
 };
-
-export const searchConceptsQueryKey = (params?: Partial<ConceptQuery>) => [SEARCH_CONCEPTS, params];
 
 export const useSearchConcepts = (
   query: ConceptQuery,
   options?: UseQueryOptions<IConceptSearchResult>,
 ) =>
   useQuery<IConceptSearchResult>(
-    searchConceptsQueryKey(query),
+    conceptQueryKeys.searchConcepts(query),
     () => searchConcepts(query),
     options,
   );
-
-export const conceptStateMachineQueryKey = () => [CONCEPT_STATE_MACHINE];
 
 export const useConceptStateMachine = (
   options?: UseQueryOptions<ConceptStatusStateMachineType>,
 ) => {
   return useQuery<ConceptStatusStateMachineType>(
-    conceptStateMachineQueryKey(),
+    conceptQueryKeys.statusStateMachine,
     () => fetchStatusStateMachine(),
     options,
   );

--- a/src/modules/draft/draftQueries.ts
+++ b/src/modules/draft/draftQueries.ts
@@ -95,7 +95,7 @@ export const useUpdateUserDataMutation = () => {
     {
       onMutate: async (newUserData) => {
         const key = draftQueryKeys.userData;
-        await queryClient.cancelQueries(key);
+        await queryClient.cancelQueries({ queryKey: key });
         const previousUserData = queryClient.getQueryData<IUserData>(key);
         queryClient.setQueryData<IUserData>(key, {
           ...previousUserData,
@@ -109,7 +109,7 @@ export const useUpdateUserDataMutation = () => {
           queryClient.setQueryData(draftQueryKeys.userData, previousUserData);
         }
       },
-      onSettled: () => queryClient.invalidateQueries(draftQueryKeys.userData),
+      onSettled: () => queryClient.invalidateQueries({ queryKey: draftQueryKeys.userData }),
     },
   );
 };

--- a/src/modules/draft/draftQueries.ts
+++ b/src/modules/draft/draftQueries.ts
@@ -31,7 +31,6 @@ import {
 } from './draftApi';
 import { DraftStatusStateMachineType } from '../../interfaces';
 import { DraftSearchQuery } from './draftApiInterfaces';
-import { useAuth0Users } from '../auth0/auth0Queries';
 
 export interface UseDraft {
   id: number;
@@ -39,11 +38,20 @@ export interface UseDraft {
   responsibleId?: string;
 }
 
-export const draftQueryKey = (params?: Partial<UseDraft>) => [DRAFT, params];
+export const draftQueryKeys = {
+  draft: (params?: Partial<UseDraft>) => [DRAFT, params] as const,
+  search: (params?: Partial<DraftSearchQuery>) => [SEARCH_DRAFTS, params] as const,
+  licenses: [LICENSES] as const,
+  userData: [USER_DATA] as const,
+  statusStateMachine: (params?: Partial<StatusStateMachineParams>) =>
+    [DRAFT_STATUS_STATE_MACHINE, params] as const,
+};
+
+draftQueryKeys.draft({ id: 1 });
 
 export const useDraft = (params: UseDraft, options?: UseQueryOptions<IArticle>) => {
   return useQuery<IArticle>(
-    draftQueryKey(params),
+    draftQueryKeys.draft(params),
     () => fetchDraft(params.id, params.language),
     options,
   );
@@ -52,25 +60,21 @@ interface UseSearchDrafts extends DraftSearchQuery {
   ids: number[];
 }
 
-const searchDraftQueryKey = (params: UseSearchDrafts) => [SEARCH_DRAFTS, params];
-
 export const useSearchDrafts = (
   params: UseSearchDrafts,
   options?: UseQueryOptions<ISearchResult>,
 ) => {
   return useQuery<ISearchResult>(
-    searchDraftQueryKey(params),
+    draftQueryKeys.search(params),
     () => searchAllDrafts(params.ids, params.language, params.sort),
     options,
   );
 };
 
-export const licensesQueryKey = () => [LICENSES];
-
 export const useLicenses = <ReturnType = ILicense[]>(
   options?: UseQueryOptions<ILicense[], unknown, ReturnType>,
 ) =>
-  useQuery<ILicense[], unknown, ReturnType>(licensesQueryKey(), fetchLicenses, {
+  useQuery<ILicense[], unknown, ReturnType>(draftQueryKeys.licenses, fetchLicenses, {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     refetchOnReconnect: false,
@@ -79,10 +83,8 @@ export const useLicenses = <ReturnType = ILicense[]>(
     ...options,
   });
 
-export const userDataQueryKey = () => [USER_DATA];
-
 export const useUserData = (options?: UseQueryOptions<IUserData | undefined>) =>
-  useQuery<IUserData | undefined>(userDataQueryKey(), fetchUserData, options);
+  useQuery<IUserData | undefined>(draftQueryKeys.userData, fetchUserData, options);
 
 export const useUpdateUserDataMutation = () => {
   const queryClient = useQueryClient();
@@ -92,7 +94,7 @@ export const useUpdateUserDataMutation = () => {
     },
     {
       onMutate: async (newUserData) => {
-        const key = userDataQueryKey();
+        const key = draftQueryKeys.userData;
         await queryClient.cancelQueries(key);
         const previousUserData = queryClient.getQueryData<IUserData>(key);
         queryClient.setQueryData<IUserData>(key, {
@@ -104,10 +106,10 @@ export const useUpdateUserDataMutation = () => {
       },
       onError: (_, __, previousUserData) => {
         if (previousUserData) {
-          queryClient.setQueryData(userDataQueryKey(), previousUserData);
+          queryClient.setQueryData(draftQueryKeys.userData, previousUserData);
         }
       },
-      onSettled: () => queryClient.invalidateQueries(userDataQueryKey()),
+      onSettled: () => queryClient.invalidateQueries(draftQueryKeys.userData),
     },
   );
 };
@@ -116,16 +118,12 @@ interface StatusStateMachineParams {
   articleId?: number;
 }
 
-export const draftStatusStateMachineQueryKey = (params?: Partial<StatusStateMachineParams>) => [
-  DRAFT_STATUS_STATE_MACHINE,
-  params,
-];
 export const useDraftStatusStateMachine = (
   params: StatusStateMachineParams = {},
   options?: UseQueryOptions<DraftStatusStateMachineType>,
 ) => {
   return useQuery<DraftStatusStateMachineType>(
-    draftStatusStateMachineQueryKey(params),
+    draftQueryKeys.statusStateMachine(params),
     () => fetchStatusStateMachine(params.articleId),
     options,
   );

--- a/src/modules/frontpage/filmMutations.ts
+++ b/src/modules/frontpage/filmMutations.ts
@@ -26,7 +26,7 @@ export const useUpdateFilmFrontpageMutation = () => {
           queryClient.setQueryData(filmQueryKeys.filmFrontpage, previousFrontpage);
         }
       },
-      onSettled: () => queryClient.invalidateQueries(filmQueryKeys.filmFrontpage),
+      onSettled: () => queryClient.invalidateQueries({ queryKey: filmQueryKeys.filmFrontpage }),
     },
   );
 };

--- a/src/modules/frontpage/filmMutations.ts
+++ b/src/modules/frontpage/filmMutations.ts
@@ -12,7 +12,7 @@ import {
   INewOrUpdatedFilmFrontPageData,
 } from '@ndla/types-backend/frontpage-api';
 import { updateFilmFrontpage } from './frontpageApi';
-import { filmFrontpageQueryKey } from './filmQueries';
+import { filmQueryKeys } from './filmQueries';
 
 export const useUpdateFilmFrontpageMutation = () => {
   const queryClient = useQueryClient();
@@ -23,10 +23,10 @@ export const useUpdateFilmFrontpageMutation = () => {
     {
       onError: (_, __, previousFrontpage) => {
         if (previousFrontpage) {
-          queryClient.setQueryData(filmFrontpageQueryKey(), previousFrontpage);
+          queryClient.setQueryData(filmQueryKeys.filmFrontpage, previousFrontpage);
         }
       },
-      onSettled: () => queryClient.invalidateQueries(filmFrontpageQueryKey()),
+      onSettled: () => queryClient.invalidateQueries(filmQueryKeys.filmFrontpage),
     },
   );
 };

--- a/src/modules/frontpage/filmQueries.ts
+++ b/src/modules/frontpage/filmQueries.ts
@@ -17,10 +17,17 @@ import { FILM_FRONTPAGE_QUERY, FILM_SLIDESHOW } from '../../queryKeys';
 import { getIdFromUrn } from '../../util/ndlaFilmHelpers';
 import { sortMoviesByIdList } from '../../containers/NdlaFilm/filmUtil';
 
-export const filmFrontpageQueryKey = () => [FILM_FRONTPAGE_QUERY];
+export const filmQueryKeys = {
+  filmFrontpage: [FILM_FRONTPAGE_QUERY],
+  movies: (params: UseMovies) => [FILM_SLIDESHOW, params] as const,
+};
 
 export const useFilmFrontpageQuery = (options?: UseQueryOptions<IFilmFrontPageData>) => {
-  return useQuery<IFilmFrontPageData>(filmFrontpageQueryKey(), () => fetchFilmFrontpage(), options);
+  return useQuery<IFilmFrontPageData>(
+    filmQueryKeys.filmFrontpage,
+    () => fetchFilmFrontpage(),
+    options,
+  );
 };
 
 const slideshowArticlesQueryObject = {
@@ -34,8 +41,6 @@ export interface UseMovies {
   movieUrns: string[];
 }
 
-export const moviesQueryKey = (params?: Partial<UseMovies>) => [FILM_SLIDESHOW, params];
-
 export const useMoviesQuery = (
   params: UseMovies,
   options: UseQueryOptions<IMultiSearchResult> = {},
@@ -47,7 +52,7 @@ export const useMoviesQuery = (
   const ids = sortBy(movieIds).join(',');
 
   return useQuery<IMultiSearchResult>(
-    [FILM_SLIDESHOW, params],
+    filmQueryKeys.movies(params),
     () => searchResources({ ...slideshowArticlesQueryObject, ids: ids }),
     {
       select: (res) => ({ ...res, results: sortMoviesByIdList(movieIds, res.results, i18n) }),

--- a/src/modules/frontpage/frontpageMutations.ts
+++ b/src/modules/frontpage/frontpageMutations.ts
@@ -9,11 +9,11 @@
 import { IFrontPage } from '@ndla/types-backend/frontpage-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postFrontpage } from './frontpageApi';
-import { frontpageQueryKey } from './frontpageQueries';
+import { frontpageQueryKeys } from './frontpageQueries';
 
 export const useUpdateFrontpageMutation = () => {
   const qc = useQueryClient();
   return useMutation<IFrontPage, unknown, IFrontPage>(postFrontpage, {
-    onSettled: () => qc.invalidateQueries(frontpageQueryKey()),
+    onSettled: () => qc.invalidateQueries(frontpageQueryKeys.frontpage),
   });
 };

--- a/src/modules/frontpage/frontpageMutations.ts
+++ b/src/modules/frontpage/frontpageMutations.ts
@@ -14,6 +14,6 @@ import { frontpageQueryKeys } from './frontpageQueries';
 export const useUpdateFrontpageMutation = () => {
   const qc = useQueryClient();
   return useMutation<IFrontPage, unknown, IFrontPage>(postFrontpage, {
-    onSettled: () => qc.invalidateQueries(frontpageQueryKeys.frontpage),
+    onSettled: () => qc.invalidateQueries({ queryKey: frontpageQueryKeys.frontpage }),
   });
 };

--- a/src/modules/frontpage/frontpageQueries.ts
+++ b/src/modules/frontpage/frontpageQueries.ts
@@ -11,8 +11,10 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { FRONTPAGE } from '../../queryKeys';
 import { fetchFrontpage } from './frontpageApi';
 
-export const frontpageQueryKey = () => [FRONTPAGE];
+export const frontpageQueryKeys = {
+  frontpage: [FRONTPAGE] as const,
+};
 
 export const useFrontpage = (options?: UseQueryOptions<IFrontPage>) => {
-  return useQuery<IFrontPage>(frontpageQueryKey(), () => fetchFrontpage(), options);
+  return useQuery<IFrontPage>(frontpageQueryKeys.frontpage, () => fetchFrontpage(), options);
 };

--- a/src/modules/image/imageQueries.ts
+++ b/src/modules/image/imageQueries.ts
@@ -20,15 +20,17 @@ export interface UseImage {
   language?: string;
 }
 
-export const imageQueryKey = (params?: Partial<UseImage>) => [IMAGE, params];
+export const imageQueryKeys = {
+  image: (params?: Partial<UseImage>) => [IMAGE, params] as const,
+  search: (params?: Partial<ISearchParams>) => [SEARCH_IMAGES, params] as const,
+};
+
 export const useImage = (params: UseImage, options?: UseQueryOptions<IImageMetaInformationV3>) =>
   useQuery<IImageMetaInformationV3>(
-    imageQueryKey(params),
+    imageQueryKeys.image(params),
     () => fetchImage(params.id, params.language),
     options,
   );
 
-export const searchImagesQueryKey = (params?: Partial<ISearchParams>) => [SEARCH_IMAGES, params];
-
 export const useSearchImages = (query: ISearchParams, options?: UseQueryOptions<ISearchResultV3>) =>
-  useQuery<ISearchResultV3>(searchImagesQueryKey(query), () => searchImages(query), options);
+  useQuery<ISearchResultV3>(imageQueryKeys.search(query), () => searchImages(query), options);

--- a/src/modules/nodes/nodeMutations.ts
+++ b/src/modules/nodes/nodeMutations.ts
@@ -38,7 +38,7 @@ import {
   putResourcesPrimary,
   PutResourcesPrimaryParams,
 } from './nodeApi';
-import { childNodesWithArticleTypeQueryKey, nodesQueryKey } from './nodeQueries';
+import { nodeQueryKeys } from './nodeQueries';
 import {
   createResourceResourceType,
   ResourceResourceTypePostParams,
@@ -54,7 +54,7 @@ export const useAddNodeMutation = () => {
     ({ body, taxonomyVersion }) => postNode({ body, taxonomyVersion }),
     {
       onMutate: async ({ body: newNode, taxonomyVersion }) => {
-        const key = nodesQueryKey({ taxonomyVersion, isRoot: true });
+        const key = nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
         await queryClient.cancelQueries(key);
         const previousNodes = queryClient.getQueryData<Node[]>(key) ?? [];
         const optimisticNode: Node = {
@@ -76,7 +76,7 @@ export const useAddNodeMutation = () => {
       },
       onError: (e) => handleError(e),
       onSettled: (_, __, { taxonomyVersion }) =>
-        queryClient.invalidateQueries(nodesQueryKey({ taxonomyVersion })),
+        queryClient.invalidateQueries(nodeQueryKeys.nodes({ taxonomyVersion })),
     },
   );
 };
@@ -96,12 +96,12 @@ export const useUpdateNodeMetadataMutation = () => {
     {
       onMutate: async ({ id, metadata, rootId, taxonomyVersion }) => {
         const key = rootId
-          ? childNodesWithArticleTypeQueryKey({
+          ? nodeQueryKeys.childNodes({
               taxonomyVersion,
               id: rootId,
               language: i18n.language,
             })
-          : nodesQueryKey({
+          : nodeQueryKeys.nodes({
               isContext: true,
               nodeType: 'SUBJECT',
               language: i18n.language,
@@ -118,12 +118,12 @@ export const useUpdateNodeMetadataMutation = () => {
       },
       onSettled: (_, __, { rootId, taxonomyVersion }) => {
         const key = rootId
-          ? childNodesWithArticleTypeQueryKey({
+          ? nodeQueryKeys.childNodes({
               taxonomyVersion,
               id: rootId,
               language: i18n.language,
             })
-          : nodesQueryKey({
+          : nodeQueryKeys.nodes({
               language: i18n.language,
               nodeType: 'SUBJECT',
               isContext: true,
@@ -148,12 +148,12 @@ export const useDeleteNodeMutation = () => {
     {
       onMutate: async ({ id, rootId, taxonomyVersion }) => {
         const key = rootId
-          ? childNodesWithArticleTypeQueryKey({
+          ? nodeQueryKeys.childNodes({
               taxonomyVersion,
               id: rootId,
               language: i18n.language,
             })
-          : nodesQueryKey({ taxonomyVersion, isRoot: true });
+          : nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
         await qc.cancelQueries(key);
         const prevNodes = qc.getQueryData<Node[]>(key) ?? [];
         const withoutDeleted = prevNodes.filter((s) => s.id !== id);
@@ -161,12 +161,12 @@ export const useDeleteNodeMutation = () => {
       },
       onSettled: (_, __, { rootId, taxonomyVersion }) => {
         const key = rootId
-          ? childNodesWithArticleTypeQueryKey({
+          ? nodeQueryKeys.childNodes({
               taxonomyVersion,
               id: rootId,
               language: i18n.language,
             })
-          : nodesQueryKey({ taxonomyVersion, isRoot: true });
+          : nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
         qc.invalidateQueries(key);
       },
     },

--- a/src/modules/nodes/nodeMutations.ts
+++ b/src/modules/nodes/nodeMutations.ts
@@ -55,7 +55,7 @@ export const useAddNodeMutation = () => {
     {
       onMutate: async ({ body: newNode, taxonomyVersion }) => {
         const key = nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
-        await queryClient.cancelQueries(key);
+        await queryClient.cancelQueries({ queryKey: key });
         const previousNodes = queryClient.getQueryData<Node[]>(key) ?? [];
         const optimisticNode: Node = {
           ...newNode,
@@ -76,7 +76,7 @@ export const useAddNodeMutation = () => {
       },
       onError: (e) => handleError(e),
       onSettled: (_, __, { taxonomyVersion }) =>
-        queryClient.invalidateQueries(nodeQueryKeys.nodes({ taxonomyVersion })),
+        queryClient.invalidateQueries({ queryKey: nodeQueryKeys.nodes({ taxonomyVersion }) }),
     },
   );
 };
@@ -107,7 +107,7 @@ export const useUpdateNodeMetadataMutation = () => {
               language: i18n.language,
               taxonomyVersion,
             });
-        await qc.cancelQueries(key);
+        await qc.cancelQueries({ queryKey: key });
         const prevNodes = qc.getQueryData<Node[]>(key) ?? [];
         const newNodes = prevNodes.map((node) => {
           if (node.id === id) {
@@ -129,7 +129,7 @@ export const useUpdateNodeMetadataMutation = () => {
               isContext: true,
               taxonomyVersion,
             });
-        qc.invalidateQueries(key);
+        qc.invalidateQueries({ queryKey: key });
       },
     },
   );
@@ -154,7 +154,7 @@ export const useDeleteNodeMutation = () => {
               language: i18n.language,
             })
           : nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
-        await qc.cancelQueries(key);
+        await qc.cancelQueries({ queryKey: key });
         const prevNodes = qc.getQueryData<Node[]>(key) ?? [];
         const withoutDeleted = prevNodes.filter((s) => s.id !== id);
         qc.setQueryData<Node[]>(key, withoutDeleted);
@@ -167,7 +167,7 @@ export const useDeleteNodeMutation = () => {
               language: i18n.language,
             })
           : nodeQueryKeys.nodes({ taxonomyVersion, isRoot: true });
-        qc.invalidateQueries(key);
+        qc.invalidateQueries({ queryKey: key });
       },
     },
   );

--- a/src/modules/search/searchQueries.ts
+++ b/src/modules/search/searchQueries.ts
@@ -16,7 +16,9 @@ import { getAccessToken, getAccessTokenPersonal } from '../../util/authHelpers';
 import { isValid } from '../../util/jwtHelper';
 import { FAVOURITES_SUBJECT_ID } from '../../constants';
 
-export const searchQueryKey = (params?: Partial<MultiSearchApiQuery>) => [SEARCH, params];
+export const searchQueryKeys = {
+  search: (params?: Partial<MultiSearchApiQuery>) => [SEARCH, params] as const,
+};
 
 export interface UseSearch extends MultiSearchApiQuery {
   favoriteSubjects?: string[];
@@ -34,8 +36,12 @@ export const useSearch = (query: UseSearch, options?: UseQueryOptions<IMultiSear
     subjects: isFav ? data?.favoriteSubjects?.join(',') : query.subjects,
   };
 
-  return useQuery<IMultiSearchResult>(searchQueryKey(actualQuery), () => search(actualQuery), {
-    ...options,
-    enabled: options?.enabled && !isInitialLoading,
-  });
+  return useQuery<IMultiSearchResult>(
+    searchQueryKeys.search(actualQuery),
+    () => search(actualQuery),
+    {
+      ...options,
+      enabled: options?.enabled && !isInitialLoading,
+    },
+  );
 };

--- a/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
+++ b/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
@@ -12,32 +12,34 @@ import { fetchAllResourceTypes, fetchResourceType } from '.';
 import { WithTaxonomyVersion } from '../../../interfaces';
 import { RESOURCE_TYPE, RESOURCE_TYPES } from '../../../queryKeys';
 
+export const resourceTypeQueryKeys = {
+  resourceType: (params?: Partial<UseResourceTypeParams>) => [RESOURCE_TYPE, params] as const,
+  resourceTypes: (params?: Partial<UseAllResourceTypesParams>) => [RESOURCE_TYPES, params] as const,
+};
+
 interface UseResourceTypeParams extends WithTaxonomyVersion {
   id: string;
   language: string;
 }
-export const resourceTypeQueryKey = (params?: Partial<UseResourceTypeParams>) => [
-  RESOURCE_TYPE,
-  params,
-];
 export const useResourceType = (
   params: UseResourceTypeParams,
   options?: UseQueryOptions<ResourceType>,
-) => useQuery<ResourceType>(resourceTypeQueryKey(params), () => fetchResourceType(params), options);
+) =>
+  useQuery<ResourceType>(
+    resourceTypeQueryKeys.resourceType(params),
+    () => fetchResourceType(params),
+    options,
+  );
 
 interface UseAllResourceTypesParams extends WithTaxonomyVersion {
   language: string;
 }
-export const resourceTypesQueryKey = (params?: Partial<UseAllResourceTypesParams>) => [
-  RESOURCE_TYPES,
-  params,
-];
 export const useAllResourceTypes = <ReturnType>(
   params: UseAllResourceTypesParams,
   options?: UseQueryOptions<ResourceType[], unknown, ReturnType>,
 ) =>
   useQuery<ResourceType[], unknown, ReturnType>(
-    resourceTypesQueryKey(params),
+    resourceTypeQueryKeys.resourceTypes(params),
     () => fetchAllResourceTypes(params),
     options,
   );

--- a/src/modules/taxonomy/versions/versionQueries.ts
+++ b/src/modules/taxonomy/versions/versionQueries.ts
@@ -12,16 +12,23 @@ import { VERSION, VERSIONS } from '../../../queryKeys';
 import { fetchVersion, fetchVersions } from './versionApi';
 import { GetVersionsParams } from './versionApiTypes';
 
+export const versionQueryKeys = {
+  version: (params?: Partial<UseVersionParams>) => [VERSION, params] as const,
+  versions: (params?: Partial<UseVersionsParams>) => [VERSIONS, params] as const,
+};
+
 interface UseVersionsParams extends GetVersionsParams {}
-export const versionsQueryKey = (params?: Partial<UseVersionsParams>) => [VERSIONS, params];
 export const useVersions = (params?: UseVersionsParams, options?: UseQueryOptions<Version[]>) => {
-  return useQuery<Version[]>(versionsQueryKey(params), () => fetchVersions({ ...params }), options);
+  return useQuery<Version[]>(
+    versionQueryKeys.versions(params),
+    () => fetchVersions({ ...params }),
+    options,
+  );
 };
 
 interface UseVersionParams {
   id: string;
 }
-export const versionQueryKey = (params?: Partial<UseVersionParams>) => [VERSION, params];
-export const useVersion = ({ id }: UseVersionParams, options?: UseQueryOptions<Version>) => {
-  return useQuery<Version>([VERSION, id], () => fetchVersion({ id }), options);
+export const useVersion = (params: UseVersionParams, options?: UseQueryOptions<Version>) => {
+  return useQuery<Version>([versionQueryKeys.version(params)], () => fetchVersion(params), options);
 };

--- a/src/queryKeys.ts
+++ b/src/queryKeys.ts
@@ -67,3 +67,5 @@ export const RESOURCE_META = 'resourceMeta';
 
 export const VERSION = 'version';
 export const VERSIONS = 'versions';
+
+export const TRANFSFORM_ARTICLE = 'transformArticle';


### PR DESCRIPTION
Har begynt å se på migrering til nyeste react query-versjonen. Tenker vi kan prøve å gjøre bruk av react query litt enklere i samme slengen. Har tatt inspirasjon for denne PR'en herifra: https://tkdodo.eu/blog/effective-react-query-keys

Lurer litt på om vi kanskje skulle hatt ett stort `query`-objekt som inneholder alt av queries man kan gjøre i appen. Det gjør kanskje discoverability litt enklere?