### PR TITLE
Make internal hooks use object syntax

### DIFF
--- a/src/components/ResourcePage.tsx
+++ b/src/components/ResourcePage.tsx
@@ -63,7 +63,7 @@ interface Props<T extends BaseResource> {
   className?: string;
   useHook: (
     params: { id: number; language?: string },
-    options?: UseQueryOptions<T>,
+    options?: Partial<UseQueryOptions<T>>,
   ) => UseQueryResult<T>;
   createUrl: string;
   titleTranslationKey?: string;
@@ -114,7 +114,7 @@ interface EditResourceRedirectProps<T extends BaseResource> {
   isNewlyCreated: boolean;
   useHook: (
     params: { id: number; language?: string },
-    options?: UseQueryOptions<T>,
+    options?: Partial<UseQueryOptions<T>>,
   ) => UseQueryResult<T>;
   Component: ComponentType<ResourceComponentProps>;
 }

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
@@ -44,10 +44,10 @@ interface Props<ParamType extends BaseParams, InnerType, ApiType, Type = ApiType
   onChange: (value: InnerType) => void;
   useQuery: (
     params: ParamType,
-    options?: UseQueryOptions<ApiType, unknown, Type>,
+    options?: Partial<UseQueryOptions<ApiType, unknown, Type>>,
   ) => UseQueryResult<Type, unknown>;
   params?: ParamType;
-  options?: UseQueryOptions<ApiType, unknown, Type>;
+  options?: Partial<UseQueryOptions<ApiType, unknown, Type>>;
   transform: (value: Type) => SearchResultBase<DropdownItem<InnerType>>;
   placeholder: string;
   preload?: boolean;

--- a/src/modules/article/articleGqlQueries.ts
+++ b/src/modules/article/articleGqlQueries.ts
@@ -35,7 +35,7 @@ export const usePreviewArticle = (
   content: string,
   language: string,
   visualElement?: string,
-  options?: UseQueryOptions<string>,
+  options?: Partial<UseQueryOptions<string>>,
 ): UseQueryResult<string> => {
   return useTransformArticle(
     {
@@ -76,11 +76,11 @@ interface ReturnData {
 
 export const useTransformArticle = (
   params: UseTransformArticle,
-  options?: UseQueryOptions<string>,
+  options?: Partial<UseQueryOptions<string>>,
 ): UseQueryResult<string> => {
-  return useQuery<string>(
-    transformArticleQueryKeys.transformArticle(params),
-    async (): Promise<string> => {
+  return useQuery<string>({
+    queryKey: transformArticleQueryKeys.transformArticle(params),
+    queryFn: async (): Promise<string> => {
       const res = await request<ReturnData, UseTransformArticle>(
         gqlEndpoint,
         transformArticleMutation,
@@ -91,6 +91,6 @@ export const useTransformArticle = (
       );
       return res.transformArticleContent;
     },
-    options,
-  );
+    ...options,
+  });
 };

--- a/src/modules/article/articleQueries.ts
+++ b/src/modules/article/articleQueries.ts
@@ -17,11 +17,11 @@ export const articleQueryKeys = {
 
 export const useArticleSearch = (
   params: ArticleSearchParams,
-  options?: UseQueryOptions<ISearchResultV2>,
+  options?: Partial<UseQueryOptions<ISearchResultV2>>,
 ) => {
-  return useQuery<ISearchResultV2>(
-    articleQueryKeys.search(params),
-    () => searchArticles(params),
-    options,
-  );
+  return useQuery<ISearchResultV2>({
+    queryKey: articleQueryKeys.search(params),
+    queryFn: () => searchArticles(params),
+    ...options,
+  });
 };

--- a/src/modules/audio/audioQueries.ts
+++ b/src/modules/audio/audioQueries.ts
@@ -29,41 +29,44 @@ export const audioQueryKeys = {
   podcastSeriesSearch: (params?: Partial<SeriesSearchParams>) => [SEARCH_SERIES, params] as const,
 };
 
-export const useAudio = (params: UseAudio, options?: UseQueryOptions<IAudioMetaInformation>) =>
-  useQuery<IAudioMetaInformation>(
-    audioQueryKeys.audio(params),
-    () => fetchAudio(params.id, params.language),
-    options,
-  );
+export const useAudio = (
+  params: UseAudio,
+  options?: Partial<UseQueryOptions<IAudioMetaInformation>>,
+) =>
+  useQuery<IAudioMetaInformation>({
+    queryKey: audioQueryKeys.audio(params),
+    queryFn: () => fetchAudio(params.id, params.language),
+    ...options,
+  });
 
 export interface UseSeries {
   id: number;
   language?: string;
 }
 
-export const useSeries = (params: UseSeries, options?: UseQueryOptions<ISeries>) =>
-  useQuery<ISeries>(
-    audioQueryKeys.podcastSeries(params),
-    () => fetchSeries(params.id, params.language),
-    options,
-  );
+export const useSeries = (params: UseSeries, options?: Partial<UseQueryOptions<ISeries>>) =>
+  useQuery<ISeries>({
+    queryKey: audioQueryKeys.podcastSeries(params),
+    queryFn: () => fetchSeries(params.id, params.language),
+    ...options,
+  });
 
 export const useSearchSeries = (
   query: SeriesSearchParams,
-  options?: UseQueryOptions<ISeriesSummarySearchResult>,
+  options?: Partial<UseQueryOptions<ISeriesSummarySearchResult>>,
 ) =>
-  useQuery<ISeriesSummarySearchResult>(
-    audioQueryKeys.podcastSeriesSearch(query),
-    () => searchSeries(query),
-    options,
-  );
+  useQuery<ISeriesSummarySearchResult>({
+    queryKey: audioQueryKeys.podcastSeriesSearch(query),
+    queryFn: () => searchSeries(query),
+    ...options,
+  });
 
 export const useSearchAudio = (
   query: AudioSearchParams,
-  options?: UseQueryOptions<IAudioSummarySearchResult>,
+  options?: Partial<UseQueryOptions<IAudioSummarySearchResult>>,
 ) =>
-  useQuery<IAudioSummarySearchResult>(
-    audioQueryKeys.search(query),
-    () => searchAudio(query),
-    options,
-  );
+  useQuery<IAudioSummarySearchResult>({
+    queryKey: audioQueryKeys.search(query),
+    queryFn: () => searchAudio(query),
+    ...options,
+  });

--- a/src/modules/auth0/auth0Queries.ts
+++ b/src/modules/auth0/auth0Queries.ts
@@ -21,32 +21,35 @@ export const auth0QueryKeys = {
   responsibles: (params?: Partial<Auth0Editors>) => [AUTH0_RESPONSIBLES, params] as const,
 };
 
-export const useAuth0Users = (params: Auth0Users, options: UseQueryOptions<Auth0UserData[]>) =>
-  useQuery<Auth0UserData[]>(
-    auth0QueryKeys.users(params),
-    () => fetchAuth0Users(params.uniqueUserIds),
-    options,
-  );
+export const useAuth0Users = (
+  params: Auth0Users,
+  options: Partial<UseQueryOptions<Auth0UserData[]>>,
+) =>
+  useQuery<Auth0UserData[]>({
+    queryKey: auth0QueryKeys.users(params),
+    queryFn: () => fetchAuth0Users(params.uniqueUserIds),
+    ...options,
+  });
 
 export interface Auth0Editors {
   permission: string;
 }
 
 export const useAuth0Editors = <ReturnType>(
-  options: UseQueryOptions<Auth0UserData[], unknown, ReturnType>,
+  options: Partial<UseQueryOptions<Auth0UserData[], unknown, ReturnType>>,
 ) =>
-  useQuery<Auth0UserData[], unknown, ReturnType>(
-    auth0QueryKeys.editors,
-    () => fetchAuth0Editors(),
-    options,
-  );
+  useQuery<Auth0UserData[], unknown, ReturnType>({
+    queryKey: auth0QueryKeys.editors,
+    queryFn: () => fetchAuth0Editors(),
+    ...options,
+  });
 
 export const useAuth0Responsibles = <ReturnType>(
   params: Auth0Editors,
-  options: UseQueryOptions<Auth0UserData[], unknown, ReturnType>,
+  options: Partial<UseQueryOptions<Auth0UserData[], unknown, ReturnType>>,
 ) =>
-  useQuery<Auth0UserData[], unknown, ReturnType>(
-    auth0QueryKeys.responsibles(params),
-    () => fetchAuth0Responsibles(params.permission),
-    options,
-  );
+  useQuery<Auth0UserData[], unknown, ReturnType>({
+    queryKey: auth0QueryKeys.responsibles(params),
+    queryFn: () => fetchAuth0Responsibles(params.permission),
+    ...options,
+  });

--- a/src/modules/concept/conceptQueries.ts
+++ b/src/modules/concept/conceptQueries.ts
@@ -24,30 +24,30 @@ export const conceptQueryKeys = {
   statusStateMachine: [CONCEPT_STATE_MACHINE] as const,
 };
 
-export const useConcept = (params: UseConcept, options?: UseQueryOptions<IConcept>) => {
-  return useQuery<IConcept>(
-    conceptQueryKeys.concept(params),
-    () => fetchConcept(params.id, params.language),
-    options,
-  );
+export const useConcept = (params: UseConcept, options?: Partial<UseQueryOptions<IConcept>>) => {
+  return useQuery<IConcept>({
+    queryKey: conceptQueryKeys.concept(params),
+    queryFn: () => fetchConcept(params.id, params.language),
+    ...options,
+  });
 };
 
 export const useSearchConcepts = (
   query: ConceptQuery,
-  options?: UseQueryOptions<IConceptSearchResult>,
+  options?: Partial<UseQueryOptions<IConceptSearchResult>>,
 ) =>
-  useQuery<IConceptSearchResult>(
-    conceptQueryKeys.searchConcepts(query),
-    () => searchConcepts(query),
-    options,
-  );
+  useQuery<IConceptSearchResult>({
+    queryKey: conceptQueryKeys.searchConcepts(query),
+    queryFn: () => searchConcepts(query),
+    ...options,
+  });
 
 export const useConceptStateMachine = (
-  options?: UseQueryOptions<ConceptStatusStateMachineType>,
+  options?: Partial<UseQueryOptions<ConceptStatusStateMachineType>>,
 ) => {
-  return useQuery<ConceptStatusStateMachineType>(
-    conceptQueryKeys.statusStateMachine,
-    () => fetchStatusStateMachine(),
-    options,
-  );
+  return useQuery<ConceptStatusStateMachineType>({
+    queryKey: conceptQueryKeys.statusStateMachine,
+    queryFn: () => fetchStatusStateMachine(),
+    ...options,
+  });
 };

--- a/src/modules/draft/draftMutations.ts
+++ b/src/modules/draft/draftMutations.ts
@@ -11,19 +11,19 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { copyRevisionDates, updateDraft } from './draftApi';
 
 export const useUpdateDraftMutation = (
-  options?: UseMutationOptions<IArticle, unknown, { id: number; body: IUpdatedArticle }>,
+  options?: Partial<UseMutationOptions<IArticle, unknown, { id: number; body: IUpdatedArticle }>>,
 ) => {
-  return useMutation<IArticle, undefined, { id: number; body: IUpdatedArticle }>(
-    (vars) => updateDraft(vars.id, vars.body),
-    options,
-  );
+  return useMutation<IArticle, undefined, { id: number; body: IUpdatedArticle }>({
+    mutationFn: (vars) => updateDraft(vars.id, vars.body),
+    ...options,
+  });
 };
 
 export const useCopyRevisionDates = (
   options?: UseMutationOptions<void, unknown, { nodeId: string }>,
 ) => {
-  return useMutation<void, unknown, { nodeId: string }>(
-    (vars) => copyRevisionDates(vars.nodeId),
-    options,
-  );
+  return useMutation<void, unknown, { nodeId: string }>({
+    mutationFn: (vars) => copyRevisionDates(vars.nodeId),
+    ...options,
+  });
 };

--- a/src/modules/draft/draftQueries.ts
+++ b/src/modules/draft/draftQueries.ts
@@ -49,12 +49,12 @@ export const draftQueryKeys = {
 
 draftQueryKeys.draft({ id: 1 });
 
-export const useDraft = (params: UseDraft, options?: UseQueryOptions<IArticle>) => {
-  return useQuery<IArticle>(
-    draftQueryKeys.draft(params),
-    () => fetchDraft(params.id, params.language),
-    options,
-  );
+export const useDraft = (params: UseDraft, options?: Partial<UseQueryOptions<IArticle>>) => {
+  return useQuery<IArticle>({
+    queryKey: draftQueryKeys.draft(params),
+    queryFn: () => fetchDraft(params.id, params.language),
+    ...options,
+  });
 };
 interface UseSearchDrafts extends DraftSearchQuery {
   ids: number[];
@@ -62,19 +62,21 @@ interface UseSearchDrafts extends DraftSearchQuery {
 
 export const useSearchDrafts = (
   params: UseSearchDrafts,
-  options?: UseQueryOptions<ISearchResult>,
+  options?: Partial<UseQueryOptions<ISearchResult>>,
 ) => {
-  return useQuery<ISearchResult>(
-    draftQueryKeys.search(params),
-    () => searchAllDrafts(params.ids, params.language, params.sort),
-    options,
-  );
+  return useQuery<ISearchResult>({
+    queryKey: draftQueryKeys.search(params),
+    queryFn: () => searchAllDrafts(params.ids, params.language, params.sort),
+    ...options,
+  });
 };
 
 export const useLicenses = <ReturnType = ILicense[]>(
-  options?: UseQueryOptions<ILicense[], unknown, ReturnType>,
+  options?: Partial<UseQueryOptions<ILicense[], unknown, ReturnType>>,
 ) =>
-  useQuery<ILicense[], unknown, ReturnType>(draftQueryKeys.licenses, fetchLicenses, {
+  useQuery<ILicense[], unknown, ReturnType>({
+    queryKey: draftQueryKeys.licenses,
+    queryFn: fetchLicenses,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     refetchOnReconnect: false,
@@ -83,8 +85,12 @@ export const useLicenses = <ReturnType = ILicense[]>(
     ...options,
   });
 
-export const useUserData = (options?: UseQueryOptions<IUserData | undefined>) =>
-  useQuery<IUserData | undefined>(draftQueryKeys.userData, fetchUserData, options);
+export const useUserData = (options?: Partial<UseQueryOptions<IUserData | undefined>>) =>
+  useQuery<IUserData | undefined>({
+    queryKey: draftQueryKeys.userData,
+    queryFn: fetchUserData,
+    ...options,
+  });
 
 export const useUpdateUserDataMutation = () => {
   const queryClient = useQueryClient();
@@ -120,11 +126,11 @@ interface StatusStateMachineParams {
 
 export const useDraftStatusStateMachine = (
   params: StatusStateMachineParams = {},
-  options?: UseQueryOptions<DraftStatusStateMachineType>,
+  options?: Partial<UseQueryOptions<DraftStatusStateMachineType>>,
 ) => {
-  return useQuery<DraftStatusStateMachineType>(
-    draftQueryKeys.statusStateMachine(params),
-    () => fetchStatusStateMachine(params.articleId),
-    options,
-  );
+  return useQuery<DraftStatusStateMachineType>({
+    queryKey: draftQueryKeys.statusStateMachine(params),
+    queryFn: () => fetchStatusStateMachine(params.articleId),
+    ...options,
+  });
 };

--- a/src/modules/embed/queries.ts
+++ b/src/modules/embed/queries.ts
@@ -20,19 +20,25 @@ import {
 export const useAudioMeta = (
   resourceId: string,
   language: string,
-  options?: UseQueryOptions<AudioMeta>,
+  options?: Partial<UseQueryOptions<AudioMeta>>,
 ) => {
-  return useQuery<AudioMeta>(
-    [AUDIO_EMBED, resourceId, language],
-    () => fetchAudioMeta(resourceId, language),
-    options,
-  );
+  return useQuery<AudioMeta>({
+    queryKey: [AUDIO_EMBED, resourceId, language],
+    queryFn: () => fetchAudioMeta(resourceId, language),
+    ...options,
+  });
 };
 
-export const useH5pMeta = (path: string, url: string, options?: UseQueryOptions<H5pData>) => {
-  return useQuery<H5pData>(['h5pMeta', path, url], () => fetchH5pMeta(path, url), {
-    ...options,
+export const useH5pMeta = (
+  path: string,
+  url: string,
+  options?: Partial<UseQueryOptions<H5pData>>,
+) => {
+  return useQuery<H5pData>({
     retry: false,
+    queryKey: ['h5pMeta', path, url],
+    queryFn: () => fetchH5pMeta(path, url),
+    ...options,
   });
 };
 
@@ -40,16 +46,14 @@ export const useConceptVisualElement = (
   conceptId: number,
   visualElement: string,
   language: string,
-  options?: UseQueryOptions<ConceptVisualElementMeta | undefined>,
+  options?: Partial<UseQueryOptions<ConceptVisualElementMeta | undefined>>,
 ) => {
-  return useQuery<ConceptVisualElementMeta | undefined>(
-    ['conceptVisualElement', conceptId, language],
-    () => fetchConceptVisualElement(visualElement, language),
-    {
-      ...options,
-      retry: false,
-    },
-  );
+  return useQuery<ConceptVisualElementMeta | undefined>({
+    retry: false,
+    queryKey: ['conceptVisualElement', conceptId, language],
+    queryFn: () => fetchConceptVisualElement(visualElement, language),
+    ...options,
+  });
 };
 
 export const useConceptListMeta = (
@@ -57,11 +61,12 @@ export const useConceptListMeta = (
   subject: string | undefined,
   language: string,
   concepts: IConceptSummary[],
-  options?: UseQueryOptions<ConceptListData>,
+  options?: Partial<UseQueryOptions<ConceptListData>>,
 ) => {
-  return useQuery<ConceptListData>(
-    ['conceptListMeta', tag, subject],
-    () => fetchConceptListMeta(concepts, language),
-    { ...options, retry: false },
-  );
+  return useQuery<ConceptListData>({
+    retry: false,
+    queryKey: ['conceptListMeta', tag, subject],
+    queryFn: () => fetchConceptListMeta(concepts, language),
+    ...options,
+  });
 };

--- a/src/modules/frontpage/filmMutations.ts
+++ b/src/modules/frontpage/filmMutations.ts
@@ -16,17 +16,13 @@ import { filmQueryKeys } from './filmQueries';
 
 export const useUpdateFilmFrontpageMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation<IFilmFrontPageData, unknown, INewOrUpdatedFilmFrontPageData>(
-    (data) => {
-      return updateFilmFrontpage(data);
+  return useMutation<IFilmFrontPageData, unknown, INewOrUpdatedFilmFrontPageData>({
+    mutationFn: (data) => updateFilmFrontpage(data),
+    onError: (_, __, previousFrontpage) => {
+      if (previousFrontpage) {
+        queryClient.setQueryData(filmQueryKeys.filmFrontpage, previousFrontpage);
+      }
     },
-    {
-      onError: (_, __, previousFrontpage) => {
-        if (previousFrontpage) {
-          queryClient.setQueryData(filmQueryKeys.filmFrontpage, previousFrontpage);
-        }
-      },
-      onSettled: () => queryClient.invalidateQueries({ queryKey: filmQueryKeys.filmFrontpage }),
-    },
-  );
+    onSettled: () => queryClient.invalidateQueries({ queryKey: filmQueryKeys.filmFrontpage }),
+  });
 };

--- a/src/modules/frontpage/filmQueries.ts
+++ b/src/modules/frontpage/filmQueries.ts
@@ -22,12 +22,12 @@ export const filmQueryKeys = {
   movies: (params: UseMovies) => [FILM_SLIDESHOW, params] as const,
 };
 
-export const useFilmFrontpageQuery = (options?: UseQueryOptions<IFilmFrontPageData>) => {
-  return useQuery<IFilmFrontPageData>(
-    filmQueryKeys.filmFrontpage,
-    () => fetchFilmFrontpage(),
-    options,
-  );
+export const useFilmFrontpageQuery = (options?: Partial<UseQueryOptions<IFilmFrontPageData>>) => {
+  return useQuery<IFilmFrontPageData>({
+    queryKey: filmQueryKeys.filmFrontpage,
+    queryFn: () => fetchFilmFrontpage(),
+    ...options,
+  });
 };
 
 const slideshowArticlesQueryObject = {
@@ -43,7 +43,7 @@ export interface UseMovies {
 
 export const useMoviesQuery = (
   params: UseMovies,
-  options: UseQueryOptions<IMultiSearchResult> = {},
+  options: Partial<UseQueryOptions<IMultiSearchResult>> = {},
 ) => {
   const { i18n } = useTranslation();
   const movieIds = params.movieUrns
@@ -51,12 +51,10 @@ export const useMoviesQuery = (
     .filter((id) => !isNaN(id));
   const ids = sortBy(movieIds).join(',');
 
-  return useQuery<IMultiSearchResult>(
-    filmQueryKeys.movies(params),
-    () => searchResources({ ...slideshowArticlesQueryObject, ids: ids }),
-    {
-      select: (res) => ({ ...res, results: sortMoviesByIdList(movieIds, res.results, i18n) }),
-      ...options,
-    },
-  );
+  return useQuery<IMultiSearchResult>({
+    queryKey: filmQueryKeys.movies(params),
+    queryFn: () => searchResources({ ...slideshowArticlesQueryObject, ids: ids }),
+    select: (res) => ({ ...res, results: sortMoviesByIdList(movieIds, res.results, i18n) }),
+    ...options,
+  });
 };

--- a/src/modules/frontpage/frontpageMutations.ts
+++ b/src/modules/frontpage/frontpageMutations.ts
@@ -13,7 +13,8 @@ import { frontpageQueryKeys } from './frontpageQueries';
 
 export const useUpdateFrontpageMutation = () => {
   const qc = useQueryClient();
-  return useMutation<IFrontPage, unknown, IFrontPage>(postFrontpage, {
+  return useMutation<IFrontPage, unknown, IFrontPage>({
+    mutationFn: postFrontpage,
     onSettled: () => qc.invalidateQueries({ queryKey: frontpageQueryKeys.frontpage }),
   });
 };

--- a/src/modules/frontpage/frontpageQueries.ts
+++ b/src/modules/frontpage/frontpageQueries.ts
@@ -15,6 +15,10 @@ export const frontpageQueryKeys = {
   frontpage: [FRONTPAGE] as const,
 };
 
-export const useFrontpage = (options?: UseQueryOptions<IFrontPage>) => {
-  return useQuery<IFrontPage>(frontpageQueryKeys.frontpage, () => fetchFrontpage(), options);
+export const useFrontpage = (options?: Partial<UseQueryOptions<IFrontPage>>) => {
+  return useQuery<IFrontPage>({
+    queryKey: frontpageQueryKeys.frontpage,
+    queryFn: () => fetchFrontpage(),
+    ...options,
+  });
 };

--- a/src/modules/image/imageQueries.ts
+++ b/src/modules/image/imageQueries.ts
@@ -25,12 +25,22 @@ export const imageQueryKeys = {
   search: (params?: Partial<ISearchParams>) => [SEARCH_IMAGES, params] as const,
 };
 
-export const useImage = (params: UseImage, options?: UseQueryOptions<IImageMetaInformationV3>) =>
-  useQuery<IImageMetaInformationV3>(
-    imageQueryKeys.image(params),
-    () => fetchImage(params.id, params.language),
-    options,
-  );
+export const useImage = (
+  params: UseImage,
+  options?: Partial<UseQueryOptions<IImageMetaInformationV3>>,
+) =>
+  useQuery<IImageMetaInformationV3>({
+    queryKey: imageQueryKeys.image(params),
+    queryFn: () => fetchImage(params.id, params.language),
+    ...options,
+  });
 
-export const useSearchImages = (query: ISearchParams, options?: UseQueryOptions<ISearchResultV3>) =>
-  useQuery<ISearchResultV3>(imageQueryKeys.search(query), () => searchImages(query), options);
+export const useSearchImages = (
+  query: ISearchParams,
+  options?: Partial<UseQueryOptions<ISearchResultV3>>,
+) =>
+  useQuery<ISearchResultV3>({
+    queryKey: imageQueryKeys.search(query),
+    queryFn: () => searchImages(query),
+    ...options,
+  });

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -41,8 +41,12 @@ export const nodeQueryKeys = {
 };
 
 interface UseNodesParams extends WithTaxonomyVersion, GetNodeParams {}
-export const useNodes = (params: UseNodesParams, options?: UseQueryOptions<Node[]>) => {
-  return useQuery<Node[]>(nodeQueryKeys.nodes(params), () => fetchNodes(params), options);
+export const useNodes = (params: UseNodesParams, options?: Partial<UseQueryOptions<Node[]>>) => {
+  return useQuery<Node[]>({
+    queryKey: nodeQueryKeys.nodes(params),
+    queryFn: () => fetchNodes(params),
+    ...options,
+  });
 };
 
 interface UseNodeParams extends WithTaxonomyVersion {
@@ -50,9 +54,11 @@ interface UseNodeParams extends WithTaxonomyVersion {
   language?: string;
 }
 
-export const useNode = (params: UseNodeParams, options?: UseQueryOptions<Node>) => {
+export const useNode = (params: UseNodeParams, options?: Partial<UseQueryOptions<Node>>) => {
   const qc = useQueryClient();
-  return useQuery<Node>(nodeQueryKeys.node(params), () => fetchNode(params), {
+  return useQuery<Node>({
+    queryKey: nodeQueryKeys.node(params),
+    queryFn: () => fetchNode(params),
     placeholderData: qc
       .getQueryData<Node[]>(
         nodeQueryKeys.nodes({ taxonomyVersion: params.taxonomyVersion, language: params.language }),
@@ -82,13 +88,13 @@ export interface NodeResourceMeta {
 
 export const useNodeResourceMetas = (
   params: UseNodeResourceMetas,
-  options?: UseQueryOptions<NodeResourceMeta[]>,
+  options?: Partial<UseQueryOptions<NodeResourceMeta[]>>,
 ) => {
-  return useQuery<NodeResourceMeta[]>(
-    nodeQueryKeys.resourceMetas(params),
-    () => fetchNodeResourceMetas(params),
-    options,
-  );
+  return useQuery<NodeResourceMeta[]>({
+    queryKey: nodeQueryKeys.resourceMetas(params),
+    queryFn: () => fetchNodeResourceMetas(params),
+    ...options,
+  });
 };
 
 interface ContentUriPartition {
@@ -210,8 +216,12 @@ interface UseNodeTree extends WithTaxonomyVersion {
   language: string;
 }
 
-export const useNodeTree = (params: UseNodeTree, options?: UseQueryOptions<NodeTree>) => {
-  return useQuery<NodeTree>(nodeQueryKeys.tree(params), () => fetchNodeTree(params), options);
+export const useNodeTree = (params: UseNodeTree, options?: Partial<UseQueryOptions<NodeTree>>) => {
+  return useQuery<NodeTree>({
+    queryKey: nodeQueryKeys.tree(params),
+    queryFn: () => fetchNodeTree(params),
+    ...options,
+  });
 };
 
 interface NodeTreeGetParams extends WithTaxonomyVersion {
@@ -269,13 +279,13 @@ interface UseChildNodesWithArticleTypeParams extends WithTaxonomyVersion {
 
 export const useChildNodesWithArticleType = (
   params: UseChildNodesWithArticleTypeParams,
-  options?: UseQueryOptions<(NodeChildWithChildren & { articleType?: string })[]>,
+  options?: Partial<UseQueryOptions<(NodeChildWithChildren & { articleType?: string })[]>>,
 ) => {
-  return useQuery<NodeChildWithChildren[]>(
-    nodeQueryKeys.childNodes(params),
-    () => fetchChildNodesWithArticleType(params),
-    options,
-  );
+  return useQuery<NodeChildWithChildren[]>({
+    queryKey: nodeQueryKeys.childNodes(params),
+    queryFn: () => fetchChildNodesWithArticleType(params),
+    ...options,
+  });
 };
 
 interface UseResourcesWithNodeConnectionParams extends WithTaxonomyVersion, GetNodeResourcesParams {
@@ -284,13 +294,13 @@ interface UseResourcesWithNodeConnectionParams extends WithTaxonomyVersion, GetN
 
 export const useResourcesWithNodeConnection = (
   params: UseResourcesWithNodeConnectionParams,
-  options?: UseQueryOptions<NodeChild[]>,
+  options?: Partial<UseQueryOptions<NodeChild[]>>,
 ) => {
-  return useQuery<NodeChild[]>(
-    nodeQueryKeys.resources(params),
-    () => fetchNodeResources(params),
-    options,
-  );
+  return useQuery<NodeChild[]>({
+    ...options,
+    queryKey: nodeQueryKeys.resources(params),
+    queryFn: () => fetchNodeResources(params),
+  });
 };
 
 interface UseSearchNodes extends WithTaxonomyVersion {
@@ -304,11 +314,11 @@ interface UseSearchNodes extends WithTaxonomyVersion {
 
 export const useSearchNodes = (
   params: UseSearchNodes,
-  options?: UseQueryOptions<SearchResultBase<Node>>,
+  options?: Partial<UseQueryOptions<SearchResultBase<Node>>>,
 ) => {
-  return useQuery<SearchResultBase<Node>>(
-    nodeQueryKeys.search(params),
-    () => searchNodes(params),
-    options,
-  );
+  return useQuery<SearchResultBase<Node>>({
+    queryKey: nodeQueryKeys.search(params),
+    queryFn: () => searchNodes(params),
+    ...options,
+  });
 };

--- a/src/modules/search/searchQueries.ts
+++ b/src/modules/search/searchQueries.ts
@@ -24,7 +24,10 @@ export interface UseSearch extends MultiSearchApiQuery {
   favoriteSubjects?: string[];
 }
 
-export const useSearch = (query: UseSearch, options?: UseQueryOptions<IMultiSearchResult>) => {
+export const useSearch = (
+  query: UseSearch,
+  options?: Partial<UseQueryOptions<IMultiSearchResult>>,
+) => {
   const isFav = query.subjects === FAVOURITES_SUBJECT_ID;
 
   const { data, isInitialLoading } = useUserData({
@@ -36,12 +39,10 @@ export const useSearch = (query: UseSearch, options?: UseQueryOptions<IMultiSear
     subjects: isFav ? data?.favoriteSubjects?.join(',') : query.subjects,
   };
 
-  return useQuery<IMultiSearchResult>(
-    searchQueryKeys.search(actualQuery),
-    () => search(actualQuery),
-    {
-      ...options,
-      enabled: options?.enabled && !isInitialLoading,
-    },
-  );
+  return useQuery<IMultiSearchResult>({
+    queryKey: searchQueryKeys.search(actualQuery),
+    queryFn: () => search(actualQuery),
+    ...options,
+    enabled: options?.enabled && !isInitialLoading,
+  });
 };

--- a/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
+++ b/src/modules/taxonomy/resourcetypes/resourceTypesQueries.ts
@@ -23,23 +23,23 @@ interface UseResourceTypeParams extends WithTaxonomyVersion {
 }
 export const useResourceType = (
   params: UseResourceTypeParams,
-  options?: UseQueryOptions<ResourceType>,
+  options?: Partial<UseQueryOptions<ResourceType>>,
 ) =>
-  useQuery<ResourceType>(
-    resourceTypeQueryKeys.resourceType(params),
-    () => fetchResourceType(params),
-    options,
-  );
+  useQuery<ResourceType>({
+    queryKey: resourceTypeQueryKeys.resourceType(params),
+    queryFn: () => fetchResourceType(params),
+    ...options,
+  });
 
 interface UseAllResourceTypesParams extends WithTaxonomyVersion {
   language: string;
 }
 export const useAllResourceTypes = <ReturnType>(
   params: UseAllResourceTypesParams,
-  options?: UseQueryOptions<ResourceType[], unknown, ReturnType>,
+  options?: Partial<UseQueryOptions<ResourceType[], unknown, ReturnType>>,
 ) =>
-  useQuery<ResourceType[], unknown, ReturnType>(
-    resourceTypeQueryKeys.resourceTypes(params),
-    () => fetchAllResourceTypes(params),
-    options,
-  );
+  useQuery<ResourceType[], unknown, ReturnType>({
+    queryKey: resourceTypeQueryKeys.resourceTypes(params),
+    queryFn: () => fetchAllResourceTypes(params),
+    ...options,
+  });

--- a/src/modules/taxonomy/taxonomyMutations.ts
+++ b/src/modules/taxonomy/taxonomyMutations.ts
@@ -18,22 +18,23 @@ import {
 interface UseUpdateTaxMutation extends WithTaxonomyVersion, UpdateTaxParams {}
 
 export const useUpdateTaxonomyMutation = (
-  options?: UseMutationOptions<void, unknown, UseUpdateTaxMutation>,
+  options?: Partial<UseMutationOptions<void, unknown, UseUpdateTaxMutation>>,
 ) => {
-  return useMutation<void, unknown, UseUpdateTaxMutation>(
-    ({ node, originalNode, taxonomyVersion }) => updateTax({ node, originalNode }, taxonomyVersion),
-    options,
-  );
+  return useMutation<void, unknown, UseUpdateTaxMutation>({
+    mutationFn: ({ node, originalNode, taxonomyVersion }) =>
+      updateTax({ node, originalNode }, taxonomyVersion),
+    ...options,
+  });
 };
 
 interface UseCreateTopicNodeConnections extends CreateTopicNodeConnections {}
 
 export const useCreateTopicNodeConnectionsMutation = (
-  options?: UseMutationOptions<void, unknown, UseCreateTopicNodeConnections>,
+  options?: Partial<UseMutationOptions<void, unknown, UseCreateTopicNodeConnections>>,
 ) => {
-  return useMutation<void, unknown, UseCreateTopicNodeConnections>(
-    ({ articleId, placements, name, taxonomyVersion }) =>
+  return useMutation<void, unknown, UseCreateTopicNodeConnections>({
+    mutationFn: ({ articleId, placements, name, taxonomyVersion }) =>
       createTopicNodeConnections({ articleId, placements, name, taxonomyVersion }),
-    options,
-  );
+    ...options,
+  });
 };

--- a/src/modules/taxonomy/versions/versionMutations.ts
+++ b/src/modules/taxonomy/versions/versionMutations.ts
@@ -16,12 +16,12 @@ interface UsePostVersionMutationParams {
 }
 
 export const usePostVersionMutation = (
-  options?: UseMutationOptions<string, unknown, UsePostVersionMutationParams>,
+  options?: Partial<UseMutationOptions<string, unknown, UsePostVersionMutationParams>>,
 ) => {
-  return useMutation<string, unknown, UsePostVersionMutationParams>(
-    ({ body, sourceId }) => postVersion({ body, sourceId }),
-    options,
-  );
+  return useMutation<string, unknown, UsePostVersionMutationParams>({
+    mutationFn: ({ body, sourceId }) => postVersion({ body, sourceId }),
+    ...options,
+  });
 };
 
 interface UsePutVersionMutationParams {
@@ -30,12 +30,12 @@ interface UsePutVersionMutationParams {
 }
 
 export const usePutVersionMutation = (
-  options?: UseMutationOptions<void, unknown, UsePutVersionMutationParams>,
+  options?: Partial<UseMutationOptions<void, unknown, UsePutVersionMutationParams>>,
 ) => {
-  return useMutation<void, unknown, UsePutVersionMutationParams>(
-    ({ id, body }) => putVersion({ id, body }),
-    options,
-  );
+  return useMutation<void, unknown, UsePutVersionMutationParams>({
+    mutationFn: ({ id, body }) => putVersion({ id, body }),
+    ...options,
+  });
 };
 
 interface UseDeleteVersionMutationParams {
@@ -43,12 +43,12 @@ interface UseDeleteVersionMutationParams {
 }
 
 export const useDeleteVersionMutation = (
-  options?: UseMutationOptions<void, unknown, UseDeleteVersionMutationParams>,
+  options?: Partial<UseMutationOptions<void, unknown, UseDeleteVersionMutationParams>>,
 ) => {
-  return useMutation<void, unknown, UseDeleteVersionMutationParams>(
-    ({ id }) => deleteVersion({ id }),
-    options,
-  );
+  return useMutation<void, unknown, UseDeleteVersionMutationParams>({
+    mutationFn: ({ id }) => deleteVersion({ id }),
+    ...options,
+  });
 };
 
 interface UsePublishVersionMutation {
@@ -56,10 +56,10 @@ interface UsePublishVersionMutation {
 }
 
 export const usePublishVersionMutation = (
-  options?: UseMutationOptions<void, unknown, UsePublishVersionMutation>,
+  options?: Partial<UseMutationOptions<void, unknown, UsePublishVersionMutation>>,
 ) => {
-  return useMutation<void, unknown, UsePublishVersionMutation>(
-    ({ id }) => publishVersion({ id }),
-    options,
-  );
+  return useMutation<void, unknown, UsePublishVersionMutation>({
+    mutationFn: ({ id }) => publishVersion({ id }),
+    ...options,
+  });
 };

--- a/src/modules/taxonomy/versions/versionQueries.ts
+++ b/src/modules/taxonomy/versions/versionQueries.ts
@@ -18,7 +18,10 @@ export const versionQueryKeys = {
 };
 
 interface UseVersionsParams extends GetVersionsParams {}
-export const useVersions = (params?: UseVersionsParams, options?: UseQueryOptions<Version[]>) => {
+export const useVersions = (
+  params?: UseVersionsParams,
+  options?: Partial<UseQueryOptions<Version[]>>,
+) => {
   return useQuery<Version[]>(
     versionQueryKeys.versions(params),
     () => fetchVersions({ ...params }),
@@ -29,6 +32,13 @@ export const useVersions = (params?: UseVersionsParams, options?: UseQueryOption
 interface UseVersionParams {
   id: string;
 }
-export const useVersion = (params: UseVersionParams, options?: UseQueryOptions<Version>) => {
-  return useQuery<Version>([versionQueryKeys.version(params)], () => fetchVersion(params), options);
+export const useVersion = (
+  params: UseVersionParams,
+  options?: Partial<UseQueryOptions<Version>>,
+) => {
+  return useQuery<Version>({
+    queryKey: [versionQueryKeys.version(params)],
+    queryFn: () => fetchVersion(params),
+    ...options,
+  });
 };

--- a/src/modules/taxonomy/versions/versionQueries.ts
+++ b/src/modules/taxonomy/versions/versionQueries.ts
@@ -22,11 +22,11 @@ export const useVersions = (
   params?: UseVersionsParams,
   options?: Partial<UseQueryOptions<Version[]>>,
 ) => {
-  return useQuery<Version[]>(
-    versionQueryKeys.versions(params),
-    () => fetchVersions({ ...params }),
-    options,
-  );
+  return useQuery<Version[]>({
+    queryKey: versionQueryKeys.versions(params),
+    queryFn: () => fetchVersions({ ...params }),
+    ...options,
+  });
 };
 
 interface UseVersionParams {


### PR DESCRIPTION
Runde 2 med arbeid mot React Query 5. Den eneste tillate syntaxen for `useQuery` vil være objekt-syntax. Dette medfører at `UseQueryOptions` nå krever at man sender inn både `queryKey` og `queryFn`. Kommer rundt dette ved å sette de til partial.