### PR TITLE
Alt tekst for serie og podkast skal være frivillig.

### DIFF
--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -66,9 +66,6 @@ const podcastRules: RulesType<PodcastFormValues, IAudioMetaInformation> = {
     required: true,
   },
   metaImageAlt: {
-    // coverPhotoAltText
-    required: true,
-    onlyValidateIf: (values: PodcastFormValues) => !!values.coverPhotoId,
     warnings: {
       languageMatch: true,
     },

--- a/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
+++ b/src/containers/PodcastSeries/components/PodcastSeriesForm.tsx
@@ -51,10 +51,6 @@ const podcastRules: RulesType<PodcastSeriesFormikType, ISeries> = {
   coverPhotoId: {
     required: true,
   },
-  metaImageAlt: {
-    required: true,
-    onlyValidateIf: (values: PodcastSeriesFormikType) => !!values.coverPhotoId,
-  },
 };
 
 const AdminWarningTextWrapper = styled.div`


### PR DESCRIPTION
Alt-tekst på metabilder for podkast skal være frivillig i og med at det er for det meste dekorativt. Endringa gjør at du kan legge til bilde på både podkast og serie uten å sette alt-tekst.