### PR TITLE
Place LanguageSelector in SlateToolbar

### DIFF
--- a/src/components/SlateEditor/plugins/span/LanguageButton.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageButton.tsx
@@ -24,6 +24,7 @@ const StyledLanguageButton = styled.button<{ isActive: boolean }>`
 
   padding: 8px 0.5rem 8px 0.5rem;
   border: none;
+  white-space: nowrap;
   &:hover {
     background: ${colors.brand.lightest};
   }

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -90,7 +90,7 @@ const LanguageSelector = ({ element, clicks, onClose, setClicks }: Props) => {
 
   return (
     <Portal container={container}>
-      <Container contentEditable={false}>
+      <Container id={'langaugeSelector'} contentEditable={false}>
         {languages.map((lang) => (
           <LanguageButton
             key={lang}

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { Transforms } from 'slate';
 import { useSlateStatic } from 'slate-react';
 import styled from '@emotion/styled';
@@ -16,7 +16,6 @@ import { DeleteForever } from '@ndla/icons/editor';
 import { Portal } from '@radix-ui/react-portal';
 import { SpanElement } from '.';
 import LanguageButton from './LanguageButton';
-import { useEffect } from 'react';
 
 interface Props {
   element: SpanElement;
@@ -44,9 +43,7 @@ const Container = styled.div`
 const LanguageSelector = ({ element, clicks, onClose, setClicks }: Props) => {
   const editor = useSlateStatic();
 
-  console.log('clicks:', clicks);
-
-  const handleClickFallback = (e: MouseEvent | KeyboardEvent) => {
+  const handleClickFallback = () => {
     clicks > 0 ? onClose() : setClicks((prev) => prev + 1);
   };
 

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -15,9 +15,11 @@ import { DeleteForever } from '@ndla/icons/editor';
 import { Portal } from '@radix-ui/react-portal';
 import { SpanElement } from '.';
 import LanguageButton from './LanguageButton';
+import { useEffect } from 'react';
 
 interface Props {
   element: SpanElement;
+  isOpen: boolean;
   onClose: () => void;
 }
 
@@ -37,8 +39,23 @@ const Container = styled.div`
   box-shadow: 3px 3px ${spacing.xsmall} #99999959;
 `;
 
-const LanguageSelector = ({ element, onClose }: Props) => {
+const LanguageSelector = ({ element, isOpen, onClose }: Props) => {
   const editor = useSlateStatic();
+
+  const handleClickFallback = (e: MouseEvent) => {
+    console.log(e);
+    isOpen &&
+      setTimeout(() => {
+        onClose();
+      }, 500);
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickFallback);
+    return () => {
+      document.removeEventListener('click', handleClickFallback);
+    };
+  });
 
   const onClick = (language: string) => {
     Transforms.setNodes(

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -6,15 +6,15 @@
  *
  */
 
-import styled from '@emotion/styled';
 import { Transforms } from 'slate';
 import { useSlateStatic } from 'slate-react';
-import { colors } from '@ndla/core';
+import styled from '@emotion/styled';
 import { ButtonV2 } from '@ndla/button';
+import { colors, spacing } from '@ndla/core';
 import { DeleteForever } from '@ndla/icons/editor';
+import { Portal } from '@radix-ui/react-portal';
 import { SpanElement } from '.';
 import LanguageButton from './LanguageButton';
-import { Portal } from '@radix-ui/react-portal';
 
 interface Props {
   element: SpanElement;
@@ -34,7 +34,7 @@ const Container = styled.div`
   overflow: hidden;
   border-radius: 4px;
   border-width: 1px;
-  box-shadow: 3px 3px 5px #99999959;
+  box-shadow: 3px 3px ${spacing.xsmall} #99999959;
 `;
 
 const LanguageSelector = ({ element, onClose }: Props) => {

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -30,9 +30,9 @@ const Container = styled.div`
   position: absolute;
   user-select: none;
   font-family: monospace;
-  transform: translateY(100%);
-  left: 0;
-  top: 0;
+  transform: translate(-50%, 50%);
+  left: 50%;
+  top: 50%;
   border: ${colors.brand.greyLight} solid 1px;
   background: ${colors.white};
   overflow: hidden;

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { Dispatch, SetStateAction } from 'react';
 import { Transforms } from 'slate';
 import { useSlateStatic } from 'slate-react';
 import styled from '@emotion/styled';
@@ -19,8 +20,9 @@ import { useEffect } from 'react';
 
 interface Props {
   element: SpanElement;
-  isOpen: boolean;
+  clicks: number;
   onClose: () => void;
+  setClicks: Dispatch<SetStateAction<number>>;
 }
 
 export const languages = ['ar', 'de', 'en', 'es', 'fr', 'la', 'no', 'se', 'sma', 'so', 'ti', 'zh'];
@@ -39,21 +41,27 @@ const Container = styled.div`
   box-shadow: 3px 3px ${spacing.xsmall} #99999959;
 `;
 
-const LanguageSelector = ({ element, isOpen, onClose }: Props) => {
+const LanguageSelector = ({ element, clicks, onClose, setClicks }: Props) => {
   const editor = useSlateStatic();
 
-  const handleClickFallback = (e: MouseEvent) => {
-    console.log(e);
-    isOpen &&
-      setTimeout(() => {
-        onClose();
-      }, 500);
+  console.log('clicks:', clicks);
+
+  const handleClickFallback = (e: MouseEvent | KeyboardEvent) => {
+    clicks > 0 ? onClose() : setClicks((prev) => prev + 1);
+  };
+
+  const handleKeypressFallback = (e: KeyboardEvent) => {
+    if (e.key === 'Escape' || e.key === 'Esc') {
+      onClose();
+    }
   };
 
   useEffect(() => {
     document.addEventListener('click', handleClickFallback);
+    document.addEventListener('keydown', handleKeypressFallback);
     return () => {
       document.removeEventListener('click', handleClickFallback);
+      document.removeEventListener('keydown', handleKeypressFallback);
     };
   });
 

--- a/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
+++ b/src/components/SlateEditor/plugins/span/LanguageSelector.tsx
@@ -14,6 +14,7 @@ import { ButtonV2 } from '@ndla/button';
 import { DeleteForever } from '@ndla/icons/editor';
 import { SpanElement } from '.';
 import LanguageButton from './LanguageButton';
+import { Portal } from '@radix-ui/react-portal';
 
 interface Props {
   element: SpanElement;
@@ -24,20 +25,16 @@ export const languages = ['ar', 'de', 'en', 'es', 'fr', 'la', 'no', 'se', 'sma',
 
 const Container = styled.div`
   display: flex;
-  z-index: 1;
   font-size: 0.8rem;
   flex-direction: row;
-  position: absolute;
   user-select: none;
   font-family: monospace;
-  transform: translate(-50%, 50%);
-  left: 50%;
-  top: 50%;
   border: ${colors.brand.greyLight} solid 1px;
   background: ${colors.white};
   overflow: hidden;
   border-radius: 4px;
   border-width: 1px;
+  box-shadow: 3px 3px 5px #99999959;
 `;
 
 const LanguageSelector = ({ element, onClose }: Props) => {
@@ -67,20 +64,24 @@ const LanguageSelector = ({ element, onClose }: Props) => {
     });
   };
 
+  const container = document.getElementById('toolbarPortal');
+
   return (
-    <Container contentEditable={false}>
-      {languages.map((lang) => (
-        <LanguageButton
-          key={lang}
-          language={lang}
-          onClick={onClick}
-          isActive={lang === element.data.lang}
-        />
-      ))}
-      <ButtonV2 variant="ghost" colorTheme="danger" contentEditable={false} onClick={onDelete}>
-        <DeleteForever />
-      </ButtonV2>
-    </Container>
+    <Portal container={container}>
+      <Container contentEditable={false}>
+        {languages.map((lang) => (
+          <LanguageButton
+            key={lang}
+            language={lang}
+            onClick={onClick}
+            isActive={lang === element.data.lang}
+          />
+        ))}
+        <ButtonV2 variant="ghost" colorTheme="danger" contentEditable={false} onClick={onDelete}>
+          <DeleteForever />
+        </ButtonV2>
+      </Container>
+    </Portal>
   );
 };
 

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -7,7 +7,7 @@
  */
 
 import styled from '@emotion/styled';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { colors } from '@ndla/core';
 import { RenderElementProps, useSelected, useSlateStatic } from 'slate-react';
 import { SpanElement } from '.';
@@ -38,17 +38,39 @@ const Span = ({ element, attributes, children }: Props) => {
   const selected = useSelected();
   const { selection } = useSlateStatic();
 
+  // const handleOutsideClick = (event: MouseEvent) => {
+  //   console.log('event target', event.target);
+  //   if (attributes.ref.current && !attributes.ref.current.contains(event.target)) {
+  //     setShowPicker(false);
+  //   }
+  // };
+
   useEffect(() => {
     if (!selected) {
       setShowPicker(false);
     }
   }, [selection, selected]);
 
+  // useEffect(() => {
+  //   if (showPicker) {
+  //     document.addEventListener('click', handleOutsideClick);
+  //   } else {
+  //     document.removeEventListener('click', handleOutsideClick);
+  //   }
+  //   return () => {
+  //     document.removeEventListener('click', handleOutsideClick);
+  //   };
+  // });
+
   return (
     <StyledSpan {...attributes} language={language}>
       {children}
       {!language || showPicker ? (
-        <LanguageSelector element={element} onClose={() => setShowPicker(false)} />
+        <LanguageSelector
+          element={element}
+          onClose={() => setShowPicker(false)}
+          isOpen={showPicker}
+        />
       ) : (
         <SelectedLanguage
           language={language}

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -56,7 +56,8 @@ const Span = ({ element, attributes, children }: Props) => {
           clicks={clicks}
           setClicks={setClicks}
         />
-      ) : (
+      ) : null}
+      {language ? (
         <SelectedLanguage
           language={language}
           element={element}
@@ -65,10 +66,11 @@ const Span = ({ element, attributes, children }: Props) => {
             if (toolbar) {
               showToolbar(toolbar);
             }
+            setClicks(0);
             setShowPicker(true);
           }}
         />
-      )}
+      ) : null}
     </StyledSpan>
   );
 };

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -23,10 +23,8 @@ interface Props {
 
 const StyledSpan = styled.span<{ language?: string }>`
   position: relative;
-
   text-decoration: underline;
   text-decoration-color: ${colors.brand.tertiary};
-
   &:hover > .selected-language {
     display: block;
   }

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -13,6 +13,7 @@ import { RenderElementProps, useSelected, useSlateStatic } from 'slate-react';
 import { SpanElement } from '.';
 import SelectedLanguage from './SelectedLanguage';
 import LanguageSelector from './LanguageSelector';
+import { showToolbar } from '../toolbar/SlateToolbar';
 
 interface Props {
   attributes: RenderElementProps['attributes'];
@@ -52,7 +53,13 @@ const Span = ({ element, attributes, children }: Props) => {
         <SelectedLanguage
           language={language}
           element={element}
-          onClick={() => setShowPicker(true)}
+          onClick={() => {
+            const toolbar = document.getElementById('toolbarContainer');
+            if (toolbar) {
+              showToolbar(toolbar);
+            }
+            setShowPicker(true);
+          }}
         />
       )}
     </StyledSpan>

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -7,7 +7,7 @@
  */
 
 import styled from '@emotion/styled';
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { colors } from '@ndla/core';
 import { RenderElementProps, useSelected, useSlateStatic } from 'slate-react';
 import { SpanElement } from '.';

--- a/src/components/SlateEditor/plugins/span/Span.tsx
+++ b/src/components/SlateEditor/plugins/span/Span.tsx
@@ -34,16 +34,10 @@ const StyledSpan = styled.span<{ language?: string }>`
 
 const Span = ({ element, attributes, children }: Props) => {
   const [showPicker, setShowPicker] = useState(false);
+  const [clicks, setClicks] = useState<number>(0);
   const language = element.data.lang;
   const selected = useSelected();
   const { selection } = useSlateStatic();
-
-  // const handleOutsideClick = (event: MouseEvent) => {
-  //   console.log('event target', event.target);
-  //   if (attributes.ref.current && !attributes.ref.current.contains(event.target)) {
-  //     setShowPicker(false);
-  //   }
-  // };
 
   useEffect(() => {
     if (!selected) {
@@ -51,25 +45,18 @@ const Span = ({ element, attributes, children }: Props) => {
     }
   }, [selection, selected]);
 
-  // useEffect(() => {
-  //   if (showPicker) {
-  //     document.addEventListener('click', handleOutsideClick);
-  //   } else {
-  //     document.removeEventListener('click', handleOutsideClick);
-  //   }
-  //   return () => {
-  //     document.removeEventListener('click', handleOutsideClick);
-  //   };
-  // });
-
   return (
     <StyledSpan {...attributes} language={language}>
       {children}
       {!language || showPicker ? (
         <LanguageSelector
           element={element}
-          onClose={() => setShowPicker(false)}
-          isOpen={showPicker}
+          onClose={() => {
+            setShowPicker(false);
+            setClicks(0);
+          }}
+          clicks={clicks}
+          setClicks={setClicks}
         />
       ) : (
         <SelectedLanguage

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -14,12 +14,7 @@ import { colors, spacing } from '@ndla/core';
 import { Portal } from '@radix-ui/react-portal';
 import ToolbarButton from './ToolbarButton';
 import { toggleMark } from '../mark/utils';
-import {
-  handleClickInline,
-  handleClickBlock,
-  handleClickSelect,
-  handleClickTable,
-} from './handleMenuClicks';
+import { handleClickInline, handleClickBlock, handleClickTable } from './handleMenuClicks';
 import hasNodeWithProps from '../../utils/hasNodeWithProps';
 import { isMarkActive } from '../mark';
 import { LIST_TYPES as listTypes } from '../list/types';
@@ -137,8 +132,6 @@ const SlateToolbar = () => {
         handleClickInline(event, editor, type);
       } else if (kind === 'table') {
         handleClickTable(event, editor, type);
-      } else if (kind === 'select') {
-        handleClickSelect(event, editor, type);
       }
     },
     [editor],

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -13,7 +13,12 @@ import styled from '@emotion/styled';
 import { Portal } from '@radix-ui/react-portal';
 import ToolbarButton from './ToolbarButton';
 import { toggleMark } from '../mark/utils';
-import { handleClickInline, handleClickBlock, handleClickTable } from './handleMenuClicks';
+import {
+  handleClickInline,
+  handleClickBlock,
+  handleClickSelect,
+  handleClickTable,
+} from './handleMenuClicks';
 import hasNodeWithProps from '../../utils/hasNodeWithProps';
 import { isMarkActive } from '../mark';
 import { LIST_TYPES as listTypes } from '../list/types';
@@ -27,13 +32,15 @@ import hasDefinitionListItem from '../definitionList/utils/hasDefinitionListItem
 const topicArticleElements: { [key: string]: string[] } = {
   mark: ['bold', 'italic', 'code', 'sub', 'sup'],
   block: ['quote', 'heading-2', 'heading-3', 'heading-4', 'definition-list', ...listTypes],
-  inline: ['link', 'mathml', 'concept', 'span'],
+  inline: ['link', 'mathml', 'concept'],
+  select: ['span'],
 };
 
 const learningResourceElements: { [key: string]: string[] } = {
   mark: ['bold', 'italic', 'code', 'sub', 'sup'],
   block: ['quote', 'heading-2', 'heading-3', 'heading-4', 'definition-list', ...listTypes],
-  inline: ['link', 'mathml', 'concept', 'span'],
+  inline: ['link', 'mathml', 'concept'],
+  select: ['span'],
   table: ['left', 'center', 'right'],
 };
 
@@ -121,6 +128,8 @@ const SlateToolbar = () => {
         handleClickInline(event, editor, type);
       } else if (kind === 'table') {
         handleClickTable(event, editor, type);
+      } else if (kind === 'select') {
+        handleClickSelect(event, editor, type);
       }
     },
     [editor],
@@ -141,6 +150,7 @@ const SlateToolbar = () => {
   );
 
   const onMouseDown = useCallback((e: MouseEvent) => e.preventDefault(), []);
+  console.log(toolbarElements);
 
   return (
     <Portal>
@@ -173,6 +183,19 @@ const SlateToolbar = () => {
             type={type}
             kind="inline"
             isActive={hasNodeWithProps(editor, specialRules[type] ?? { type })}
+            handleOnClick={onButtonClick}
+          />
+        ))}
+        {toolbarElements.select.map((type) => (
+          <ToolbarButton
+            key={type}
+            type={type}
+            kind="select"
+            isActive={
+              type.includes('list')
+                ? isActiveList(type)
+                : hasNodeWithProps(editor, specialRules[type] ?? { type })
+            }
             handleOnClick={onButtonClick}
           />
         ))}

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -10,6 +10,7 @@ import { createRef, memo, MouseEvent, useCallback, useEffect, useMemo } from 're
 import { Editor, Element, Range } from 'slate';
 import { useFocused, useSlate } from 'slate-react';
 import styled from '@emotion/styled';
+import { colors, spacing } from '@ndla/core';
 import { Portal } from '@radix-ui/react-portal';
 import ToolbarButton from './ToolbarButton';
 import { toggleMark } from '../mark/utils';
@@ -32,15 +33,13 @@ import hasDefinitionListItem from '../definitionList/utils/hasDefinitionListItem
 const topicArticleElements: { [key: string]: string[] } = {
   mark: ['bold', 'italic', 'code', 'sub', 'sup'],
   block: ['quote', 'heading-2', 'heading-3', 'heading-4', 'definition-list', ...listTypes],
-  inline: ['link', 'mathml', 'concept'],
-  select: ['span'],
+  inline: ['link', 'mathml', 'concept', 'span'],
 };
 
 const learningResourceElements: { [key: string]: string[] } = {
   mark: ['bold', 'italic', 'code', 'sub', 'sup'],
   block: ['quote', 'heading-2', 'heading-3', 'heading-4', 'definition-list', ...listTypes],
-  inline: ['link', 'mathml', 'concept'],
-  select: ['span'],
+  inline: ['link', 'mathml', 'concept', 'span'],
   table: ['left', 'center', 'right'],
 };
 
@@ -60,17 +59,27 @@ const specialRules: { [key: string]: Partial<Element> } = {
 };
 
 const ToolbarContainer = styled.div`
-  border-radius: 4px;
-  position: absolute;
-  z-index: 11;
-  top: -10000px;
   left: -10000px;
-  margin-top: -6px;
   opacity: 0;
-  color: black;
-  background-color: white;
+  position: absolute;
+  top: -10000px;
   transition: opacity 0.75s;
-  box-shadow: 3px 3px 5px #99999959;
+  z-index: 11;
+`;
+
+const ToolbarButtons = styled.div`
+  background-color: ${colors.white};
+  border-radius: ${spacing.xxsmall};
+  box-shadow: 3px 3px ${spacing.xsmall} #99999959;
+  color: ${colors.black};
+  margin: -6px 0 ${spacing.xsmall};
+`;
+
+const ToolbarSubMenu = styled.div`
+  display: none;
+  &:not(:empty) {
+    display: inline-block;
+  }
 `;
 
 const SlateToolbar = () => {
@@ -155,60 +164,51 @@ const SlateToolbar = () => {
   return (
     <Portal>
       <ToolbarContainer ref={portalRef} onMouseDown={onMouseDown}>
-        {toolbarElements.mark.map((type) => (
-          <ToolbarButton
-            key={type}
-            type={type}
-            kind="mark"
-            isActive={isMarkActive(editor, type)}
-            handleOnClick={onButtonClick}
-          />
-        ))}
-        {toolbarElements.block.map((type) => (
-          <ToolbarButton
-            key={type}
-            type={type}
-            kind="block"
-            isActive={
-              type.includes('list')
-                ? isActiveList(type)
-                : hasNodeWithProps(editor, specialRules[type] ?? { type })
-            }
-            handleOnClick={onButtonClick}
-          />
-        ))}
-        {toolbarElements.inline.map((type) => (
-          <ToolbarButton
-            key={type}
-            type={type}
-            kind="inline"
-            isActive={hasNodeWithProps(editor, specialRules[type] ?? { type })}
-            handleOnClick={onButtonClick}
-          />
-        ))}
-        {toolbarElements.select.map((type) => (
-          <ToolbarButton
-            key={type}
-            type={type}
-            kind="select"
-            isActive={
-              type.includes('list')
-                ? isActiveList(type)
-                : hasNodeWithProps(editor, specialRules[type] ?? { type })
-            }
-            handleOnClick={onButtonClick}
-          />
-        ))}
-        {getCurrentBlock(editor, TYPE_TABLE_CELL) &&
-          toolbarElements.table?.map((type, index) => (
+        <ToolbarButtons>
+          {toolbarElements.mark.map((type) => (
             <ToolbarButton
-              key={index}
+              key={type}
               type={type}
-              kind="table"
-              isActive={hasCellAlignOfType(editor, type)}
+              kind="mark"
+              isActive={isMarkActive(editor, type)}
               handleOnClick={onButtonClick}
             />
           ))}
+          {toolbarElements.block.map((type) => (
+            <ToolbarButton
+              key={type}
+              type={type}
+              kind="block"
+              isActive={
+                type.includes('list')
+                  ? isActiveList(type)
+                  : hasNodeWithProps(editor, specialRules[type] ?? { type })
+              }
+              handleOnClick={onButtonClick}
+            />
+          ))}
+          {toolbarElements.inline.map((type) => (
+            <ToolbarButton
+              key={type}
+              type={type}
+              kind="inline"
+              isActive={hasNodeWithProps(editor, specialRules[type] ?? { type })}
+              handleOnClick={onButtonClick}
+            />
+          ))}
+
+          {getCurrentBlock(editor, TYPE_TABLE_CELL) &&
+            toolbarElements.table?.map((type, index) => (
+              <ToolbarButton
+                key={index}
+                type={type}
+                kind="table"
+                isActive={hasCellAlignOfType(editor, type)}
+                handleOnClick={onButtonClick}
+              />
+            ))}
+        </ToolbarButtons>
+        <ToolbarSubMenu id="toolbarPortal"></ToolbarSubMenu>
       </ToolbarContainer>
     </Portal>
   );

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -77,6 +77,22 @@ const ToolbarSubMenu = styled.div`
   }
 `;
 
+export const showToolbar = (toolbar: HTMLElement) => {
+  toolbar.style.display = 'block';
+  const native = window.getSelection();
+  if (!native) {
+    return;
+  }
+  const range = native.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+
+  toolbar.style.opacity = '1';
+  const left = rect.left + window.scrollX - toolbar.offsetWidth / 2 + rect.width / 2;
+
+  toolbar.style.top = `${rect.top + window.scrollY - toolbar.offsetHeight}px`;
+  toolbar.style.left = `${left > 10 ? left : 10}px`;
+};
+
 const SlateToolbar = () => {
   const portalRef = createRef<HTMLDivElement>();
   const editor = useSlate();
@@ -107,19 +123,7 @@ const SlateToolbar = () => {
       return;
     }
 
-    menu.style.display = 'block';
-    const native = window.getSelection();
-    if (!native) {
-      return;
-    }
-    const range = native.getRangeAt(0);
-    const rect = range.getBoundingClientRect();
-
-    menu.style.opacity = '1';
-    const left = rect.left + window.scrollX - menu.offsetWidth / 2 + rect.width / 2;
-
-    menu.style.top = `${rect.top + window.scrollY - menu.offsetHeight}px`;
-    menu.style.left = `${left > 10 ? left : 10}px`;
+    showToolbar(menu);
   });
 
   const onButtonClick = useCallback(
@@ -155,7 +159,7 @@ const SlateToolbar = () => {
 
   return (
     <Portal>
-      <ToolbarContainer ref={portalRef} onMouseDown={onMouseDown}>
+      <ToolbarContainer id="toolbarContainer" ref={portalRef} onMouseDown={onMouseDown}>
         <ToolbarButtons>
           {toolbarElements.mark.map((type) => (
             <ToolbarButton

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -159,7 +159,6 @@ const SlateToolbar = () => {
   );
 
   const onMouseDown = useCallback((e: MouseEvent) => e.preventDefault(), []);
-  console.log(toolbarElements);
 
   return (
     <Portal>

--- a/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
+++ b/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
@@ -54,6 +54,15 @@ export function handleClickInline(event: SyntheticEvent, editor: Editor, type: s
   }
 }
 
+export function handleClickSelect(event: SyntheticEvent, editor: Editor, type: string) {
+  if (editor.selection) {
+    event.preventDefault();
+    if (type === 'span') {
+      toggleSpan(editor);
+    }
+  }
+}
+
 export const handleClickTable = (event: SyntheticEvent, editor: Editor, type: string) => {
   event.preventDefault();
 

--- a/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
+++ b/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
@@ -54,15 +54,6 @@ export function handleClickInline(event: SyntheticEvent, editor: Editor, type: s
   }
 }
 
-export function handleClickSelect(event: SyntheticEvent, editor: Editor, type: string) {
-  if (editor.selection) {
-    event.preventDefault();
-    if (type === 'span') {
-      toggleSpan(editor);
-    }
-  }
-}
-
 export const handleClickTable = (event: SyntheticEvent, editor: Editor, type: string) => {
   event.preventDefault();
 


### PR DESCRIPTION
Når jeg eksperimenterte, fant jeg også en feil som gjorde at teksten på språk-knappene ble wrappet vertikalt ved grid-visning; som også ble rettet. Det er ikke sikkert at den lenger er helt strengt tatt nødvendig når jeg gikk en annen vei med løsning, men det er allikevel en fin sikkerhet at den er der, så har latt den stå.