### PR TITLE
Refactor link plugin code. Fix onClose problems

### DIFF
--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -71,15 +71,7 @@ const StyledLink = styled.a`
   cursor: text;
 `;
 
-const Link = (props: Props) => {
-  const {
-    attributes,
-    editor: { onChange },
-    editor,
-    element,
-    language,
-    children,
-  } = props;
+const Link = ({ attributes, editor, element, language, children }: Props) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [model, setModel] = useState<Model | undefined>();
   const startOpen = useRef(!hasHrefOrContentId(element));
@@ -155,7 +147,12 @@ const Link = (props: Props) => {
       </StyledLink>
       <ModalContent>
         {model && (
-          <EditLink {...props} model={model} closeEditMode={toggleEditMode} onChange={onChange} />
+          <EditLink
+            editor={editor}
+            element={element}
+            model={model}
+            closeEditMode={toggleEditMode}
+          />
         )}
       </ModalContent>
     </Modal>


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3883

Lukking av modal ville få react/slate til å kræsje. 
Løsningen var å flytte `Reacteditor.focus()` til et tidligere punkt i koden før man gjorde endringer på teksten. 
Tok også tak i litt opprydning for å få props destructa når vi tar de imot istedenfor overalt i koden!