### PR TITLE
Separate render logic from the rest of Slate logic

### DIFF
--- a/src/components/SlateEditor/plugins/aside/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/aside/__tests__/normalizer-test.ts
@@ -10,14 +10,14 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_HEADING } from '../../heading/types';
 import { TYPE_LINK } from '../../link/types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_ASIDE } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('aside normalizer tests', () => {
   test('adds paragraphs around aside element', () => {

--- a/src/components/SlateEditor/plugins/aside/index.tsx
+++ b/src/components/SlateEditor/plugins/aside/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import {
   afterOrBeforeTextBlockElement,
@@ -16,7 +15,6 @@ import {
   textBlockElements,
 } from '../../utils/normalizationHelpers';
 import { SlateSerializer } from '../../interfaces';
-import SlateAside from './SlateAside';
 import { getAsideType } from './utils';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { TYPE_ASIDE } from './types';
@@ -66,20 +64,7 @@ export const asideSerializer: SlateSerializer = {
 };
 
 export const asidePlugin = (editor: Editor) => {
-  const { renderElement: nextRenderElement, normalizeNode: nextNormalizeNode } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_ASIDE) {
-      return (
-        <SlateAside editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateAside>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/aside/render.tsx
+++ b/src/components/SlateEditor/plugins/aside/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/aside/render.tsx
+++ b/src/components/SlateEditor/plugins/aside/render.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_ASIDE } from './types';
+import SlateAside from './SlateAside';
+
+export const asideRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_ASIDE) {
+      return (
+        <SlateAside editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateAside>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/audio/index.tsx
+++ b/src/components/SlateEditor/plugins/audio/index.tsx
@@ -8,7 +8,6 @@
 
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { NormalizerConfig, defaultBlockNormalizer } from '../../utils/defaultNormalizer';
@@ -16,7 +15,6 @@ import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers'
 import { TYPE_NDLA_EMBED } from '../embed/types';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { TYPE_AUDIO } from './types';
-import SlateAudio from './SlateAudio';
 
 const normalizerConfig: NormalizerConfig = {
   previous: {
@@ -43,23 +41,8 @@ export const audioSerializer: SlateSerializer = {
   },
 };
 
-export const audioPlugin = (language: string, disableNormalize?: boolean) => (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_AUDIO) {
-      return (
-        <SlateAudio attributes={attributes} editor={editor} element={element} language={language}>
-          {children}
-        </SlateAudio>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+export const audioPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/audio/render.tsx
+++ b/src/components/SlateEditor/plugins/audio/render.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_AUDIO } from './types';
+import SlateAudio from './SlateAudio';
+
+export const audioRenderer = (language: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_AUDIO) {
+      return (
+        <SlateAudio attributes={attributes} editor={editor} element={element} language={language}>
+          {children}
+        </SlateAudio>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/blockquote/index.tsx
+++ b/src/components/SlateEditor/plugins/blockquote/index.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element, Transforms } from 'slate';
 import { SlateSerializer } from '../../interfaces';
@@ -71,17 +70,7 @@ const onEnter = (
 };
 
 export const blockQuotePlugin = (editor: Editor) => {
-  const { renderElement: nextRenderElement, onKeyDown: nextOnKeyDown } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_QUOTE) {
-      return <blockquote {...attributes}>{children}</blockquote>;
-    } else if (nextRenderElement) {
-      return nextRenderElement(props);
-    }
-    return undefined;
-  };
+  const { onKeyDown: nextOnKeyDown } = editor;
 
   editor.onKeyDown = (e: KeyboardEvent) => {
     if (e.key === KEY_ENTER) {

--- a/src/components/SlateEditor/plugins/blockquote/render.tsx
+++ b/src/components/SlateEditor/plugins/blockquote/render.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_QUOTE } from './types';
+
+export const blockQuoteRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_QUOTE) {
+      return <blockquote {...attributes}>{children}</blockquote>;
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/blogPost/index.tsx
+++ b/src/components/SlateEditor/plugins/blogPost/index.tsx
@@ -7,10 +7,8 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
-import SlateBlogPost from './SlateBlogPost';
 import { TYPE_BLOGPOST } from './types';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
@@ -51,22 +49,7 @@ export const blogPostSerializer: SlateSerializer = {
 };
 
 export const blogPostPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_BLOGPOST) {
-      return (
-        <SlateBlogPost editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateBlogPost>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/blogPost/render.tsx
+++ b/src/components/SlateEditor/plugins/blogPost/render.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_BLOGPOST } from './types';
+import SlateBlogPost from './SlateBlogPost';
+
+export const blogPostRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_BLOGPOST) {
+      return (
+        <SlateBlogPost editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateBlogPost>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/bodybox/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/bodybox/__tests__/normalizer-test.ts
@@ -11,14 +11,14 @@ import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_HEADING } from '../../heading/types';
 import { TYPE_LINK } from '../../link/types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_BODYBOX } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('bodybox normalizer tests', () => {
   test('adds paragraphs around bodybox element', () => {

--- a/src/components/SlateEditor/plugins/bodybox/index.tsx
+++ b/src/components/SlateEditor/plugins/bodybox/index.tsx
@@ -8,7 +8,6 @@
 
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import {
   afterOrBeforeTextBlockElement,
   firstTextBlockElement,
@@ -16,7 +15,6 @@ import {
   textBlockElements,
 } from '../../utils/normalizationHelpers';
 import { SlateSerializer } from '../../interfaces';
-import SlateBodybox from './SlateBodybox';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { TYPE_BODYBOX } from './types';
@@ -63,20 +61,7 @@ export const bodyboxSerializer: SlateSerializer = {
 };
 
 export const bodyboxPlugin = (editor: Editor) => {
-  const { renderElement: nextRenderElement, normalizeNode: nextNormalizeNode } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_BODYBOX) {
-      return (
-        <SlateBodybox editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateBodybox>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/bodybox/render.tsx
+++ b/src/components/SlateEditor/plugins/bodybox/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/bodybox/render.tsx
+++ b/src/components/SlateEditor/plugins/bodybox/render.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_BODYBOX } from './types';
+import SlateBodybox from './SlateBodybox';
+
+export const bodyboxRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_BODYBOX) {
+      return (
+        <SlateBodybox editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateBodybox>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/break/index.tsx
+++ b/src/components/SlateEditor/plugins/break/index.tsx
@@ -8,7 +8,6 @@
 
 import { Editor, Element, Descendant } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import { SlateSerializer } from '../../interfaces';
 import { TYPE_BREAK } from './types';
 
@@ -54,21 +53,7 @@ export const breakSerializer: SlateSerializer = {
 };
 
 export const breakPlugin = (editor: Editor) => {
-  const { renderElement: nextRenderELement, isVoid: nextIsVoid } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_BREAK) {
-      return (
-        <div {...attributes} contentEditable={false}>
-          <br />
-          {children}
-        </div>
-      );
-    } else if (nextRenderELement) {
-      return nextRenderELement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { isVoid: nextIsVoid } = editor;
 
   editor.isVoid = (element: Element) => {
     if (element.type === TYPE_BREAK) {

--- a/src/components/SlateEditor/plugins/break/render.tsx
+++ b/src/components/SlateEditor/plugins/break/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/break/render.tsx
+++ b/src/components/SlateEditor/plugins/break/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_BREAK } from './types';
+
+export const breakRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_BREAK) {
+      return (
+        <div {...attributes} contentEditable={false}>
+          <br />
+          {children}
+        </div>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/campaignBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/index.tsx
@@ -8,7 +8,6 @@
 
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import { CampaignBlockEmbedData } from '@ndla/types-embed';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
@@ -17,7 +16,6 @@ import { TYPE_CAMPAIGN_BLOCK } from './types';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
-import SlateCampaignBlock from './SlateCampaignBlock';
 
 export interface CampaignBlockElement {
   type: 'campaign-block';
@@ -52,22 +50,7 @@ export const campaignBlockSerializer: SlateSerializer = {
 };
 
 export const campaignBlockPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_CAMPAIGN_BLOCK) {
-      return (
-        <SlateCampaignBlock editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateCampaignBlock>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/campaignBlock/render.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/render.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_CAMPAIGN_BLOCK } from './types';
+import SlateCampaignBlock from './SlateCampaignBlock';
+
+export const campaignBlockRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CAMPAIGN_BLOCK) {
+      return (
+        <SlateCampaignBlock editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateCampaignBlock>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/codeBlock/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/codeBlock/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_CODEBLOCK } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('codeblock normalizer tests', () => {
   test('adds paragraphs around codeblock', () => {

--- a/src/components/SlateEditor/plugins/codeBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/index.tsx
@@ -7,10 +7,8 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { CodeEmbedData } from '@ndla/types-embed';
-import CodeBlock from './CodeBlock';
 import { SlateSerializer } from '../../interfaces';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
@@ -56,24 +54,7 @@ export const codeblockSerializer: SlateSerializer = {
 };
 
 export const codeblockPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_CODEBLOCK) {
-      return (
-        <CodeBlock editor={editor} element={element} attributes={attributes}>
-          {children}
-        </CodeBlock>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/codeBlock/render.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/codeBlock/render.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2020-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_CODEBLOCK } from './types';
+import CodeBlock from './CodeBlock';
+
+export const codeblockRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CODEBLOCK) {
+      return (
+        <CodeBlock editor={editor} element={element} attributes={attributes}>
+          {children}
+        </CodeBlock>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/concept/block/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/index.tsx
@@ -8,7 +8,6 @@
 
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import {
   createEmbedTagV2,
   reduceElementDataAttributesV2,
@@ -18,7 +17,6 @@ import { defaultBlockNormalizer, NormalizerConfig } from '../../../utils/default
 import { afterOrBeforeTextBlockElement } from '../../../utils/normalizationHelpers';
 import { TYPE_NDLA_EMBED } from '../../embed/types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
-import BlockWrapper from './BlockWrapper';
 import { TYPE_CONCEPT_BLOCK, TYPE_GLOSS_BLOCK } from './types';
 
 const normalizerConfig: NormalizerConfig = {
@@ -57,20 +55,8 @@ export const blockConceptSerializer: SlateSerializer = {
   },
 };
 
-export const blockConceptPlugin = (locale: string) => (editor: Editor) => {
-  const { renderElement, isVoid, normalizeNode } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_CONCEPT_BLOCK || element.type === TYPE_GLOSS_BLOCK) {
-      return (
-        <BlockWrapper attributes={attributes} element={element} editor={editor} locale={locale}>
-          {children}
-        </BlockWrapper>
-      );
-    }
-    return renderElement?.(props);
-  };
+export const blockConceptPlugin = (editor: Editor) => {
+  const { isVoid, normalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/concept/block/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/render.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/concept/block/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/render.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import BlockWrapper from './BlockWrapper';
+import { TYPE_CONCEPT_BLOCK, TYPE_GLOSS_BLOCK } from './types';
+
+export const blockConceptRenderer = (locale: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CONCEPT_BLOCK || element.type === TYPE_GLOSS_BLOCK) {
+      return (
+        <BlockWrapper attributes={attributes} element={element} editor={editor} locale={locale}>
+          {children}
+        </BlockWrapper>
+      );
+    } else return renderElement?.({ attributes, element, children });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/concept/inline/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/index.tsx
@@ -8,13 +8,11 @@
 
 import { Descendant, Editor, Element, Node, Range, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import hasNodeOfType from '../../../utils/hasNodeOfType';
 import {
   createEmbedTagV2,
   reduceElementDataAttributesV2,
 } from '../../../../../util/embedTagHelpers';
-import InlineConcept from './InlineWrapper';
 import { KEY_BACKSPACE } from '../../../utils/keys';
 import { SlateSerializer } from '../../../interfaces';
 import { TYPE_CONCEPT_INLINE } from './types';
@@ -77,24 +75,8 @@ const onBackspace = (
   return nextOnKeyDown?.(e);
 };
 
-export const inlineConceptPlugin = (locale: string) => (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    isInline: nextIsInline,
-    onKeyDown: nextOnKeyDown,
-  } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_CONCEPT_INLINE) {
-      return (
-        <InlineConcept element={element} attributes={attributes} editor={editor} locale={locale}>
-          {children}
-        </InlineConcept>
-      );
-    }
-    return nextRenderElement?.(props);
-  };
+export const inlineConceptPlugin = (editor: Editor) => {
+  const { isInline: nextIsInline, onKeyDown: nextOnKeyDown } = editor;
 
   editor.isInline = (element: Element) => {
     if (element.type === TYPE_CONCEPT_INLINE) {

--- a/src/components/SlateEditor/plugins/concept/inline/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/render.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_CONCEPT_INLINE } from './types';
+import InlineConcept from './InlineWrapper';
+
+export const inlineConceptRenderer = (locale: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CONCEPT_INLINE) {
+      return (
+        <InlineConcept element={element} attributes={attributes} editor={editor} locale={locale}>
+          {children}
+        </InlineConcept>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/concept/inline/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/render.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/conceptList/index.tsx
+++ b/src/components/SlateEditor/plugins/conceptList/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { ConceptListEmbedData, EmbedData } from '@ndla/types-embed';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
@@ -15,7 +14,6 @@ import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNor
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
 import { TYPE_NDLA_EMBED } from '../embed/types';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
-import ConceptList from './ConceptList';
 import { TYPE_CONCEPT_LIST } from './types';
 import { defaultConceptListBlock } from './utils';
 
@@ -54,20 +52,8 @@ export const conceptListSerializer: SlateSerializer = {
   },
 };
 
-export const conceptListPlugin = (language: string) => (editor: Editor) => {
-  const { renderElement, isVoid, normalizeNode } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_CONCEPT_LIST) {
-      return (
-        <ConceptList attributes={attributes} element={element} language={language} editor={editor}>
-          {children}
-        </ConceptList>
-      );
-    }
-    return renderElement?.(props);
-  };
+export const conceptListPlugin = (editor: Editor) => {
+  const { isVoid, normalizeNode } = editor;
 
   editor.isVoid = (element: Element) => {
     if (element.type === TYPE_CONCEPT_LIST) {

--- a/src/components/SlateEditor/plugins/conceptList/render.tsx
+++ b/src/components/SlateEditor/plugins/conceptList/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/conceptList/render.tsx
+++ b/src/components/SlateEditor/plugins/conceptList/render.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_CONCEPT_LIST } from './types';
+import ConceptList from './ConceptList';
+
+export const conceptListRenderer = (language: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CONCEPT_LIST) {
+      return (
+        <ConceptList attributes={attributes} element={element} language={language} editor={editor}>
+          {children}
+        </ConceptList>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/contactBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/index.tsx
@@ -8,13 +8,11 @@
 
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import { ContactBlockEmbedData } from '@ndla/types-embed';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { TYPE_NDLA_EMBED } from '../embed/types';
 import { TYPE_CONTACT_BLOCK } from './types';
-import SlateContactBlock from './SlateContactBlock';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
@@ -52,22 +50,7 @@ export const contactBlockSerializer: SlateSerializer = {
 };
 
 export const contactBlockPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_CONTACT_BLOCK) {
-      return (
-        <SlateContactBlock editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateContactBlock>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/contactBlock/render.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/render.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_CONTACT_BLOCK } from './types';
+import SlateContactBlock from './SlateContactBlock';
+
+export const contactBlockRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_CONTACT_BLOCK) {
+      return (
+        <SlateContactBlock editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateContactBlock>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/definitionList/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/definitionList/__tests__/normalizer-test.ts
@@ -9,13 +9,13 @@
 import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import withPlugins from '../../../utils/withPlugins';
 import { TYPE_DEFINITION_DESCRIPTION, TYPE_DEFINITION_LIST, TYPE_DEFINITION_TERM } from '../types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('definition normalizing tests', () => {
   test('should not remove any description or term', () => {

--- a/src/components/SlateEditor/plugins/definitionList/index.tsx
+++ b/src/components/SlateEditor/plugins/definitionList/index.tsx
@@ -8,13 +8,10 @@
 
 import { Descendant, Editor, Element, Path, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
-import { DefinitionDescription, DefinitionTerm } from '@ndla/ui';
 import { SlateSerializer } from '../../interfaces';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { KEY_BACKSPACE, KEY_ENTER, KEY_TAB } from '../../utils/keys';
 import { TYPE_DEFINITION_DESCRIPTION, TYPE_DEFINITION_LIST, TYPE_DEFINITION_TERM } from './types';
-import { TYPE_SECTION } from '../section/types';
 import onEnter from './handlers/onEnter';
 import onTab from './handlers/onTab';
 import onBackspace from './handlers/onBackspace';
@@ -82,11 +79,7 @@ export const definitionListSerializer: SlateSerializer = {
 };
 
 export const definitionListPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    onKeyDown: nextOnKeyDown,
-  } = editor;
+  const { normalizeNode: nextNormalizeNode, onKeyDown: nextOnKeyDown } = editor;
 
   editor.onKeyDown = (e: KeyboardEvent) => {
     if (e.key === KEY_ENTER) {
@@ -98,20 +91,6 @@ export const definitionListPlugin = (editor: Editor) => {
     } else if (nextOnKeyDown) {
       nextOnKeyDown(e);
     }
-  };
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { attributes, children, element } = props;
-    if (element.type === TYPE_DEFINITION_LIST) {
-      return <dl {...attributes}>{children}</dl>;
-    } else if (element.type === TYPE_DEFINITION_DESCRIPTION) {
-      return <DefinitionDescription {...attributes}>{children}</DefinitionDescription>;
-    } else if (element.type === TYPE_DEFINITION_TERM) {
-      return <DefinitionTerm {...attributes}>{children}</DefinitionTerm>;
-    } else if (nextRenderElement) {
-      return nextRenderElement(props);
-    }
-    return undefined;
   };
 
   editor.normalizeNode = (entry) => {

--- a/src/components/SlateEditor/plugins/definitionList/render.tsx
+++ b/src/components/SlateEditor/plugins/definitionList/render.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { DefinitionDescription, DefinitionTerm } from '@ndla/ui';
+import { TYPE_DEFINITION_DESCRIPTION, TYPE_DEFINITION_LIST, TYPE_DEFINITION_TERM } from './types';
+
+export const definitionListRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_DEFINITION_LIST) {
+      return <dl {...attributes}>{children}</dl>;
+    } else if (element.type === TYPE_DEFINITION_DESCRIPTION) {
+      return <DefinitionDescription {...attributes}>{children}</DefinitionDescription>;
+    } else if (element.type === TYPE_DEFINITION_TERM) {
+      return <DefinitionTerm {...attributes}>{children}</DefinitionTerm>;
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/details/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/details/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_DETAILS, TYPE_SUMMARY } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('details normalizer tests', () => {
   test('adds paragraphs around details element', () => {

--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -7,10 +7,9 @@
  */
 
 import { Element, Descendant, Editor, Path, Transforms, Node, Range, Location } from 'slate';
-import { ReactEditor, RenderElementProps, RenderLeafProps } from 'slate-react';
+import { ReactEditor, RenderLeafProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
-import Details from './Details';
 import hasNodeOfType from '../../utils/hasNodeOfType';
 import getCurrentBlock from '../../utils/getCurrentBlock';
 import containsVoid from '../../utils/containsVoid';
@@ -19,7 +18,6 @@ import {
   lastTextBlockElement,
   textBlockElements,
 } from '../../utils/normalizationHelpers';
-import Summary from './Summary';
 import WithPlaceHolder from '../../common/WithPlaceHolder';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { KEY_BACKSPACE, KEY_ENTER } from '../../utils/keys';
@@ -144,7 +142,6 @@ export const detailsSerializer: SlateSerializer = {
 
 export const detailsPlugin = (editor: Editor) => {
   const {
-    renderElement: nextRenderElement,
     normalizeNode: nextNormalizeNode,
     onKeyDown: nextOnKeyDown,
     shouldShowToolbar: nextShouldShowToolbar,
@@ -173,24 +170,6 @@ export const detailsPlugin = (editor: Editor) => {
       return nextShouldShowToolbar();
     }
     return true;
-  };
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_SUMMARY) {
-      return (
-        <Summary attributes={attributes} element={element}>
-          {children}
-        </Summary>
-      );
-    } else if (element.type === TYPE_DETAILS) {
-      return (
-        <Details attributes={attributes} editor={editor} element={element}>
-          {children}
-        </Details>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
   };
 
   editor.renderLeaf = (props: RenderLeafProps) => {

--- a/src/components/SlateEditor/plugins/details/render.tsx
+++ b/src/components/SlateEditor/plugins/details/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/details/render.tsx
+++ b/src/components/SlateEditor/plugins/details/render.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_DETAILS, TYPE_SUMMARY } from './types';
+import Summary from './Summary';
+import Details from './Details';
+
+export const detailsRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_SUMMARY) {
+      return (
+        <Summary attributes={attributes} element={element}>
+          {children}
+        </Summary>
+      );
+    } else if (element.type === TYPE_DETAILS) {
+      return (
+        <Details attributes={attributes} editor={editor} element={element}>
+          {children}
+        </Details>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/div/index.tsx
+++ b/src/components/SlateEditor/plugins/div/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Editor, Element, Descendant } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
 import { TYPE_DIV } from './types';
@@ -47,16 +46,5 @@ export const divSerializer: SlateSerializer = {
 };
 
 export const divPlugin = (editor: Editor) => {
-  const { renderElement: nextRenderElement } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_DIV) {
-      return <div {...attributes}>{children}</div>;
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
-
   return editor;
 };

--- a/src/components/SlateEditor/plugins/div/render.tsx
+++ b/src/components/SlateEditor/plugins/div/render.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { RenderElementProps } from 'slate-react';
+import { TYPE_DIV } from './types';
+
+export const divRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
+    if (element.type === TYPE_DIV) {
+      return <div {...attributes}>{children}</div>;
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/div/render.tsx
+++ b/src/components/SlateEditor/plugins/div/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
@@ -10,14 +10,14 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_EMBED_IMAGE } from '../types';
 import { TYPE_AUDIO } from '../../audio/types';
 import { TYPE_H5P } from '../../h5p/types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('embed normalizer tests', () => {
   test('adds paragraphs around embed', () => {

--- a/src/components/SlateEditor/plugins/embed/index.tsx
+++ b/src/components/SlateEditor/plugins/embed/index.tsx
@@ -7,8 +7,6 @@
  */
 
 import { Editor, Descendant, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
-import SlateFigure from './SlateFigure';
 import { SlateSerializer } from '../../interfaces';
 import {
   Embed,
@@ -80,52 +78,28 @@ export const embedSerializer: SlateSerializer = {
   },
 };
 
-export const embedPlugin =
-  (language: string, disableNormalize?: boolean, allowDecorative?: boolean) => (editor: Editor) => {
-    const {
-      renderElement: nextRenderElement,
-      normalizeNode: nextNormalizeNode,
-      isVoid: nextIsVoid,
-    } = editor;
+export const embedPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
-    editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-      if (isSlateEmbedElement(element)) {
-        return (
-          <SlateFigure
-            attributes={attributes}
-            editor={editor}
-            element={element}
-            language={language}
-            allowDecorative={allowDecorative}
-          >
-            {children}
-          </SlateFigure>
-        );
-      } else if (nextRenderElement) {
-        return nextRenderElement({ attributes, children, element });
+  editor.normalizeNode = (entry) => {
+    const [node] = entry;
+
+    if (isSlateEmbed(node)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+        return;
       }
       return undefined;
-    };
+    }
 
-    editor.normalizeNode = (entry) => {
-      const [node] = entry;
-
-      if (isSlateEmbed(node)) {
-        if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
-          return;
-        }
-        return undefined;
-      }
-
-      nextNormalizeNode(entry);
-    };
-
-    editor.isVoid = (element: Element) => {
-      if (isSlateEmbedElement(element)) {
-        return true;
-      }
-      return nextIsVoid(element);
-    };
-
-    return editor;
+    nextNormalizeNode(entry);
   };
+
+  editor.isVoid = (element: Element) => {
+    if (isSlateEmbedElement(element)) {
+      return true;
+    }
+    return nextIsVoid(element);
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/embed/render.tsx
+++ b/src/components/SlateEditor/plugins/embed/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/embed/render.tsx
+++ b/src/components/SlateEditor/plugins/embed/render.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { isSlateEmbedElement } from './utils';
+import SlateFigure from './SlateFigure';
+
+export const embedRenderer = (language: string, allowDecorative?: boolean) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (isSlateEmbedElement(element)) {
+      return (
+        <SlateFigure
+          attributes={attributes}
+          editor={editor}
+          element={element}
+          language={language}
+          allowDecorative={allowDecorative}
+        >
+          {children}
+        </SlateFigure>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/file/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/file/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_FILE } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('file normalizer tests', () => {
   test('adds paragraphs around file element', () => {

--- a/src/components/SlateEditor/plugins/file/index.tsx
+++ b/src/components/SlateEditor/plugins/file/index.tsx
@@ -7,8 +7,6 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
-import FileList from './FileList';
 import { createEmbedTag } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { File } from '../../../../interfaces';
@@ -54,24 +52,7 @@ export const fileSerializer: SlateSerializer = {
 };
 
 export const filePlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_FILE) {
-      return (
-        <FileList editor={editor} element={element} attributes={attributes}>
-          {children}
-        </FileList>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.isVoid = (element: Element) => {
     if (element.type === TYPE_FILE) {

--- a/src/components/SlateEditor/plugins/file/render.tsx
+++ b/src/components/SlateEditor/plugins/file/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_FILE } from './types';
+import FileList from './FileList';
+
+export const fileRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_FILE) {
+      return (
+        <FileList editor={editor} element={element} attributes={attributes}>
+          {children}
+        </FileList>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/file/render.tsx
+++ b/src/components/SlateEditor/plugins/file/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/footnote/index.tsx
+++ b/src/components/SlateEditor/plugins/footnote/index.tsx
@@ -7,10 +7,8 @@
  */
 
 import { Descendant, Editor, Element, Transforms, Range } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
-import Footnote from './Footnote';
 import { reduceElementDataAttributes, createEmbedTag } from '../../../../util/embedTagHelpers';
 import getCurrentBlock from '../../utils/getCurrentBlock';
 import { KEY_BACKSPACE, KEY_DELETE } from '../../utils/keys';
@@ -62,24 +60,7 @@ export const footnoteSerializer: SlateSerializer = {
 };
 
 export const footnotePlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    isInline: nextIsInline,
-    isVoid: nextIsVoid,
-    onKeyDown: nextOnKeyDown,
-  } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_FOOTNOTE) {
-      return (
-        <Footnote element={element} attributes={attributes} editor={editor}>
-          {children}
-        </Footnote>
-      );
-    }
-    return nextRenderElement && nextRenderElement(props);
-  };
+  const { isInline: nextIsInline, isVoid: nextIsVoid, onKeyDown: nextOnKeyDown } = editor;
 
   editor.isInline = (element: Element) => {
     if (element.type === TYPE_FOOTNOTE) {

--- a/src/components/SlateEditor/plugins/footnote/render.tsx
+++ b/src/components/SlateEditor/plugins/footnote/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/footnote/render.tsx
+++ b/src/components/SlateEditor/plugins/footnote/render.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_FOOTNOTE } from './types';
+import Footnote from './Footnote';
+
+export const footnoteRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ element, attributes, children }) => {
+    if (element.type === TYPE_FOOTNOTE) {
+      <Footnote element={element} attributes={attributes} editor={editor}>
+        {children}
+      </Footnote>;
+    } else return renderElement?.({ element, attributes, children });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/grid/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/grid/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent';
+import { frontpagePlugins } from '../../../../../containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_GRID, TYPE_GRID_CELL } from '../types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), frontpagePlugins)));
 
 describe('normalizing grid tests', () => {
   test('column of two should have only two cells', () => {

--- a/src/components/SlateEditor/plugins/grid/index.tsx
+++ b/src/components/SlateEditor/plugins/grid/index.tsx
@@ -7,11 +7,9 @@
  */
 
 import { Descendant, Editor, Element, Transforms } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { GridType } from '@ndla/ui';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
-import { SlateGrid } from './SlateGrid';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
 import { SlateSerializer } from '../../interfaces';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
@@ -20,7 +18,6 @@ import { TYPE_GRID, TYPE_GRID_CELL } from './types';
 import { defaultGridCellBlock } from './utils';
 import { TYPE_EMBED_IMAGE } from '../embed/types';
 import { TYPE_BLOGPOST } from '../blogPost/types';
-import SlateGridCell from './SlateGridCell';
 import { TYPE_HEADING } from '../heading/types';
 import { TYPE_LIST } from '../list/types';
 import { TYPE_KEY_FIGURE } from '../keyFigure/types';
@@ -116,24 +113,7 @@ export const gridSerializer: SlateSerializer = {
 };
 
 export const gridPlugin = (editor: Editor) => {
-  const { renderElement: nextRenderElement, normalizeNode: nextNormalizeNode } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_GRID) {
-      return (
-        <SlateGrid editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateGrid>
-      );
-    } else if (element.type === TYPE_GRID_CELL) {
-      return (
-        <SlateGridCell editor={editor} element={element} attributes={attributes}>
-          {children}
-        </SlateGridCell>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+  const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;

--- a/src/components/SlateEditor/plugins/grid/render.tsx
+++ b/src/components/SlateEditor/plugins/grid/render.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_GRID, TYPE_GRID_CELL } from './types';
+import { SlateGrid } from './SlateGrid';
+import SlateGridCell from './SlateGridCell';
+
+export const gridRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_GRID) {
+      return (
+        <SlateGrid editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateGrid>
+      );
+    } else if (element.type === TYPE_GRID_CELL) {
+      return (
+        <SlateGridCell editor={editor} element={element} attributes={attributes}>
+          {children}
+        </SlateGridCell>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/h5p/index.tsx
+++ b/src/components/SlateEditor/plugins/h5p/index.tsx
@@ -8,7 +8,6 @@
 
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { NormalizerConfig, defaultBlockNormalizer } from '../../utils/defaultNormalizer';
@@ -16,7 +15,6 @@ import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers'
 import { TYPE_NDLA_EMBED } from '../embed/types';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { TYPE_H5P } from './types';
-import SlateH5p from './SlateH5p';
 
 const normalizerConfig: NormalizerConfig = {
   previous: {
@@ -43,23 +41,8 @@ export const h5pSerializer: SlateSerializer = {
   },
 };
 
-export const h5pPlugin = (language: string, disableNormalize?: boolean) => (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    isVoid: nextIsVoid,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_H5P) {
-      return (
-        <SlateH5p attributes={attributes} editor={editor} element={element} language={language}>
-          {children}
-        </SlateH5p>
-      );
-    }
-    return nextRenderElement?.({ attributes, children, element });
-  };
+export const h5pPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
+  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/h5p/render.tsx
+++ b/src/components/SlateEditor/plugins/h5p/render.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_H5P } from './types';
+import SlateH5p from './SlateH5p';
+
+export const h5pRenderer = (language: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_H5P) {
+      return (
+        <SlateH5p attributes={attributes} editor={editor} element={element} language={language}>
+          {children}
+        </SlateH5p>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/heading/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/heading/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor, Transforms } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_HEADING } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('heading normalizer tests', () => {
   test('unwrap empty header if not selected', () => {

--- a/src/components/SlateEditor/plugins/heading/index.tsx
+++ b/src/components/SlateEditor/plugins/heading/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import { createElement } from 'react';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element, Transforms, Range, Node, Path } from 'slate';
 import { SlateSerializer } from '../../interfaces';
@@ -105,36 +104,7 @@ const onBackspace = (
 };
 
 export const headingPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    onKeyDown: nextOnKeyDown,
-  } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_HEADING) {
-      switch (element.level) {
-        case 1:
-          return <h1 {...attributes}>{children}</h1>;
-        case 2:
-          return <h2 {...attributes}>{children}</h2>;
-        case 3:
-          return <h3 {...attributes}>{children}</h3>;
-        case 4:
-          return <h4 {...attributes}>{children}</h4>;
-        case 5:
-          return <h5 {...attributes}>{children}</h5>;
-        case 6:
-          return <h6 {...attributes}>{children}</h6>;
-        default:
-          return nextRenderElement && nextRenderElement(props);
-      }
-    } else if (nextRenderElement) {
-      return nextRenderElement(props);
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode, onKeyDown: nextOnKeyDown } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;

--- a/src/components/SlateEditor/plugins/heading/render.tsx
+++ b/src/components/SlateEditor/plugins/heading/render.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_HEADING } from './types';
+
+export const headingRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_HEADING) {
+      switch (element.level) {
+        case 1:
+          return <h1 {...attributes}>{children}</h1>;
+        case 2:
+          return <h2 {...attributes}>{children}</h2>;
+        case 3:
+          return <h3 {...attributes}>{children}</h3>;
+        case 4:
+          return <h4 {...attributes}>{children}</h4>;
+        case 5:
+          return <h5 {...attributes}>{children}</h5>;
+        case 6:
+          return <h6 {...attributes}>{children}</h6>;
+        default:
+          return renderElement?.({ attributes, children, element });
+      }
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/heading/render.tsx
+++ b/src/components/SlateEditor/plugins/heading/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/keyFigure/index.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/index.tsx
@@ -9,7 +9,6 @@
 import { EmbedData, KeyFigureEmbedData } from '@ndla/types-embed';
 import { Descendant, Editor, Element } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
@@ -17,7 +16,6 @@ import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers'
 import { TYPE_NDLA_EMBED } from '../embed/types';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { TYPE_KEY_FIGURE } from './types';
-import SlateKeyFigure from './SlateKeyFigure';
 
 export interface KeyFigureElement {
   type: 'key-figure';
@@ -54,19 +52,7 @@ export const keyFigureSerializer: SlateSerializer = {
 };
 
 export const keyFigurePlugin = (editor: Editor) => {
-  const { renderElement, normalizeNode, isVoid: nextIsVoid } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_KEY_FIGURE) {
-      return (
-        <SlateKeyFigure element={element} editor={editor} attributes={attributes}>
-          {children}
-        </SlateKeyFigure>
-      );
-    }
-    return renderElement?.(props);
-  };
+  const { normalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node] = entry;

--- a/src/components/SlateEditor/plugins/keyFigure/render.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_KEY_FIGURE } from './types';
+import SlateKeyFigure from './SlateKeyFigure';
+
+export const keyFigureRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_KEY_FIGURE) {
+      return (
+        <SlateKeyFigure element={element} editor={editor} attributes={attributes}>
+          {children}
+        </SlateKeyFigure>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_LINK, TYPE_CONTENT_LINK } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('link normalizer tests', () => {
   test('Remove any elements in links', () => {

--- a/src/components/SlateEditor/plugins/link/index.tsx
+++ b/src/components/SlateEditor/plugins/link/index.tsx
@@ -6,12 +6,10 @@
  *
  */
 
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element, Text, Node, Transforms } from 'slate';
 import { ContentLinkEmbedData } from '@ndla/types-embed';
 import { SlateSerializer } from '../../interfaces';
-import Link from './Link';
 import { reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
 import { TYPE_CONTENT_LINK, TYPE_LINK } from './types';
 import { TYPE_NDLA_EMBED } from '../embed/types';
@@ -87,12 +85,8 @@ export const linkSerializer: SlateSerializer = {
   },
 };
 
-export const linkPlugin = (language: string) => (editor: Editor) => {
-  const {
-    isInline: nextIsInline,
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-  } = editor;
+export const linkPlugin = (editor: Editor) => {
+  const { isInline: nextIsInline, normalizeNode: nextNormalizeNode } = editor;
 
   editor.isInline = (element: Element) => {
     if (element.type === 'link' || element.type === 'content-link') {
@@ -100,20 +94,6 @@ export const linkPlugin = (language: string) => (editor: Editor) => {
     } else {
       return nextIsInline(element);
     }
-  };
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { children, element, attributes } = props;
-    if (element.type === 'link' || element.type === 'content-link') {
-      return (
-        <Link element={element} attributes={attributes} editor={editor} language={language}>
-          {children}
-        </Link>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement(props);
-    }
-    return undefined;
   };
 
   editor.normalizeNode = (entry) => {

--- a/src/components/SlateEditor/plugins/link/render.tsx
+++ b/src/components/SlateEditor/plugins/link/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/link/render.tsx
+++ b/src/components/SlateEditor/plugins/link/render.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import Link from './Link';
+
+export const linkRenderer = (language: string) => (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === 'link' || element.type === 'content-link') {
+      return (
+        <Link element={element} attributes={attributes} editor={editor} language={language}>
+          {children}
+        </Link>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/linkBlockList/index.tsx
+++ b/src/components/SlateEditor/plugins/linkBlockList/index.tsx
@@ -8,14 +8,12 @@
 
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { NormalizerConfig, defaultBlockNormalizer } from '../../utils/defaultNormalizer';
 import { afterOrBeforeTextBlockElement } from '../../utils/normalizationHelpers';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { SlateSerializer } from '../../interfaces';
 import { TYPE_LINK_BLOCK_LIST } from './types';
 import { createEmbedTagV2, reduceElementDataAttributesV2 } from '../../../../util/embedTagHelpers';
-import SlateLinkBlockList from './SlateLinkBlockList';
 
 const normalizerConfig: NormalizerConfig = {
   previous: {
@@ -57,18 +55,7 @@ export const linkBlockListSerializer: SlateSerializer = {
 };
 
 export const linkBlockListPlugin = (editor: Editor) => {
-  const { renderElement, isVoid, normalizeNode } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_LINK_BLOCK_LIST) {
-      return (
-        <SlateLinkBlockList attributes={attributes} element={element} editor={editor}>
-          {children}
-        </SlateLinkBlockList>
-      );
-    }
-    return renderElement?.({ attributes, children, element });
-  };
+  const { isVoid, normalizeNode } = editor;
 
   editor.isVoid = (element) => {
     if (element.type === TYPE_LINK_BLOCK_LIST) {

--- a/src/components/SlateEditor/plugins/linkBlockList/render.tsx
+++ b/src/components/SlateEditor/plugins/linkBlockList/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_LINK_BLOCK_LIST } from './types';
+import SlateLinkBlockList from './SlateLinkBlockList';
+
+export const linkBlockListRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_LINK_BLOCK_LIST) {
+      return (
+        <SlateLinkBlockList attributes={attributes} element={element} editor={editor}>
+          {children}
+        </SlateLinkBlockList>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/list/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/list/__tests__/normalizer-test.ts
@@ -11,11 +11,11 @@ import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import { TYPE_LIST, TYPE_LIST_ITEM } from '../types';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('list normalizer tests', () => {
   test('Unwrap list item not placed inside list', () => {

--- a/src/components/SlateEditor/plugins/list/index.tsx
+++ b/src/components/SlateEditor/plugins/list/index.tsx
@@ -1,8 +1,5 @@
 import { Editor, Node, Element, Descendant, Transforms, Text, Path } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import styled from '@emotion/styled';
-import { OrderedList, UnOrderedList } from '@ndla/ui';
 import { SlateSerializer } from '../../interfaces';
 import onEnter from './handlers/onEnter';
 import { firstTextBlockElement } from '../../utils/normalizationHelpers';
@@ -33,11 +30,6 @@ export interface ListItemElement {
   moveUp?: boolean;
   moveDown?: boolean;
 }
-
-const BulletedList = styled(UnOrderedList)`
-  margin: 16px 0;
-  padding: 0;
-`;
 
 const inlines = [TYPE_CONCEPT_INLINE, TYPE_FOOTNOTE, TYPE_LINK, TYPE_CONTENT_LINK, TYPE_MATHML];
 
@@ -154,42 +146,7 @@ export const listSerializer: SlateSerializer = {
 };
 
 export const listPlugin = (editor: Editor) => {
-  const { onKeyDown, renderElement, normalizeNode } = editor;
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === TYPE_LIST) {
-      if (element.listType === 'bulleted-list') {
-        return <BulletedList {...attributes}>{children}</BulletedList>;
-      } else if (element.listType === 'numbered-list') {
-        const { start } = element.data;
-        return (
-          <OrderedList
-            start={start ? parseInt(start) : undefined}
-            className={`${start ? `ol-reset-${start}` : ''}`}
-            {...attributes}
-          >
-            {children}
-          </OrderedList>
-        );
-      } else if (element.listType === 'letter-list') {
-        const { start } = element.data;
-        return (
-          <OrderedList
-            start={start ? parseInt(start) : undefined}
-            data-type="letters"
-            className={`ol-list--roman ${start ? `ol-reset-${start}` : ''}`}
-            {...attributes}
-          >
-            {children}
-          </OrderedList>
-        );
-      }
-    } else if (element.type === TYPE_LIST_ITEM) {
-      return <li {...attributes}>{children}</li>;
-    } else if (renderElement) {
-      return renderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { onKeyDown, normalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;

--- a/src/components/SlateEditor/plugins/list/render.tsx
+++ b/src/components/SlateEditor/plugins/list/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/list/render.tsx
+++ b/src/components/SlateEditor/plugins/list/render.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import styled from '@emotion/styled';
+import { OrderedList, UnOrderedList } from '@ndla/ui';
+import { TYPE_LIST, TYPE_LIST_ITEM } from './types';
+
+const BulletedList = styled(UnOrderedList)`
+  margin: 16px 0;
+  padding: 0;
+`;
+
+export const listRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_LIST) {
+      if (element.listType === 'bulleted-list') {
+        return <BulletedList {...attributes}>{children}</BulletedList>;
+      } else if (element.listType === 'numbered-list') {
+        const { start } = element.data;
+        return (
+          <OrderedList
+            start={start ? parseInt(start) : undefined}
+            className={`${start ? `ol-reset-${start}` : ''}`}
+            {...attributes}
+          >
+            {children}
+          </OrderedList>
+        );
+      } else if (element.listType === 'letter-list') {
+        const { start } = element.data;
+        return (
+          <OrderedList
+            start={start ? parseInt(start) : undefined}
+            data-type="letters"
+            className={`ol-list--roman ${start ? `ol-reset-${start}` : ''}`}
+            {...attributes}
+          >
+            {children}
+          </OrderedList>
+        );
+      }
+    } else if (element.type === TYPE_LIST_ITEM) {
+      return <li {...attributes}>{children}</li>;
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/mark/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/mark/__tests__/normalizer-test.ts
@@ -10,11 +10,11 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('mark normalizer tests', () => {
   test('Remove marks from empty text nodes', () => {

--- a/src/components/SlateEditor/plugins/mark/index.tsx
+++ b/src/components/SlateEditor/plugins/mark/index.tsx
@@ -6,11 +6,9 @@
  *
  */
 
-import styled from '@emotion/styled';
 import { ReactElement } from 'react';
 import { Descendant, Editor, Text, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderLeafProps } from 'slate-react';
 import { SlateSerializer } from '../../interfaces';
 
 export const isMarkActive = (editor: Editor, format: string) => {
@@ -36,13 +34,6 @@ const marks: { [key: string]: string } = {
   sup: 'sup',
   sub: 'sub',
 };
-
-const StyledCode = styled.code`
-  display: inline;
-  padding: 0;
-  margin: 0;
-  background-color: #eee;
-`;
 
 export const markSerializer: SlateSerializer = {
   deserialize(el: HTMLElement, children: Descendant[]) {
@@ -88,36 +79,7 @@ export const markSerializer: SlateSerializer = {
 };
 
 export const markPlugin = (editor: Editor) => {
-  const { renderLeaf: nextRenderLeaf, normalizeNode: nextNormalizeNode } = editor;
-
-  editor.renderLeaf = ({ attributes, children, leaf, text }: RenderLeafProps) => {
-    let ret;
-    if (leaf.bold) {
-      ret = <strong {...attributes}>{ret || children}</strong>;
-    }
-    if (leaf.italic) {
-      ret = <em {...attributes}>{ret || children}</em>;
-    }
-    if (leaf.sup) {
-      ret = <sup {...attributes}>{ret || children}</sup>;
-    }
-    if (leaf.sub) {
-      ret = <sub {...attributes}>{ret || children}</sub>;
-    }
-    if (leaf.underlined) {
-      ret = <u {...attributes}>{ret || children}</u>;
-    }
-    if (leaf.code) {
-      ret = <StyledCode {...attributes}>{ret || children}</StyledCode>;
-    }
-    if (ret) {
-      return ret;
-    }
-    if (nextRenderLeaf) {
-      return nextRenderLeaf({ attributes, children, leaf, text });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;

--- a/src/components/SlateEditor/plugins/mark/render.tsx
+++ b/src/components/SlateEditor/plugins/mark/render.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import styled from '@emotion/styled';
+import { Editor } from 'slate';
+
+const StyledCode = styled.code`
+  display: inline;
+  padding: 0;
+  margin: 0;
+  background-color: #eee;
+`;
+
+export const markRenderer = (editor: Editor) => {
+  const { renderLeaf } = editor;
+  editor.renderLeaf = ({ attributes, children, leaf, text }) => {
+    let ret;
+    if (leaf.bold) {
+      ret = <strong {...attributes}>{ret || children}</strong>;
+    }
+    if (leaf.italic) {
+      ret = <em {...attributes}>{ret || children}</em>;
+    }
+    if (leaf.sup) {
+      ret = <sup {...attributes}>{ret || children}</sup>;
+    }
+    if (leaf.sub) {
+      ret = <sub {...attributes}>{ret || children}</sub>;
+    }
+    if (leaf.underlined) {
+      ret = <u {...attributes}>{ret || children}</u>;
+    }
+    if (leaf.code) {
+      ret = <StyledCode {...attributes}>{ret || children}</StyledCode>;
+    }
+    if (ret) {
+      return ret;
+    } else return renderLeaf?.({ attributes, children, leaf, text });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/mark/render.tsx
+++ b/src/components/SlateEditor/plugins/mark/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/mathml/index.tsx
+++ b/src/components/SlateEditor/plugins/mathml/index.tsx
@@ -7,11 +7,9 @@
  */
 
 import { Descendant, Editor, Element } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
 import { reduceElementDataAttributes } from '../../../../util/embedTagHelpers';
-import MathEditor from './MathEditor';
 import { TYPE_MATHML } from './types';
 import { KEY_ARROW_DOWN, KEY_ARROW_UP } from '../../utils/keys';
 import { onArrowDown, onArrowUp } from './utils';
@@ -49,24 +47,7 @@ export const mathmlSerializer: SlateSerializer = {
 };
 
 export const mathmlPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    isInline: nextIsInline,
-    isVoid: nextIsVoid,
-    onKeyDown,
-  } = editor;
-
-  editor.renderElement = (props: RenderElementProps) => {
-    const { element, attributes, children } = props;
-    if (element.type === TYPE_MATHML) {
-      return (
-        <MathEditor element={element} attributes={attributes} editor={editor}>
-          {children}
-        </MathEditor>
-      );
-    }
-    return nextRenderElement && nextRenderElement(props);
-  };
+  const { isInline: nextIsInline, isVoid: nextIsVoid, onKeyDown } = editor;
 
   editor.isInline = (element: Element) => {
     if (element.type === TYPE_MATHML) {

--- a/src/components/SlateEditor/plugins/mathml/mathRenderer.tsx
+++ b/src/components/SlateEditor/plugins/mathml/mathRenderer.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_MATHML } from './types';
+import MathEditor from './MathEditor';
+
+export const mathRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === TYPE_MATHML) {
+      return (
+        <MathEditor element={element} attributes={attributes} editor={editor}>
+          {children}
+        </MathEditor>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/mathml/mathRenderer.tsx
+++ b/src/components/SlateEditor/plugins/mathml/mathRenderer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/noEmbed/index.tsx
+++ b/src/components/SlateEditor/plugins/noEmbed/index.tsx
@@ -7,9 +7,8 @@
  */
 
 import { Descendant, Editor } from 'slate';
-import NoEmbedMessage from './NoEmbedMessage';
 import { SlateSerializer } from '../../interfaces';
-import { defaultEmbedBlock, isSlateEmbed, isSlateEmbedElement } from '../embed/utils';
+import { defaultEmbedBlock, isSlateEmbed } from '../embed/utils';
 import { parseEmbedTag } from '../../../../util/embedTagHelpers';
 import { Embed } from '../../../../interfaces';
 import { TYPE_NDLA_EMBED } from '../embed/types';
@@ -28,13 +27,5 @@ export const noEmbedSerializer: SlateSerializer = {
 };
 
 export const noEmbedPlugin = (editor: Editor) => {
-  const { renderElement } = editor;
-
-  editor.renderElement = ({ attributes, element, children }) => {
-    if (isSlateEmbedElement(element)) {
-      return <NoEmbedMessage attributes={attributes} element={element} />;
-    }
-    return renderElement?.({ attributes, element, children });
-  };
   return editor;
 };

--- a/src/components/SlateEditor/plugins/noEmbed/render.tsx
+++ b/src/components/SlateEditor/plugins/noEmbed/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/noEmbed/render.tsx
+++ b/src/components/SlateEditor/plugins/noEmbed/render.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { isSlateEmbedElement } from '../embed/utils';
+import NoEmbedMessage from './NoEmbedMessage';
+
+export const noEmbedRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (isSlateEmbedElement(element)) {
+      return <NoEmbedMessage attributes={attributes} element={element} />;
+    } else return renderElement?.({ attributes, element, children });
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/paragraph/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/paragraph/__tests__/normalizer-test.ts
@@ -10,11 +10,11 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_PARAGRAPH } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('paragraph normalizer tests', () => {
   test('Remove serializeAsText from paragraph that is not placed in list-item', () => {

--- a/src/components/SlateEditor/plugins/paragraph/index.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/index.tsx
@@ -7,15 +7,12 @@
  */
 
 import { Editor, Node, Element, Descendant, Text, Path, Transforms } from 'slate';
-import { RenderElementProps } from 'slate-react';
 import { jsx as slatejsx } from 'slate-hyperscript';
 import { SlateSerializer } from '../../interfaces';
 import { reduceElementDataAttributes } from '../../../../util/embedTagHelpers';
 import { getCurrentParagraph, isParagraph } from './utils';
 import containsVoid from '../../utils/containsVoid';
 import { TYPE_LIST_ITEM } from '../list/types';
-import { BlockPickerOptions } from '../blockPicker/options';
-import Paragraph from './Paragraph';
 import { KEY_ENTER } from '../../utils/keys';
 import { TYPE_BREAK } from '../break/types';
 import { TYPE_TABLE_CELL } from '../table/types';
@@ -110,88 +107,68 @@ export const paragraphSerializer: SlateSerializer = {
   },
 };
 
-export const paragraphPlugin =
-  (language?: string, blockpickerOptions?: BlockPickerOptions) => (editor: Editor) => {
-    const { onKeyDown, renderElement, normalizeNode } = editor;
+export const paragraphPlugin = (editor: Editor) => {
+  const { onKeyDown, normalizeNode } = editor;
 
-    editor.onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === KEY_ENTER) {
-        onEnter(e, editor, onKeyDown);
-      } else if (onKeyDown) {
-        onKeyDown(e);
-      }
-    };
-
-    editor.normalizeNode = (entry) => {
-      const [node, path] = entry;
-
-      if (Element.isElement(node) && node.type === TYPE_PARAGRAPH) {
-        const [parentNode] = Editor.node(editor, Path.parent(path));
-
-        // If paragraph is not in a list or table, make sure it will be rendered with <p>-tag
-        if (
-          Element.isElement(parentNode) &&
-          parentNode.type !== TYPE_TABLE_CELL &&
-          parentNode.type !== TYPE_LIST_ITEM &&
-          node.serializeAsText
-        ) {
-          return Transforms.unsetNodes(editor, 'serializeAsText', { at: path });
-        }
-
-        // If two paragraphs are direct siblings, make sure both will be rendered with <p>-tag
-        if (Path.hasPrevious(path)) {
-          const [previousNode] = Editor.node(editor, Path.previous(path));
-          if (isParagraph(previousNode) && (previousNode.serializeAsText || node.serializeAsText)) {
-            return Transforms.unsetNodes(editor, 'serializeAsText', {
-              at: Path.parent(path),
-              mode: 'all',
-              match: isParagraph,
-            });
-          }
-        }
-        if (Editor.hasPath(editor, Path.next(path))) {
-          const [nextNode] = Editor.node(editor, Path.next(path));
-          if (isParagraph(nextNode) && (nextNode.serializeAsText || node.serializeAsText)) {
-            return Transforms.unsetNodes(editor, 'serializeAsText', {
-              at: Path.parent(path),
-              mode: 'all',
-              match: isParagraph,
-            });
-          }
-        }
-      }
-
-      // Unwrap block element children. Only text allowed.
-      if (Element.isElement(node) && node.type === TYPE_PARAGRAPH) {
-        for (const [child, childPath] of Node.children(editor, path)) {
-          if (Element.isElement(child) && !editor.isInline(child)) {
-            Transforms.unwrapNodes(editor, { at: childPath });
-            return;
-          }
-        }
-      }
-
-      normalizeNode(entry);
-    };
-
-    editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-      if (element.type === TYPE_PARAGRAPH) {
-        return (
-          <Paragraph
-            attributes={attributes}
-            element={element}
-            editor={editor}
-            language={language}
-            blockpickerOptions={blockpickerOptions}
-          >
-            {children}
-          </Paragraph>
-        );
-      } else if (renderElement) {
-        return renderElement({ attributes, children, element });
-      }
-      return undefined;
-    };
-
-    return editor;
+  editor.onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === KEY_ENTER) {
+      onEnter(e, editor, onKeyDown);
+    } else if (onKeyDown) {
+      onKeyDown(e);
+    }
   };
+
+  editor.normalizeNode = (entry) => {
+    const [node, path] = entry;
+
+    if (Element.isElement(node) && node.type === TYPE_PARAGRAPH) {
+      const [parentNode] = Editor.node(editor, Path.parent(path));
+
+      // If paragraph is not in a list or table, make sure it will be rendered with <p>-tag
+      if (
+        Element.isElement(parentNode) &&
+        parentNode.type !== TYPE_TABLE_CELL &&
+        parentNode.type !== TYPE_LIST_ITEM &&
+        node.serializeAsText
+      ) {
+        return Transforms.unsetNodes(editor, 'serializeAsText', { at: path });
+      }
+
+      // If two paragraphs are direct siblings, make sure both will be rendered with <p>-tag
+      if (Path.hasPrevious(path)) {
+        const [previousNode] = Editor.node(editor, Path.previous(path));
+        if (isParagraph(previousNode) && (previousNode.serializeAsText || node.serializeAsText)) {
+          return Transforms.unsetNodes(editor, 'serializeAsText', {
+            at: Path.parent(path),
+            mode: 'all',
+            match: isParagraph,
+          });
+        }
+      }
+      if (Editor.hasPath(editor, Path.next(path))) {
+        const [nextNode] = Editor.node(editor, Path.next(path));
+        if (isParagraph(nextNode) && (nextNode.serializeAsText || node.serializeAsText)) {
+          return Transforms.unsetNodes(editor, 'serializeAsText', {
+            at: Path.parent(path),
+            mode: 'all',
+            match: isParagraph,
+          });
+        }
+      }
+    }
+
+    // Unwrap block element children. Only text allowed.
+    if (Element.isElement(node) && node.type === TYPE_PARAGRAPH) {
+      for (const [child, childPath] of Node.children(editor, path)) {
+        if (Element.isElement(child) && !editor.isInline(child)) {
+          Transforms.unwrapNodes(editor, { at: childPath });
+          return;
+        }
+      }
+    }
+
+    normalizeNode(entry);
+  };
+
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/paragraph/render.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/render.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { TYPE_PARAGRAPH } from './types';
+import Paragraph from './Paragraph';
+import { BlockPickerOptions } from '../blockPicker/options';
+
+export const paragraphRenderer =
+  (language?: string, blockpickerOptions?: BlockPickerOptions) => (editor: Editor) => {
+    const { renderElement } = editor;
+    editor.renderElement = ({ attributes, children, element }) => {
+      if (element.type === TYPE_PARAGRAPH) {
+        return (
+          <Paragraph
+            attributes={attributes}
+            element={element}
+            editor={editor}
+            language={language}
+            blockpickerOptions={blockpickerOptions}
+          >
+            {children}
+          </Paragraph>
+        );
+      } else return renderElement?.({ attributes, children, element });
+    };
+    return editor;
+  };

--- a/src/components/SlateEditor/plugins/paragraph/render.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/related/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/related/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_RELATED } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('related normalizer tests', () => {
   test('adds paragraphs around related', () => {

--- a/src/components/SlateEditor/plugins/related/index.tsx
+++ b/src/components/SlateEditor/plugins/related/index.tsx
@@ -6,12 +6,9 @@
  *
  */
 
-import { MouseEvent } from 'react';
-import { Descendant, Editor, Element, Transforms } from 'slate';
-import { ReactEditor, RenderElementProps } from 'slate-react';
+import { Descendant, Editor, Element } from 'slate';
 import { RelatedContentEmbedData } from '@ndla/types-embed';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import RelatedArticleBox from './RelatedArticleBox';
 import { SlateSerializer } from '../../interfaces';
 import { reduceElementDataAttributesV2, createEmbedTagV2 } from '../../../../util/embedTagHelpers';
 import { NormalizerConfig, defaultBlockNormalizer } from '../../utils/defaultNormalizer';
@@ -66,30 +63,7 @@ export const relatedSerializer: SlateSerializer = {
 };
 
 export const relatedPlugin = (editor: Editor) => {
-  const { renderElement, isVoid, normalizeNode } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === 'related') {
-      return (
-        <RelatedArticleBox
-          attributes={attributes}
-          element={element}
-          editor={editor}
-          onRemoveClick={(e: MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-            e.preventDefault();
-            const path = ReactEditor.findPath(editor, element);
-            ReactEditor.focus(editor);
-            Transforms.select(editor, path);
-            Transforms.removeNodes(editor, { at: path });
-          }}
-        >
-          {children}
-        </RelatedArticleBox>
-      );
-    }
-    return renderElement && renderElement({ attributes, children, element });
-  };
+  const { isVoid, normalizeNode } = editor;
 
   editor.isVoid = (element) => {
     if (element.type === 'related') {

--- a/src/components/SlateEditor/plugins/related/relatedRenderer.tsx
+++ b/src/components/SlateEditor/plugins/related/relatedRenderer.tsx
@@ -1,0 +1,31 @@
+import { Editor, Transforms } from 'slate';
+import { MouseEvent } from 'react';
+import { ReactEditor } from 'slate-react';
+import RelatedArticleBox from './RelatedArticleBox';
+
+export const relatedRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    if (element.type === 'related') {
+      return (
+        <RelatedArticleBox
+          attributes={attributes}
+          element={element}
+          editor={editor}
+          onRemoveClick={(e: MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+            e.preventDefault();
+            const path = ReactEditor.findPath(editor, element);
+            ReactEditor.focus(editor);
+            Transforms.select(editor, path);
+            Transforms.removeNodes(editor, { at: path });
+          }}
+        >
+          {children}
+        </RelatedArticleBox>
+      );
+    }
+    return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/related/relatedRenderer.tsx
+++ b/src/components/SlateEditor/plugins/related/relatedRenderer.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { Editor, Transforms } from 'slate';
 import { MouseEvent } from 'react';
 import { ReactEditor } from 'slate-react';

--- a/src/components/SlateEditor/plugins/section/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/section/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_HEADING } from '../../heading/types';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('section normalizer tests', () => {
   test('adds paragraph to empty section', () => {

--- a/src/components/SlateEditor/plugins/section/index.tsx
+++ b/src/components/SlateEditor/plugins/section/index.tsx
@@ -8,8 +8,6 @@
 
 import { Node, Element, Descendant, Editor, Text, Transforms, Range } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
-import Section from './Section';
 import { SlateSerializer } from '../../interfaces';
 import { defaultParagraphBlock } from '../paragraph/utils';
 import { KEY_BACKSPACE, KEY_TAB } from '../../utils/keys';
@@ -74,24 +72,7 @@ const onBackspace = (
 };
 
 export const sectionPlugin = (editor: Editor) => {
-  const {
-    renderElement: nextRenderElement,
-    normalizeNode: nextNormalizeNode,
-    onKeyDown: nextOnKeyDown,
-  } = editor;
-
-  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
-    if (element.type === 'section') {
-      return (
-        <Section attributes={attributes} element={element} editor={editor}>
-          {children}
-        </Section>
-      );
-    } else if (nextRenderElement) {
-      return nextRenderElement({ attributes, children, element });
-    }
-    return undefined;
-  };
+  const { normalizeNode: nextNormalizeNode, onKeyDown: nextOnKeyDown } = editor;
 
   editor.onKeyDown = (e: KeyboardEvent) => {
     if (e.key === KEY_BACKSPACE) {

--- a/src/components/SlateEditor/plugins/section/render.tsx
+++ b/src/components/SlateEditor/plugins/section/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/section/render.tsx
+++ b/src/components/SlateEditor/plugins/section/render.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { RenderElementProps } from 'slate-react';
+import Section from './Section';
+
+export const sectionRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ attributes, children, element }: RenderElementProps) => {
+    if (element.type === 'section') {
+      return (
+        <Section attributes={attributes} element={element} editor={editor}>
+          {children}
+        </Section>
+      );
+    } else return renderElement?.({ attributes, children, element });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
@@ -10,12 +10,12 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import { TYPE_SPAN } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('span normalizer tests', () => {
   test('Span with language remains after normalization', () => {

--- a/src/components/SlateEditor/plugins/span/index.tsx
+++ b/src/components/SlateEditor/plugins/span/index.tsx
@@ -9,7 +9,6 @@
 import isEmpty from 'lodash/isEmpty';
 import { Descendant, Editor, Element, Node, Transforms } from 'slate';
 import { jsx as slatejsx } from 'slate-hyperscript';
-import { RenderElementProps } from 'slate-react';
 import { createProps, reduceElementDataAttributes } from '../../../../util/embedTagHelpers';
 import { SlateSerializer } from '../../interfaces';
 import { defaultBlockNormalizer, NormalizerConfig } from '../../utils/defaultNormalizer';
@@ -20,7 +19,6 @@ import { TYPE_HEADING } from '../heading/types';
 import { TYPE_LIST_ITEM } from '../list/types';
 import { TYPE_PARAGRAPH } from '../paragraph/types';
 import { TYPE_TABLE_CELL } from '../table/types';
-import Span from './Span';
 import { TYPE_SPAN } from './types';
 
 export interface SpanElement {
@@ -70,20 +68,7 @@ export const spanSerializer: SlateSerializer = {
 };
 
 export const spanPlugin = (editor: Editor) => {
-  const { renderElement, isInline, normalizeNode } = editor;
-
-  editor.renderElement = ({ element, attributes, children }: RenderElementProps) => {
-    if (element.type === TYPE_SPAN) {
-      return (
-        <Span element={element} attributes={attributes}>
-          {children}
-        </Span>
-      );
-    } else if (renderElement) {
-      return renderElement({ element, attributes, children });
-    }
-    return undefined;
-  };
+  const { isInline, normalizeNode } = editor;
 
   editor.isInline = (element) => {
     if (element.type === TYPE_SPAN) {

--- a/src/components/SlateEditor/plugins/span/render.tsx
+++ b/src/components/SlateEditor/plugins/span/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/components/SlateEditor/plugins/span/render.tsx
+++ b/src/components/SlateEditor/plugins/span/render.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Editor } from 'slate';
+import { RenderElementProps } from 'slate-react';
+import { TYPE_SPAN } from './types';
+import Span from './Span';
+
+export const spanRenderer = (editor: Editor) => {
+  const { renderElement } = editor;
+  editor.renderElement = ({ element, attributes, children }: RenderElementProps) => {
+    if (element.type === TYPE_SPAN) {
+      return (
+        <Span element={element} attributes={attributes}>
+          {children}
+        </Span>
+      );
+    } else return renderElement?.({ element, attributes, children });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/table/__tests__/combined-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/combined-test.ts
@@ -10,14 +10,14 @@ import { createEditor, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 
 import {
   blockContentToEditorValue,
   blockContentToHTML,
 } from '../../../../../util/articleContentConverter';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('combined table plugin tests', () => {
   test('id in th and td is preserved on serialize and normalize', () => {

--- a/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
@@ -10,7 +10,7 @@ import { createEditor, Descendant, Editor } from 'slate';
 import { withHistory } from 'slate-history';
 import { withReact } from 'slate-react';
 import withPlugins from '../../../utils/withPlugins';
-import { plugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/LearningResourceContent';
+import { learningResourcePlugins } from '../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins';
 import { TYPE_PARAGRAPH } from '../../paragraph/types';
 import { TYPE_SECTION } from '../../section/types';
 import {
@@ -23,7 +23,7 @@ import {
   TYPE_TABLE_CELL_HEADER,
 } from '../types';
 
-const editor = withHistory(withReact(withPlugins(createEditor(), plugins('nb'))));
+const editor = withHistory(withReact(withPlugins(createEditor(), learningResourcePlugins)));
 
 describe('table normalizer tests', () => {
   test('Make sure non-row element in table-head or body is wrapped in row', () => {

--- a/src/components/SlateEditor/plugins/table/render.tsx
+++ b/src/components/SlateEditor/plugins/table/render.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+import { ReactEditor } from 'slate-react';
+import { Editor, Element, Node, Path } from 'slate';
+import { TdHTMLAttributes } from 'react';
+import styled from '@emotion/styled';
+import { colors, fonts } from '@ndla/core';
+import {
+  TYPE_TABLE,
+  TYPE_TABLE_BODY,
+  TYPE_TABLE_CAPTION,
+  TYPE_TABLE_CELL,
+  TYPE_TABLE_CELL_HEADER,
+  TYPE_TABLE_HEAD,
+  TYPE_TABLE_ROW,
+} from './types';
+import TableActions from './TableActions';
+import SlateTable from './SlateTable';
+import WithPlaceHolder from '../../common/WithPlaceHolder';
+
+const StyledTh = styled.th`
+  border: 1px solid ${colors.brand.lighter};
+  background-color: transparent !important;
+  text-align: top;
+  vertical-align: inherit;
+  border-bottom: 3px solid ${colors.brand.tertiary} !important;
+  font-weight: ${fonts.weight.bold};
+  vertical-align: text-top;
+`;
+
+export const tableRenderer = (editor: Editor) => {
+  const { renderElement, renderLeaf } = editor;
+  editor.renderElement = ({ attributes, children, element }) => {
+    switch (element.type) {
+      case TYPE_TABLE:
+        return (
+          <>
+            <TableActions editor={editor} element={element} />
+            <SlateTable editor={editor} element={element} attributes={attributes}>
+              <colgroup
+                contentEditable={false}
+                dangerouslySetInnerHTML={{ __html: element.colgroups || '' }}
+              />
+              {children}
+            </SlateTable>
+          </>
+        );
+      case TYPE_TABLE_CAPTION:
+        return <caption {...attributes}>{children}</caption>;
+      case TYPE_TABLE_ROW:
+        return <tr {...attributes}>{children}</tr>;
+      case TYPE_TABLE_CELL: {
+        const align = element.data.align || '';
+        const parsedAlign = (
+          ['left', 'center', 'right'].includes(align) ? align : undefined
+        ) as TdHTMLAttributes<HTMLTableCellElement>['align'];
+        return (
+          <td
+            rowSpan={element.data.rowspan}
+            colSpan={element.data.colspan}
+            align={parsedAlign}
+            {...attributes}
+          >
+            {children}
+          </td>
+        );
+      }
+      case TYPE_TABLE_HEAD:
+        return <thead {...attributes}>{children}</thead>;
+      case TYPE_TABLE_BODY:
+        return <tbody {...attributes}>{children}</tbody>;
+      case TYPE_TABLE_CELL_HEADER:
+        return (
+          <StyledTh
+            rowSpan={element.data.rowspan}
+            colSpan={element.data.colspan}
+            scope={element.data.scope}
+            {...attributes}
+          >
+            {children}
+          </StyledTh>
+        );
+      default:
+        return renderElement?.({ attributes, children, element });
+    }
+  };
+
+  editor.renderLeaf = ({ attributes, children, leaf, text }) => {
+    const path = ReactEditor.findPath(editor, text);
+
+    const [parent] = Editor.node(editor, Path.parent(path));
+    if (
+      Element.isElement(parent) &&
+      parent.type === TYPE_TABLE_CAPTION &&
+      Node.string(leaf) === ''
+    ) {
+      return (
+        <WithPlaceHolder attributes={attributes} placeholder="form.name.title">
+          {children}
+        </WithPlaceHolder>
+      );
+    }
+    return renderLeaf?.({ attributes, children, leaf, text });
+  };
+  return editor;
+};

--- a/src/components/SlateEditor/plugins/table/render.tsx
+++ b/src/components/SlateEditor/plugins/table/render.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { codeblockPlugin } from '../../../../components/SlateEditor/plugins/codeBlock';
+import { footnotePlugin } from '../../../../components/SlateEditor/plugins/footnote';
+import { embedPlugin } from '../../../../components/SlateEditor/plugins/embed';
+import { bodyboxPlugin } from '../../../../components/SlateEditor/plugins/bodybox';
+import { asidePlugin } from '../../../../components/SlateEditor/plugins/aside';
+import { detailsPlugin } from '../../../../components/SlateEditor/plugins/details';
+import { linkPlugin } from '../../../../components/SlateEditor/plugins/link';
+import { headingPlugin } from '../../../../components/SlateEditor/plugins/heading';
+import { blockPickerPlugin } from '../../../../components/SlateEditor/plugins/blockPicker';
+import { relatedPlugin } from '../../../../components/SlateEditor/plugins/related';
+import { filePlugin } from '../../../../components/SlateEditor/plugins/file';
+import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
+import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
+import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
+import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
+import { tablePlugin } from '../../../../components/SlateEditor/plugins/table';
+import { toolbarPlugin } from '../../../../components/SlateEditor/plugins/toolbar';
+import saveHotkeyPlugin from '../../../../components/SlateEditor/plugins/saveHotkey';
+import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
+import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
+import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
+import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
+import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
+import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
+import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
+import { conceptListPlugin } from '../../../../components/SlateEditor/plugins/conceptList';
+import { inlineConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/inline';
+import { blockConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/block';
+import { definitionListPlugin } from '../../../../components/SlateEditor/plugins/definitionList';
+import { contactBlockPlugin } from '../../../../components/SlateEditor/plugins/contactBlock';
+import { blogPostPlugin } from '../../../../components/SlateEditor/plugins/blogPost';
+import { gridPlugin } from '../../../../components/SlateEditor/plugins/grid';
+import { keyFigurePlugin } from '../../../../components/SlateEditor/plugins/keyFigure';
+import { campaignBlockPlugin } from '../../../../components/SlateEditor/plugins/campaignBlock';
+import { linkBlockListPlugin } from '../../../../components/SlateEditor/plugins/linkBlockList';
+import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
+import { h5pPlugin } from '../../../../components/SlateEditor/plugins/h5p';
+
+// Plugins are checked from last to first
+export const frontpagePlugins: SlatePlugin[] = [
+  sectionPlugin,
+  spanPlugin,
+  divPlugin,
+  paragraphPlugin,
+  footnotePlugin,
+  embedPlugin(),
+  audioPlugin(),
+  h5pPlugin(),
+  bodyboxPlugin,
+  asidePlugin,
+  detailsPlugin,
+  blockQuotePlugin,
+  linkPlugin,
+  conceptListPlugin,
+  inlineConceptPlugin,
+  blockConceptPlugin,
+  headingPlugin,
+  // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // // Blockquote and editList actions need to be triggered before paragraph action, else
+  // // unwrapping (jumping out of block) will not work.
+  tablePlugin,
+  relatedPlugin,
+  filePlugin,
+  mathmlPlugin,
+  contactBlockPlugin,
+  codeblockPlugin,
+  keyFigurePlugin,
+  blockPickerPlugin,
+  dndPlugin,
+  toolbarPlugin,
+  textTransformPlugin,
+  breakPlugin,
+  saveHotkeyPlugin,
+  markPlugin,
+  definitionListPlugin,
+  listPlugin,
+  gridPlugin,
+  blogPostPlugin,
+  campaignBlockPlugin,
+  linkBlockListPlugin,
+];

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpageRenderers.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpageRenderers.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { sectionRenderer } from '../../../../components/SlateEditor/plugins/section/render';
+import { spanRenderer } from '../../../../components/SlateEditor/plugins/span/render';
+import { divRenderer } from '../../../../components/SlateEditor/plugins/div/render';
+import { paragraphRenderer } from '../../../../components/SlateEditor/plugins/paragraph/render';
+import { footnoteRenderer } from '../../../../components/SlateEditor/plugins/footnote/render';
+import { audioRenderer } from '../../../../components/SlateEditor/plugins/audio/render';
+import { h5pRenderer } from '../../../../components/SlateEditor/plugins/h5p/render';
+import { embedRenderer } from '../../../../components/SlateEditor/plugins/embed/render';
+import { bodyboxRenderer } from '../../../../components/SlateEditor/plugins/bodybox/render';
+import { asideRenderer } from '../../../../components/SlateEditor/plugins/aside/render';
+import { detailsRenderer } from '../../../../components/SlateEditor/plugins/details/render';
+import { blockQuoteRenderer } from '../../../../components/SlateEditor/plugins/blockquote/render';
+import { linkRenderer } from '../../../../components/SlateEditor/plugins/link/render';
+import { conceptListRenderer } from '../../../../components/SlateEditor/plugins/conceptList/render';
+import { inlineConceptRenderer } from '../../../../components/SlateEditor/plugins/concept/inline/render';
+import { blockConceptRenderer } from '../../../../components/SlateEditor/plugins/concept/block/render';
+import { headingRenderer } from '../../../../components/SlateEditor/plugins/heading/render';
+import { tableRenderer } from '../../../../components/SlateEditor/plugins/table/render';
+import { relatedRenderer } from '../../../../components/SlateEditor/plugins/related/relatedRenderer';
+import { fileRenderer } from '../../../../components/SlateEditor/plugins/file/render';
+import { mathRenderer } from '../../../../components/SlateEditor/plugins/mathml/mathRenderer';
+import { codeblockRenderer } from '../../../../components/SlateEditor/plugins/codeBlock/render';
+import { breakRenderer } from '../../../../components/SlateEditor/plugins/break/render';
+import { markRenderer } from '../../../../components/SlateEditor/plugins/mark/render';
+import { definitionListRenderer } from '../../../../components/SlateEditor/plugins/definitionList/render';
+import { listRenderer } from '../../../../components/SlateEditor/plugins/list/render';
+import { gridRenderer } from '../../../../components/SlateEditor/plugins/grid/render';
+import { contactBlockRenderer } from '../../../../components/SlateEditor/plugins/contactBlock/render';
+import { keyFigureRenderer } from '../../../../components/SlateEditor/plugins/keyFigure/render';
+import { blogPostRenderer } from '../../../../components/SlateEditor/plugins/blogPost/render';
+import { campaignBlockRenderer } from '../../../../components/SlateEditor/plugins/campaignBlock/render';
+import { linkBlockListRenderer } from '../../../../components/SlateEditor/plugins/linkBlockList/render';
+
+// Plugins are checked from last to first
+export const frontpageRenderers = (articleLanguage: string): SlatePlugin[] => [
+  sectionRenderer,
+  spanRenderer,
+  divRenderer,
+  paragraphRenderer(articleLanguage),
+  footnoteRenderer,
+  embedRenderer(articleLanguage),
+  audioRenderer(articleLanguage),
+  h5pRenderer(articleLanguage),
+  bodyboxRenderer,
+  asideRenderer,
+  detailsRenderer,
+  blockQuoteRenderer,
+  linkRenderer(articleLanguage),
+  conceptListRenderer(articleLanguage),
+  inlineConceptRenderer(articleLanguage),
+  blockConceptRenderer(articleLanguage),
+  headingRenderer,
+  // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // // Blockquote and editList actions need to be triggered before paragraph action, else
+  // // unwrapping (jumping out of block) will not work.
+  tableRenderer,
+  relatedRenderer,
+  fileRenderer,
+  mathRenderer,
+  contactBlockRenderer,
+  codeblockRenderer,
+  keyFigureRenderer,
+  breakRenderer,
+  markRenderer,
+  definitionListRenderer,
+  listRenderer,
+  gridRenderer,
+  blogPostRenderer,
+  campaignBlockRenderer,
+  linkBlockListRenderer,
+];

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useState, useMemo, useCallback, memo, useEffect, Dispatch, SetStateAction } from 'react';
+import { useState, useMemo, useCallback, memo, useEffect } from 'react';
 import { Descendant } from 'slate';
 import { useTranslation } from 'react-i18next';
 import { FieldProps, useField, useFormikContext } from 'formik';
@@ -21,48 +21,14 @@ import LearningResourceFootnotes, { FootnoteType } from './LearningResourceFootn
 import LastUpdatedLine from '../../../../components/LastUpdatedLine/LastUpdatedLine';
 import HowToHelper from '../../../../components/HowTo/HowToHelper';
 import { findNodesByType } from '../../../../util/slateHelpers';
-import { codeblockPlugin } from '../../../../components/SlateEditor/plugins/codeBlock';
-import {
-  FootnoteElement,
-  footnotePlugin,
-} from '../../../../components/SlateEditor/plugins/footnote';
-import { embedPlugin } from '../../../../components/SlateEditor/plugins/embed';
-import { bodyboxPlugin } from '../../../../components/SlateEditor/plugins/bodybox';
-import { asidePlugin } from '../../../../components/SlateEditor/plugins/aside';
-import { detailsPlugin } from '../../../../components/SlateEditor/plugins/details';
-import { linkPlugin } from '../../../../components/SlateEditor/plugins/link';
-import { headingPlugin } from '../../../../components/SlateEditor/plugins/heading';
-import { blockPickerPlugin } from '../../../../components/SlateEditor/plugins/blockPicker';
-import { relatedPlugin } from '../../../../components/SlateEditor/plugins/related';
-import { filePlugin } from '../../../../components/SlateEditor/plugins/file';
-import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
-import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
-import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
-import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
-
-import { tablePlugin } from '../../../../components/SlateEditor/plugins/table';
+import { FootnoteElement } from '../../../../components/SlateEditor/plugins/footnote';
 import { EditMarkupLink } from '../../../../components/EditMarkupLink';
 import { IngressField, TitleField } from '../../../FormikForm';
 import { DRAFT_HTML_SCOPE } from '../../../../constants';
 import { toCreateLearningResource, toEditMarkup } from '../../../../util/routeHelpers';
-import { toolbarPlugin } from '../../../../components/SlateEditor/plugins/toolbar';
-import saveHotkeyPlugin from '../../../../components/SlateEditor/plugins/saveHotkey';
-import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
-import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
-import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
-import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
-import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
-import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
-import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import { useSession } from '../../../Session/SessionProvider';
 import RichTextEditor from '../../../../components/SlateEditor/RichTextEditor';
-import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
 import { TYPE_FOOTNOTE } from '../../../../components/SlateEditor/plugins/footnote/types';
-import { conceptListPlugin } from '../../../../components/SlateEditor/plugins/conceptList';
-import { inlineConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/inline';
-import { blockConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/block';
-import { definitionListPlugin } from '../../../../components/SlateEditor/plugins/definitionList';
-import { gridPlugin } from '../../../../components/SlateEditor/plugins/grid';
 import {
   TYPE_EMBED_BRIGHTCOVE,
   TYPE_EMBED_EXTERNAL,
@@ -73,13 +39,13 @@ import { TYPE_CODEBLOCK } from '../../../../components/SlateEditor/plugins/codeB
 import { TYPE_FILE } from '../../../../components/SlateEditor/plugins/file/types';
 import { TYPE_GRID } from '../../../../components/SlateEditor/plugins/grid/types';
 import { HandleSubmitFunc, LearningResourceFormType } from '../../../FormikForm/articleFormHooks';
-import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
 import { TYPE_AUDIO } from '../../../../components/SlateEditor/plugins/audio/types';
 import { learningResourceActions } from '../../../../components/SlateEditor/plugins/blockPicker/actions';
 import { TYPE_H5P } from '../../../../components/SlateEditor/plugins/h5p/types';
-import { h5pPlugin } from '../../../../components/SlateEditor/plugins/h5p';
 import { isFormikFormDirty } from '../../../../util/formHelper';
 import AlertModal from '../../../../components/AlertModal';
+import { learningResourcePlugins } from './learningResourcePlugins';
+import { learningResourceRenderers } from './learningResourceRenderers';
 
 const StyledFormikField = styled(FormikField)`
   display: flex;
@@ -133,46 +99,6 @@ const actionsToShowInAreas = {
 };
 
 // Plugins are checked from last to first
-export const plugins = (articleLanguage: string): SlatePlugin[] => {
-  return [
-    sectionPlugin,
-    spanPlugin,
-    divPlugin,
-    paragraphPlugin(articleLanguage),
-    footnotePlugin,
-    audioPlugin(articleLanguage),
-    h5pPlugin(articleLanguage),
-    embedPlugin(articleLanguage),
-    bodyboxPlugin,
-    asidePlugin,
-    detailsPlugin,
-    blockQuotePlugin,
-    linkPlugin(articleLanguage),
-    conceptListPlugin(articleLanguage),
-    inlineConceptPlugin(articleLanguage),
-    blockConceptPlugin(articleLanguage),
-    headingPlugin,
-    // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
-    // // Blockquote and editList actions need to be triggered before paragraph action, else
-    // // unwrapping (jumping out of block) will not work.
-    tablePlugin,
-    relatedPlugin,
-    filePlugin,
-    mathmlPlugin,
-    codeblockPlugin,
-    blockPickerPlugin,
-    dndPlugin,
-    // pasteHandler(),
-    toolbarPlugin,
-    textTransformPlugin,
-    breakPlugin,
-    saveHotkeyPlugin,
-    markPlugin,
-    definitionListPlugin,
-    listPlugin,
-    gridPlugin,
-  ];
-};
 interface Props {
   articleLanguage: string;
   articleId?: number;
@@ -298,7 +224,10 @@ const ContentField = ({
     [onChange, name],
   );
 
-  const editorPlugins = useMemo(() => plugins(articleLanguage ?? ''), [articleLanguage]);
+  const editorPlugins = useMemo(
+    () => learningResourcePlugins.concat(learningResourceRenderers(articleLanguage)),
+    [articleLanguage],
+  );
 
   return (
     <>

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { embedPlugin } from '../../../../components/SlateEditor/plugins/embed';
+import { bodyboxPlugin } from '../../../../components/SlateEditor/plugins/bodybox';
+import { asidePlugin } from '../../../../components/SlateEditor/plugins/aside';
+import { detailsPlugin } from '../../../../components/SlateEditor/plugins/details';
+import { linkPlugin } from '../../../../components/SlateEditor/plugins/link';
+import { headingPlugin } from '../../../../components/SlateEditor/plugins/heading';
+import { blockPickerPlugin } from '../../../../components/SlateEditor/plugins/blockPicker';
+import { relatedPlugin } from '../../../../components/SlateEditor/plugins/related';
+import { filePlugin } from '../../../../components/SlateEditor/plugins/file';
+import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
+import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
+import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
+import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
+import { tablePlugin } from '../../../../components/SlateEditor/plugins/table';
+import { toolbarPlugin } from '../../../../components/SlateEditor/plugins/toolbar';
+import saveHotkeyPlugin from '../../../../components/SlateEditor/plugins/saveHotkey';
+import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
+import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
+import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
+import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
+import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
+import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
+import { conceptListPlugin } from '../../../../components/SlateEditor/plugins/conceptList';
+import { inlineConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/inline';
+import { blockConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/block';
+import { definitionListPlugin } from '../../../../components/SlateEditor/plugins/definitionList';
+import { gridPlugin } from '../../../../components/SlateEditor/plugins/grid';
+import { audioPlugin } from '../../../../components/SlateEditor/plugins/audio';
+import { h5pPlugin } from '../../../../components/SlateEditor/plugins/h5p';
+import { codeblockPlugin } from '../../../../components/SlateEditor/plugins/codeBlock';
+import { footnotePlugin } from '../../../../components/SlateEditor/plugins/footnote';
+
+export const learningResourcePlugins: SlatePlugin[] = [
+  sectionPlugin,
+  spanPlugin,
+  divPlugin,
+  paragraphPlugin,
+  footnotePlugin,
+  audioPlugin(),
+  h5pPlugin(),
+  embedPlugin(),
+  bodyboxPlugin,
+  asidePlugin,
+  detailsPlugin,
+  blockQuotePlugin,
+  linkPlugin,
+  conceptListPlugin,
+  inlineConceptPlugin,
+  blockConceptPlugin,
+  headingPlugin,
+  // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // // Blockquote and editList actions need to be triggered before paragraph action, else
+  // // unwrapping (jumping out of block) will not work.
+  tablePlugin,
+  relatedPlugin,
+  filePlugin,
+  mathmlPlugin,
+  codeblockPlugin,
+  blockPickerPlugin,
+  dndPlugin,
+  // pasteHandler(),
+  toolbarPlugin,
+  textTransformPlugin,
+  breakPlugin,
+  saveHotkeyPlugin,
+  markPlugin,
+  definitionListPlugin,
+  listPlugin,
+  gridPlugin,
+];

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { sectionRenderer } from '../../../../components/SlateEditor/plugins/section/render';
+import { spanRenderer } from '../../../../components/SlateEditor/plugins/span/render';
+import { divRenderer } from '../../../../components/SlateEditor/plugins/div/render';
+import { paragraphRenderer } from '../../../../components/SlateEditor/plugins/paragraph/render';
+import { footnoteRenderer } from '../../../../components/SlateEditor/plugins/footnote/render';
+import { audioRenderer } from '../../../../components/SlateEditor/plugins/audio/render';
+import { h5pRenderer } from '../../../../components/SlateEditor/plugins/h5p/render';
+import { embedRenderer } from '../../../../components/SlateEditor/plugins/embed/render';
+import { bodyboxRenderer } from '../../../../components/SlateEditor/plugins/bodybox/render';
+import { asideRenderer } from '../../../../components/SlateEditor/plugins/aside/render';
+import { detailsRenderer } from '../../../../components/SlateEditor/plugins/details/render';
+import { blockQuoteRenderer } from '../../../../components/SlateEditor/plugins/blockquote/render';
+import { linkRenderer } from '../../../../components/SlateEditor/plugins/link/render';
+import { conceptListRenderer } from '../../../../components/SlateEditor/plugins/conceptList/render';
+import { inlineConceptRenderer } from '../../../../components/SlateEditor/plugins/concept/inline/render';
+import { blockConceptRenderer } from '../../../../components/SlateEditor/plugins/concept/block/render';
+import { headingRenderer } from '../../../../components/SlateEditor/plugins/heading/render';
+import { tableRenderer } from '../../../../components/SlateEditor/plugins/table/render';
+import { relatedRenderer } from '../../../../components/SlateEditor/plugins/related/relatedRenderer';
+import { fileRenderer } from '../../../../components/SlateEditor/plugins/file/render';
+import { mathRenderer } from '../../../../components/SlateEditor/plugins/mathml/mathRenderer';
+import { codeblockRenderer } from '../../../../components/SlateEditor/plugins/codeBlock/render';
+import { breakRenderer } from '../../../../components/SlateEditor/plugins/break/render';
+import { markRenderer } from '../../../../components/SlateEditor/plugins/mark/render';
+import { definitionListRenderer } from '../../../../components/SlateEditor/plugins/definitionList/render';
+import { listRenderer } from '../../../../components/SlateEditor/plugins/list/render';
+import { gridRenderer } from '../../../../components/SlateEditor/plugins/grid/render';
+
+// Plugins are checked from last to first
+export const learningResourceRenderers = (articleLanguage: string): SlatePlugin[] => {
+  return [
+    sectionRenderer,
+    spanRenderer,
+    divRenderer,
+    paragraphRenderer(articleLanguage),
+    footnoteRenderer,
+    audioRenderer(articleLanguage),
+    h5pRenderer(articleLanguage),
+    embedRenderer(articleLanguage),
+    bodyboxRenderer,
+    asideRenderer,
+    detailsRenderer,
+    blockQuoteRenderer,
+    linkRenderer(articleLanguage),
+    conceptListRenderer(articleLanguage),
+    inlineConceptRenderer(articleLanguage),
+    blockConceptRenderer(articleLanguage),
+    headingRenderer,
+    // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+    // // Blockquote and editList actions need to be triggered before paragraph action, else
+    // // unwrapping (jumping out of block) will not work.
+    tableRenderer,
+    relatedRenderer,
+    fileRenderer,
+    mathRenderer,
+    codeblockRenderer,
+    breakRenderer,
+    markRenderer,
+    definitionListRenderer,
+    listRenderer,
+    gridRenderer,
+  ];
+};

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -14,37 +14,21 @@ import Tooltip from '@ndla/tooltip';
 import { Eye } from '@ndla/icons/editor';
 import { IconButtonV2 } from '@ndla/button';
 import { colors } from '@ndla/core';
-import { headingPlugin } from '../../../../components/SlateEditor/plugins/heading';
-import { noEmbedPlugin } from '../../../../components/SlateEditor/plugins/noEmbed';
 import VisualElementField from '../../../FormikForm/components/VisualElementField';
 import LastUpdatedLine from './../../../../components/LastUpdatedLine/LastUpdatedLine';
 import HowToHelper from '../../../../components/HowTo/HowToHelper';
 
-import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
-import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
-import { inlineConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/inline';
-import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
-import { linkPlugin } from '../../../../components/SlateEditor/plugins/link';
-import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
 import FormikField from '../../../../components/FormikField';
 import RichTextEditor from '../../../../components/SlateEditor/RichTextEditor';
 import { EditMarkupLink } from '../../../../components/EditMarkupLink';
 import { IngressField, TitleField } from '../../../FormikForm';
 import { DRAFT_HTML_SCOPE } from '../../../../constants';
 import { toEditMarkup } from '../../../../util/routeHelpers';
-import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
-import { toolbarPlugin } from '../../../../components/SlateEditor/plugins/toolbar';
-import saveHotkeyPlugin from '../../../../components/SlateEditor/plugins/saveHotkey';
-import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
-import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
-import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
-import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
 import { TopicArticleFormType } from '../../../FormikForm/articleFormHooks';
-import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
 import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
 import { useSession } from '../../../Session/SessionProvider';
-import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
-import { definitionListPlugin } from '../../../../components/SlateEditor/plugins/definitionList';
+import { topicArticlePlugins } from './topicArticlePlugins';
+import { topicArticleRenderers } from './topicArticleRenderers';
 
 const StyledByLineFormikField = styled(FormikField)`
   display: flex;
@@ -73,29 +57,7 @@ const MarkdownButton = styled(IconButtonV2)<{ active: boolean }>`
 
 const createPlugins = (language: string): SlatePlugin[] => {
   // Plugins are checked from last to first
-  return [
-    sectionPlugin,
-    spanPlugin,
-    divPlugin,
-    paragraphPlugin(language),
-    noEmbedPlugin,
-    linkPlugin(language),
-    headingPlugin,
-    // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
-    // Blockquote and editList actions need to be triggered before paragraph action, else
-    // unwrapping (jumping out of block) will not work.
-    blockQuotePlugin,
-    definitionListPlugin,
-    listPlugin,
-    inlineConceptPlugin(language),
-    mathmlPlugin,
-    markPlugin,
-    dndPlugin,
-    toolbarPlugin,
-    textTransformPlugin,
-    breakPlugin,
-    saveHotkeyPlugin,
-  ];
+  return topicArticlePlugins.concat(topicArticleRenderers(language));
 };
 
 interface Props {

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { headingPlugin } from '../../../../components/SlateEditor/plugins/heading';
+import { noEmbedPlugin } from '../../../../components/SlateEditor/plugins/noEmbed';
+import { blockQuotePlugin } from '../../../../components/SlateEditor/plugins/blockquote';
+import { listPlugin } from '../../../../components/SlateEditor/plugins/list';
+import { inlineConceptPlugin } from '../../../../components/SlateEditor/plugins/concept/inline';
+import { paragraphPlugin } from '../../../../components/SlateEditor/plugins/paragraph';
+import { linkPlugin } from '../../../../components/SlateEditor/plugins/link';
+import { mathmlPlugin } from '../../../../components/SlateEditor/plugins/mathml';
+import { textTransformPlugin } from '../../../../components/SlateEditor/plugins/textTransform';
+import { toolbarPlugin } from '../../../../components/SlateEditor/plugins/toolbar';
+import saveHotkeyPlugin from '../../../../components/SlateEditor/plugins/saveHotkey';
+import { markPlugin } from '../../../../components/SlateEditor/plugins/mark';
+import { sectionPlugin } from '../../../../components/SlateEditor/plugins/section';
+import { divPlugin } from '../../../../components/SlateEditor/plugins/div';
+import { breakPlugin } from '../../../../components/SlateEditor/plugins/break';
+import { dndPlugin } from '../../../../components/SlateEditor/plugins/DND';
+import { spanPlugin } from '../../../../components/SlateEditor/plugins/span';
+import { definitionListPlugin } from '../../../../components/SlateEditor/plugins/definitionList';
+
+// Plugins are checked from last to first
+export const topicArticlePlugins: SlatePlugin[] = [
+  sectionPlugin,
+  spanPlugin,
+  divPlugin,
+  paragraphPlugin,
+  noEmbedPlugin,
+  linkPlugin,
+  headingPlugin,
+  // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // Blockquote and editList actions need to be triggered before paragraph action, else
+  // unwrapping (jumping out of block) will not work.
+  blockQuotePlugin,
+  definitionListPlugin,
+  listPlugin,
+  inlineConceptPlugin,
+  mathmlPlugin,
+  markPlugin,
+  dndPlugin,
+  toolbarPlugin,
+  textTransformPlugin,
+  breakPlugin,
+  saveHotkeyPlugin,
+];

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-present, NDLA.
+ * Copyright (c) 2023-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { SlatePlugin } from '../../../../components/SlateEditor/interfaces';
+import { sectionRenderer } from '../../../../components/SlateEditor/plugins/section/render';
+import { spanRenderer } from '../../../../components/SlateEditor/plugins/span/render';
+import { divRenderer } from '../../../../components/SlateEditor/plugins/div/render';
+import { paragraphRenderer } from '../../../../components/SlateEditor/plugins/paragraph/render';
+import { noEmbedRenderer } from '../../../../components/SlateEditor/plugins/noEmbed/render';
+import { linkRenderer } from '../../../../components/SlateEditor/plugins/link/render';
+import { headingRenderer } from '../../../../components/SlateEditor/plugins/heading/render';
+import { blockQuoteRenderer } from '../../../../components/SlateEditor/plugins/blockquote/render';
+import { definitionListRenderer } from '../../../../components/SlateEditor/plugins/definitionList/render';
+import { listRenderer } from '../../../../components/SlateEditor/plugins/list/render';
+import { inlineConceptRenderer } from '../../../../components/SlateEditor/plugins/concept/inline/render';
+import { mathRenderer } from '../../../../components/SlateEditor/plugins/mathml/mathRenderer';
+import { markRenderer } from '../../../../components/SlateEditor/plugins/mark/render';
+import { breakRenderer } from '../../../../components/SlateEditor/plugins/break/render';
+
+// Plugins are checked from last to first
+export const topicArticleRenderers = (articleLanguage: string): SlatePlugin[] => [
+  sectionRenderer,
+  spanRenderer,
+  divRenderer,
+  paragraphRenderer(articleLanguage),
+  noEmbedRenderer,
+  linkRenderer(articleLanguage),
+  headingRenderer,
+  // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // Blockquote and editList actions need to be triggered before paragraph action, else
+  // unwrapping (jumping out of block) will not work.
+  blockQuoteRenderer,
+  definitionListRenderer,
+  listRenderer,
+  inlineConceptRenderer(articleLanguage),
+  mathRenderer,
+  markRenderer,
+  breakRenderer,
+];

--- a/src/containers/VisualElement/VisualElement.tsx
+++ b/src/containers/VisualElement/VisualElement.tsx
@@ -13,6 +13,9 @@ import { EmbedElements, embedPlugin } from '../../components/SlateEditor/plugins
 import { VisualElementType } from '../../containers/VisualElement/VisualElementMenu';
 import { audioPlugin } from '../../components/SlateEditor/plugins/audio';
 import { h5pPlugin } from '../../components/SlateEditor/plugins/h5p';
+import { audioRenderer } from '../../components/SlateEditor/plugins/audio/render';
+import { h5pRenderer } from '../../components/SlateEditor/plugins/h5p/render';
+import { embedRenderer } from '../../components/SlateEditor/plugins/embed/render';
 
 interface Props {
   onChange: FormikHandlers['handleChange'];
@@ -37,9 +40,12 @@ const VisualElement = ({
 }: Props) => {
   const plugins = useMemo(() => {
     return [
-      audioPlugin(language, true),
-      h5pPlugin(language, true),
-      embedPlugin(language, true, allowDecorative),
+      audioPlugin(true),
+      audioRenderer(language),
+      h5pPlugin(true),
+      h5pRenderer(language),
+      embedPlugin(true),
+      embedRenderer(language, allowDecorative),
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedResource]);


### PR DESCRIPTION
Lokalt hos meg fører dette til en ganske drastisk reduksjon i tiden det tar å kjøre testene, da mengden filer jest trenger å transpilere gjennom babel blir ganske så mye mindre. Det skal dog sies at tiden det tar å kjøre testene varierer en del. Jeg har sett reduksjoner fra opptil 50% til bare 10%. Det skal dog sies at den aldri har vært tregere å kjøre enn de gamle testene.

Ikke ta dere noe særlig nær av mengden filer eller kode. Det er kun flytting av kode. Grunnen til at det er flere kodelinjer er nok bare p.g.a copyright.