### PR TITLE
Only uses id for learningpath

### DIFF
--- a/src/components/SlateEditor/plugins/link/utils.ts
+++ b/src/components/SlateEditor/plugins/link/utils.ts
@@ -68,8 +68,9 @@ export const splitArticleUrl = (href: string) => {
 
 export const splitLearningPathUrl = (href: string) => {
   const splittedHref = href.split('learningpaths/');
+  const path = splittedHref[1];
   return {
-    resourceId: splittedHref[1],
+    resourceId: path.split('/')[0],
     resourceType: 'learningpath',
   };
 };


### PR DESCRIPTION
Fixes NDLANO/Issues#3876

Dagens kode tar med for masse tekst.

Test: 
Sett inn lenke til https://test.ndla.no/subject:1:6951e039-c23e-483f-94bf-2194a1fb197d/topic:c12f7a1f-4a4d-4e39-b362-48fc931df908/topic:46b003a6-5182-4afa-b809-913645c7a707/resource:1:180650 eller https://stier.test.ndla.no/learningpaths/723/step/5344 og sjå at ting lagres korrekt med kun id i data-content-id.