### PR TITLE
Disable h5p-meta for now

### DIFF
--- a/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
+++ b/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
@@ -18,6 +18,7 @@ import { DeleteForever } from '@ndla/icons/editor';
 import { Spinner } from '@ndla/icons';
 import { H5pElement } from './types';
 import { useH5pMeta } from '../../../../modules/embed/queries';
+import config from '../../../../config';
 import { StyledDeleteEmbedButton, StyledFigureButtons } from '../embed/FigureButtons';
 import EditH5PModal from './EditH5PModal';
 import EditMetadataModal from './EditMetadataModal';
@@ -77,7 +78,9 @@ const SlateH5p = ({ element, editor, attributes, language, children }: Props) =>
     <H5pWrapper {...attributes} data-selected={isSelected}>
       <div contentEditable={false}>
         <FigureButtons>
-          <EditMetadataModal embed={embed} editor={editor} element={element} />
+          {config.h5pMetaEnabled && (
+            <EditMetadataModal embed={embed} editor={editor} element={element} />
+          )}
           <EditH5PModal embed={embed} language={language} editor={editor} element={element} />
           <StyledDeleteEmbedButton
             title={t('form.h5p.remove')}

--- a/src/config.ts
+++ b/src/config.ts
@@ -161,6 +161,7 @@ export type ConfigType = {
   brightcoveCopyrightPlayerId: string | undefined;
   disableCSP: string | undefined;
   usernamePasswordEnabled: boolean;
+  h5pMetaEnabled: boolean;
   translateServiceUrl: string;
   isVercel: boolean;
 };
@@ -202,6 +203,7 @@ const config: ConfigType = {
     'USERNAME_PASSWORD_ENABLED',
     usernamePasswordEnabled(),
   ),
+  h5pMetaEnabled: getEnvironmentVariabel('H5PMETA_ENABLED', false),
   translateServiceUrl: getEnvironmentVariabel('NDKM_URL', getTranslateServiceUrl()),
   isVercel: getEnvironmentVariabel('IS_VERCEL', 'false') === 'true',
 };

--- a/src/util/resourceHelpers.ts
+++ b/src/util/resourceHelpers.ts
@@ -67,6 +67,7 @@ export const getResourceLanguages = (t: TFunction) => [
   { id: 'und', name: t('languages.und') },
   { id: 'de', name: t('languages.de') },
   { id: 'es', name: t('languages.es') },
+  { id: 'zh', name: t('languages.zh') },
 ];
 
 export const getContentTypeFromResourceTypes = (


### PR DESCRIPTION
Inntil ndla har bestemt korleis dei skal håndtere dette, så vil dei skjule det.

Test:
Du har ikkje lenger mulighet til å redigere alt/meta for h5p.
I tillegg kan du velge kinesisk som språk i søk.