### PR TITLE
Update alt text logic for BlogPost, CampaignBlock and KeyFigure

### DIFF
--- a/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
+++ b/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
@@ -49,6 +49,10 @@ const rules: RulesType<BlogPostFormValues> = {
     required: true,
     url: true,
   },
+  metaImageAlt: {
+    required: true,
+    onlyValidateIf: (value) => !!value.metaImageId,
+  },
 };
 
 const StyledSelect = styled.select`

--- a/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
+++ b/src/components/SlateEditor/plugins/blogPost/BlogPostForm.tsx
@@ -29,7 +29,7 @@ interface BlogPostFormValues {
   size?: 'normal' | 'large';
   author?: string;
   link: string;
-  alt?: string;
+  metaImageAlt?: string;
 }
 
 const rules: RulesType<BlogPostFormValues> = {
@@ -65,7 +65,7 @@ const toInitialValues = (initialData?: BlogPostEmbedData): BlogPostFormValues =>
     language: initialData?.language ?? 'nb',
     link: initialData?.url ?? '',
     author: initialData?.author ?? '',
-    alt: initialData?.alt ?? '',
+    metaImageAlt: initialData?.alt ?? '',
   };
 };
 
@@ -113,7 +113,7 @@ const BlogPostForm = ({ initialData, onSave, onCancel }: Props) => {
         size: values.size,
         author: values.author ?? '',
         url: values.link,
-        alt: values.alt ?? '',
+        alt: values.metaImageAlt ?? '',
       };
 
       onSave(newData);
@@ -166,10 +166,14 @@ const BlogPostForm = ({ initialData, onSave, onCancel }: Props) => {
           <StyledFormikField name="size" showError>
             {({ field }: FieldProps) => <SizeField field={field} />}
           </StyledFormikField>
-          <InlineImageSearch name="metaImageId" disableAltEditing />
-          <StyledFormikField name="alt">
-            {({ field }: FieldProps) => (
-              <InputV2 customCss={inputStyle} label={t('form.name.metaImageAlt')} {...field} />
+          <InlineImageSearch name="metaImageId" disableAltEditing hideAltText />
+          <StyledFormikField name="metaImageAlt">
+            {({ field, form }: FieldProps) => (
+              <>
+                {form.values.metaImageId && (
+                  <InputV2 customCss={inputStyle} label={t('form.name.metaImageAlt')} {...field} />
+                )}
+              </>
             )}
           </StyledFormikField>
           <ButtonContainer>

--- a/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
@@ -40,7 +40,7 @@ export interface CampaignBlockFormValues {
   linkText: string;
   metaImageId?: string;
   imageSide?: CampaignBlockEmbedData['imageSide'];
-  alt?: string;
+  metaImageAlt?: string;
   isDecorative?: boolean;
 }
 
@@ -85,7 +85,7 @@ const toInitialValues = (
     headingLevel: initialData?.headingLevel ?? 'h2',
     link: initialData?.url ?? '',
     linkText: initialData?.urlText ?? '',
-    alt: initialData?.alt ?? '',
+    metaImageAlt: initialData?.alt ?? '',
     isDecorative: initialData ? initialData.alt === undefined : false,
   };
 };
@@ -147,7 +147,7 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
         url: values.link,
         urlText: values.linkText,
         imageId: values.metaImageId,
-        alt: values.isDecorative ? undefined : values.alt,
+        alt: values.isDecorative ? undefined : values.metaImageAlt,
       });
     },
     [onSave],
@@ -246,25 +246,29 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
               />
             )}
           </StyledFormikField>
-          <InlineImageSearch name="metaImageId" disableAltEditing />
-          <StyledFormikField name="alt">
+          <InlineImageSearch name="metaImageId" disableAltEditing hideAltText />
+          <StyledFormikField name="metaImageAlt">
             {({ field, form }: FieldProps) => (
               <>
-                {!form.values.isDecorative && (
+                {!form.values.isDecorative && form.values.metaImageId && (
                   <InputV2 customCss={inputStyle} label={t('form.name.metaImageAlt')} {...field} />
                 )}
               </>
             )}
           </StyledFormikField>
           <StyledFormikField name="isDecorative">
-            {({ field }: FieldProps) => (
-              <CheckboxItem
-                label={t('form.image.isDecorative')}
-                checked={field.value}
-                onChange={() =>
-                  field.onChange({ target: { name: field.name, value: !field.value } })
-                }
-              />
+            {({ field, form }: FieldProps) => (
+              <>
+                {form.values.metaImageId && (
+                  <CheckboxItem
+                    label={t('form.image.isDecorative')}
+                    checked={field.value}
+                    onChange={() =>
+                      field.onChange({ target: { name: field.name, value: !field.value } })
+                    }
+                  />
+                )}
+              </>
             )}
           </StyledFormikField>
           <ButtonContainer>

--- a/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
@@ -68,6 +68,10 @@ const rules: RulesType<CampaignBlockFormValues> = {
   linkText: {
     required: true,
   },
+  metaImageAlt: {
+    required: true,
+    onlyValidateIf: (value) => !!value.metaImageId && !value.isDecorative,
+  },
 };
 
 const toInitialValues = (

--- a/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
@@ -105,7 +105,7 @@ const SlateCampaignBlock = ({ element, editor, attributes, children }: Props) =>
     if (campaignBlock?.imageId) {
       fetchImage(campaignBlock.imageId).then((img) => setImage(img));
     }
-  }, [campaignBlock?.imageId, setImage]);
+  }, [campaignBlock?.imageId]);
 
   const handleRemove = useCallback(
     () =>

--- a/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
@@ -31,7 +31,7 @@ interface KeyFigureFormValue {
   metaImageId: string;
   title: string;
   subtitle: string;
-  alt?: string;
+  metaImageAlt?: string;
   isDecorative?: boolean;
 }
 
@@ -40,7 +40,7 @@ const toInitialValues = (initialData: KeyFigureEmbedData): KeyFigureFormValue =>
   metaImageId: initialData?.imageId ?? '',
   title: initialData?.title ?? '',
   subtitle: initialData?.subtitle ?? '',
-  alt: initialData?.alt ?? '',
+  metaImageAlt: initialData?.alt ?? '',
   isDecorative: initialData ? initialData.alt === undefined : false,
 });
 
@@ -88,7 +88,7 @@ const KeyFigureForm = ({ onSave, initialData, onCancel }: Props) => {
         imageId: values.metaImageId,
         title: values.title,
         subtitle: values.subtitle,
-        alt: values.isDecorative ? undefined : values.alt,
+        alt: values.isDecorative ? undefined : values.metaImageAlt,
       };
       onSave(newData);
     },
@@ -114,25 +114,29 @@ const KeyFigureForm = ({ onSave, initialData, onCancel }: Props) => {
               <InputV2 customCss={inputStyle} label={t('form.name.subtitle')} {...field} />
             )}
           </StyledFormikField>
-          <InlineImageSearch name="metaImageId" disableAltEditing />
-          <StyledFormikField name="alt">
+          <InlineImageSearch name="metaImageId" disableAltEditing hideAltText />
+          <StyledFormikField name="metaImageAlt">
             {({ field, form }: FieldProps) => (
               <>
-                {!form.values.isDecorative && (
+                {!form.values.isDecorative && form.values.metaImageId && (
                   <InputV2 customCss={inputStyle} label={t('form.name.metaImageAlt')} {...field} />
                 )}
               </>
             )}
           </StyledFormikField>
           <StyledFormikField name="isDecorative">
-            {({ field }: FieldProps) => (
-              <CheckboxItem
-                label={t('form.image.isDecorative')}
-                checked={field.value}
-                onChange={() =>
-                  field.onChange({ target: { name: field.name, value: !field.value } })
-                }
-              />
+            {({ field, form }: FieldProps) => (
+              <>
+                {form.values.metaImageId && (
+                  <CheckboxItem
+                    label={t('form.image.isDecorative')}
+                    checked={field.value}
+                    onChange={() =>
+                      field.onChange({ target: { name: field.name, value: !field.value } })
+                    }
+                  />
+                )}
+              </>
             )}
           </StyledFormikField>
           <ButtonContainer>

--- a/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
@@ -54,6 +54,10 @@ const rules: RulesType<KeyFigureFormValue> = {
   metaImageId: {
     required: true,
   },
+  metaImageAlt: {
+    required: true,
+    onlyValidateIf: (value) => !!value.metaImageId && !value.isDecorative,
+  },
 };
 
 const StyledFormikField = styled(FormikField)`

--- a/src/containers/ConceptPage/components/InlineImageSearch.tsx
+++ b/src/containers/ConceptPage/components/InlineImageSearch.tsx
@@ -28,9 +28,10 @@ const StyledTitleDiv = styled.div`
 interface Props {
   name: string;
   disableAltEditing?: boolean;
+  hideAltText?: boolean;
 }
 
-const InlineImageSearch = ({ name, disableAltEditing }: Props) => {
+const InlineImageSearch = ({ name, disableAltEditing, hideAltText }: Props) => {
   const { t, i18n } = useTranslation();
   const { setFieldValue, values, setFieldTouched } = useFormikContext<ConceptFormValues>();
   const [image, setImage] = useState<IImageMetaInformationV3 | undefined>();
@@ -54,6 +55,7 @@ const InlineImageSearch = ({ name, disableAltEditing }: Props) => {
     return (
       <MetaImageField
         disableAltEditing={disableAltEditing}
+        hideAltText={hideAltText}
         image={image}
         onImageRemove={() => {
           setFieldValue(name, undefined);

--- a/src/containers/FormikForm/components/MetaImageField.tsx
+++ b/src/containers/FormikForm/components/MetaImageField.tsx
@@ -31,13 +31,20 @@ const StyledImage = styled.img`
 
 interface Props {
   disableAltEditing?: boolean;
+  hideAltText?: boolean;
   image: IImageMetaInformationV3;
   onImageRemove: () => void;
   showRemoveButton: boolean;
   onImageLoad?: (width: number, height: number) => void;
 }
 
-const MetaImageField = ({ image, onImageRemove, onImageLoad, disableAltEditing }: Props) => {
+const MetaImageField = ({
+  image,
+  onImageRemove,
+  onImageLoad,
+  disableAltEditing,
+  hideAltText,
+}: Props) => {
   const { t } = useTranslation();
   const copyright = image.copyright.creators.map((creator) => creator.name).join(', ');
   const title = convertFieldWithFallback<'title'>(image, 'title', '');
@@ -78,6 +85,7 @@ const MetaImageField = ({ image, onImageRemove, onImageLoad, disableAltEditing }
   const onLoad = (_: SyntheticEvent<HTMLImageElement, Event>) => {
     onImageLoad?.(width, height);
   };
+
   return (
     <>
       <MetaImageContainer>
@@ -86,7 +94,7 @@ const MetaImageField = ({ image, onImageRemove, onImageLoad, disableAltEditing }
           title={title}
           copyright={copyright}
           action={imageAction}
-          alt={disableAltEditing ? alt : undefined}
+          alt={hideAltText ? undefined : disableAltEditing ? alt : undefined}
           translations={metaInformationTranslations}
         />
       </MetaImageContainer>


### PR DESCRIPTION
Kom frem et ønske her: https://trello.com/c/KfJFfEgd/447-alt-tekst-p%C3%A5-bloggpost-og-kampanjeblokk om lik oppførsel som for alt tekst på metabilde!

Endringer i BlogPost, CampaignBlock og KeyFigure:
- Alt tekst fra bildet brukes som default
- Skjuler alt-tekst inputfelt/isDecorative så lenge metabilde ikke er valgt