### PR TITLE
Add wrapper components for using formik, FormControl and RemainingCharacters

### DIFF
--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { FieldHelperProps, FieldInputProps, FieldMetaProps, useField } from 'formik';
+import { ComponentProps, ReactNode, useId, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from '@emotion/styled';
+import { utils } from '@ndla/core';
+import { FieldHelper, FormControlProps, FormControl as InternalFormControl } from '@ndla/forms';
+import useDebounce from '../util/useDebounce';
+
+interface FormFieldProps<T = any> {
+  name: string;
+  children: (values: {
+    field: FieldInputProps<T>;
+    meta: FieldMetaProps<T>;
+    helpers: FieldHelperProps<T>;
+  }) => ReactNode;
+}
+
+export const FormField = <T = any,>({ name, children }: FormFieldProps<T>) => {
+  const [field, meta, helpers] = useField(name);
+  return children({ field, meta, helpers });
+};
+
+export const FormControl = (props: Omit<FormControlProps, 'id'> & ComponentProps<'div'>) => {
+  const id = useId();
+  return <InternalFormControl id={id} {...props} />;
+};
+
+const HiddenSpan = styled(FieldHelper)`
+  ${utils.visuallyHidden};
+`;
+
+interface Props extends ComponentProps<'div'> {
+  value: number;
+  maxLength: number;
+  children?: ReactNode;
+}
+
+export const FormRemainingCharacters = ({ value, maxLength, children, ...rest }: Props) => {
+  const { t } = useTranslation();
+  const debouncedValue = useDebounce(value, 300);
+  const debouncedTranslation = useMemo(() => {
+    return t('form.remainingCharacters', { maxLength, remaining: maxLength - debouncedValue });
+  }, [debouncedValue, maxLength, t]);
+
+  return (
+    <div {...rest}>
+      <span aria-hidden="true">
+        {t('form.remainingCharacters', { maxLength, remaining: maxLength - value })}
+      </span>
+      <HiddenSpan aria-live="polite">{debouncedTranslation}</HiddenSpan>
+    </div>
+  );
+};


### PR DESCRIPTION
Legger til tre komponenter som på sikt kan erstatte `FormikField`, og som vil tillatte oss større fleksibilitet i hvordan vi bygger skjemafelter. De er også ganske så mye mer UU-vennlige, selv om det ikke har vært et stort fokus i ED.

Dette er formålet med komponentene:
* __FormField__: En tynn wrapper rundt Formik sin `useField`. Tanken er at vi kan sikt ganske enkelt kan bytte den ut med `react-hook-form` sin `Controller`-komponent.
* __FormControl__: En tynn wrapper rundt `FormControl` fra frontend-packages. Den sørger for at vi slipper å lage ID'er for formfeltene våre selv. Denne eksisterer kun fordi vi ikke kan bruke `useId` i frontend-packages, da den krever react 18.
* __FormRemainingCharacters__: En wrapper rundt `FieldHelper` som viser hvor mange karakterer en har igjen i et visst felt. Hensikten med komponenten er å gi seende brukere et oppdatert tall på hvor mange karakterer som gjenstår, mens skjermleser-brukere kun får beskjed etter at de har sluttet å skrive.

Jeg har også lekt litt med idéen om å slå sammen `FormField` og `FormControl`, men litt usikker på om det er noe vi ønsker. Det er kanskje akkurat litt for nærme det nåværende `FormikField`, og kan gjøre det vanskeligere å style et felt.