### PR TITLE
Conditional concept / gloss button text

### DIFF
--- a/src/components/SlateEditor/plugins/concept/SearchConceptResults.tsx
+++ b/src/components/SlateEditor/plugins/concept/SearchConceptResults.tsx
@@ -97,7 +97,9 @@ const SearchConceptResults = ({ results, searchObject, addConcept, searching = t
               addConcept(result);
             }}
           >
-            {t('form.content.concept.choose')}
+            {result.conceptType === 'concept'
+              ? t('form.content.concept.choose')
+              : t('form.content.gloss.choose')}
           </StyledButton>
         </StyledConceptResult>
       ))}

--- a/src/components/SlateEditor/plugins/concept/SearchConceptResults.tsx
+++ b/src/components/SlateEditor/plugins/concept/SearchConceptResults.tsx
@@ -97,9 +97,7 @@ const SearchConceptResults = ({ results, searchObject, addConcept, searching = t
               addConcept(result);
             }}
           >
-            {result.conceptType === 'concept'
-              ? t('form.content.concept.choose')
-              : t('form.content.gloss.choose')}
+            {t(`form.content.${result.conceptType}.choose`)}
           </StyledButton>
         </StyledConceptResult>
       ))}

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1048,6 +1048,10 @@ const phrases = {
         remove: 'Remove concept',
         choose: 'Choose concept',
       },
+      gloss: {
+        remove: 'Remove gloss',
+        choose: 'Choose gloss',
+      },
       link: {
         name: 'Name',
         domains: 'Url',

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1048,6 +1048,10 @@ const phrases = {
         remove: 'Fjern forklaring',
         choose: 'Velg forklaring',
       },
+      gloss: {
+        remove: 'Fjern glose',
+        choose: 'Velg glose',
+      },
       link: {
         name: 'Navn',
         domains: 'Url',

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1048,6 +1048,10 @@ const phrases = {
         remove: 'Fjern forklaring',
         choose: 'Velg forklaring',
       },
+      gloss: {
+        remove: 'Fjern glose',
+        choose: 'Velg glose',
+      },
       link: {
         name: 'Namn',
         domains: 'Url',


### PR DESCRIPTION
Når man går via toolbar og skal legge til glose eller forklaring, stod det Velg forklaring selv om resultatet var en glose. Har sattknappeteksten til å conditionally bruke forklaring- eller glosetekst.

Det var også en oversettelsestekst for remove, ikke bare choose. Jeg så ikke at den var i bruk p.t., men la til oversettelser også for remove under gloss.