### PR TITLE
Dynamic updates dropdown height based on screen height

### DIFF
--- a/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
+++ b/src/components/Dropdown/asyncDropdown/AsyncDropdown.tsx
@@ -61,6 +61,7 @@ interface Props<ApiType> {
   initialSearch?: boolean;
   label?: string;
   white?: boolean;
+  menuHeight?: number;
 }
 
 interface ApiTypeValues {
@@ -104,6 +105,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
   initialSearch = true,
   label,
   white = false,
+  menuHeight,
 }: Props<ApiType>) => {
   const [items, setItems] = useState<ItemValues<ApiType>[]>([]);
   const [selectedItem, setSelectedItem] = useState<ItemValues<ApiType> | null>(null);
@@ -263,6 +265,7 @@ export const AsyncDropdown = <ApiType extends ApiTypeValues>({
               hideTotalSearchCount={hideTotalSearchCount}
               page={showPagination && page}
               handlePageChange={handlePageChange}
+              menuHeight={menuHeight}
             />
           </div>
         );

--- a/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
+++ b/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
@@ -52,7 +52,7 @@ const FrontpageArticleSearch = ({ articleId, children, onChange }: Props) => {
     return () => {
       window.removeEventListener('resize', changeSize);
     };
-  });
+  }, [window.innerHeight]);
 
   const selectedValues = useMemo(() => {
     const articleIds = extractArticleIds(values);

--- a/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
+++ b/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
@@ -52,7 +52,7 @@ const FrontpageArticleSearch = ({ articleId, children, onChange }: Props) => {
     return () => {
       window.removeEventListener('resize', changeSize);
     };
-  }, [window.innerHeight]);
+  });
 
   const selectedValues = useMemo(() => {
     const articleIds = extractArticleIds(values);

--- a/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
+++ b/src/containers/FrontpageEditPage/FrontpageArticleSearch.tsx
@@ -9,7 +9,7 @@
 import styled from '@emotion/styled';
 import { Content, Portal as PopoverPortal, Root, Trigger } from '@radix-ui/react-popover';
 import { spacing, misc, colors } from '@ndla/core';
-import { ReactNode, useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Heading } from '@ndla/typography';
 import { IArticleSummaryV2 } from '@ndla/types-backend/article-api';
@@ -40,6 +40,19 @@ const PopoverContent = styled(Content)`
 const FrontpageArticleSearch = ({ articleId, children, onChange }: Props) => {
   const { t } = useTranslation();
   const { values } = useFormikContext<MenuWithArticle>();
+  const [windowHeight, setWindowHeight] = useState<number>(window.innerHeight);
+
+  useEffect(() => {
+    const changeSize = () => {
+      setWindowHeight(window.innerHeight);
+    };
+
+    window.addEventListener('resize', changeSize);
+
+    return () => {
+      window.removeEventListener('resize', changeSize);
+    };
+  });
 
   const selectedValues = useMemo(() => {
     const articleIds = extractArticleIds(values);
@@ -71,6 +84,7 @@ const FrontpageArticleSearch = ({ articleId, children, onChange }: Props) => {
             startOpen
             showPagination
             initialSearch={true}
+            menuHeight={windowHeight * 0.3}
           />
         </PopoverContent>
       </PopoverPortal>


### PR DESCRIPTION
DropdownMenu hadde et `menuHeight` attributt som kan brukes til å sette en max-height. Er sikkert mer elegante måter å gjøre det på, men etter litt testing så det ut til at 30 % av skjermhøyden gjør den ganske lik som i dag ved fullskjerm, men resizing vil dynamisk oppdatere nedtrekksmenyen slik at pagination blir synlig også på lavere skjermer (til den når et visst punkt, men da trur jeg man er langt utafor range hvor det er et problem)