### PR TITLE
Added maxRender with default value

### DIFF
--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -61,6 +61,7 @@ interface Props<ApiType> {
   initialSearch?: boolean;
   label?: string;
   white?: boolean;
+  maxRender?: number;
 }
 
 interface ApiTypeValues {
@@ -104,6 +105,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
   initialSearch = true,
   label,
   white = false,
+  maxRender = 10,
 }: Props<ApiType>) => {
   const [items, setItems] = useState<ItemValues<ApiType>[]>([]);
   const [selectedItem, setSelectedItem] = useState<ItemValues<ApiType> | null>(null);
@@ -263,6 +265,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
               hideTotalSearchCount={hideTotalSearchCount}
               page={showPagination && page}
               handlePageChange={handlePageChange}
+              maxRender={maxRender}
             />
           </div>
         );

--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -32,7 +32,11 @@ interface InputPropsOptionsRef extends GetInputPropsOptions {
 
 interface Props<ApiType> {
   onChange: (value: ApiType) => Promise<void> | void;
-  apiAction: (query: string, page?: number) => Promise<SearchResultBase<ApiType>>;
+  apiAction: (
+    query: string,
+    page?: number,
+    pageSize?: number,
+  ) => Promise<SearchResultBase<ApiType>>;
   placeholder?: string;
   labelField?: string;
   idField?: string;
@@ -62,6 +66,7 @@ interface Props<ApiType> {
   label?: string;
   white?: boolean;
   maxRender?: number;
+  pageSize?: number;
 }
 
 interface ApiTypeValues {
@@ -105,7 +110,8 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
   initialSearch = true,
   label,
   white = false,
-  maxRender = 10,
+  maxRender,
+  pageSize = 10,
 }: Props<ApiType>) => {
   const [items, setItems] = useState<ItemValues<ApiType>[]>([]);
   const [selectedItem, setSelectedItem] = useState<ItemValues<ApiType> | null>(null);
@@ -265,7 +271,8 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
               hideTotalSearchCount={hideTotalSearchCount}
               page={showPagination && page}
               handlePageChange={handlePageChange}
-              maxRender={maxRender}
+              maxRender={maxRender ? maxRender : pageSize}
+              pageSize={pageSize}
             />
           </div>
         );

--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -129,7 +129,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
   const handleSearch = useCallback(
     async (query: string = '', page: number) => {
       setLoading(true);
-      const apiOutput = await apiAction(query, showPagination ? page : undefined);
+      const apiOutput = await apiAction(query, showPagination ? page : undefined, pageSize);
       setTotalCount(apiOutput.totalCount ?? 1);
       const transformedItems: ItemValues<ApiType>[] = apiOutput.results.map((item) => ({
         ...item,

--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -144,7 +144,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
 
       setKeepOpen(keepOpen || !!query);
     },
-    [apiAction, keepOpen, showPagination],
+    [apiAction, keepOpen, pageSize, showPagination],
   );
 
   const handleInputChange = async (evt: ChangeEvent<HTMLInputElement>) => {

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
@@ -41,6 +41,7 @@ interface DropdownItem<Type> {
 interface BaseParams {
   query?: string;
   page?: number;
+  pageSize?: number;
 }
 
 interface Props<ParamType extends BaseParams, InnerType, ApiType, Type = ApiType> {
@@ -60,6 +61,7 @@ interface Props<ParamType extends BaseParams, InnerType, ApiType, Type = ApiType
   positionAbsolute?: boolean;
   isMultiSelect?: boolean;
   maxRender?: number;
+  pageSize?: number;
 }
 
 const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>({
@@ -75,13 +77,15 @@ const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>(
   wide = true,
   positionAbsolute = true,
   isMultiSelect = false,
-  maxRender = 10,
+  maxRender,
+  pageSize = 5,
 }: Props<ParamType, InnerType, ApiType, Type>) => {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState<number>(1);
   const debouncedQuery = useDebounce(query);
   const allParams: ParamType = {
     query: debouncedQuery,
+    pageSize,
     page,
     ...params,
   } as ParamType;
@@ -140,7 +144,8 @@ const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>(
               wide={wide}
               selectedItems={selectedItems}
               multiSelect={isMultiSelect}
-              maxRender={maxRender}
+              maxRender={maxRender ? maxRender : pageSize}
+              pageSize={pageSize}
             />
           </DropdownWrapper>
         );

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
@@ -59,6 +59,7 @@ interface Props<ParamType extends BaseParams, InnerType, ApiType, Type = ApiType
   wide?: boolean;
   positionAbsolute?: boolean;
   isMultiSelect?: boolean;
+  maxRender?: number;
 }
 
 const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>({
@@ -74,6 +75,7 @@ const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>(
   wide = true,
   positionAbsolute = true,
   isMultiSelect = false,
+  maxRender = 10,
 }: Props<ParamType, InnerType, ApiType, Type>) => {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState<number>(1);
@@ -138,6 +140,7 @@ const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>(
               wide={wide}
               selectedItems={selectedItems}
               multiSelect={isMultiSelect}
+              maxRender={maxRender}
             />
           </DropdownWrapper>
         );

--- a/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
+++ b/src/containers/StructurePage/folderComponents/sharedMenuOptions/components/SearchDropdown.tsx
@@ -78,7 +78,7 @@ const SearchDropdown = <ParamType extends BaseParams, InnerType, ApiType, Type>(
   positionAbsolute = true,
   isMultiSelect = false,
   maxRender,
-  pageSize = 5,
+  pageSize = 10,
 }: Props<ParamType, InnerType, ApiType, Type>) => {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState<number>(1);


### PR DESCRIPTION
Attributtet heter `maxRender` i frontend-packages, så jeg har videreført det med samme navn (for consistency, selv om jeg var frista te å kalle det pageSize). DropdownMenu brukes også flere steder enn AsyncDropdown, bl.a. i søkefelteltene for noder (som brukes til bl.a. faglenker) så jeg har også lagt den til der i tilfelle det ønskes endra seinere.