### PR TITLE
Only show compare with published if published version exists

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -230,7 +230,7 @@ const HeaderActions = ({
                 type="version"
                 article={lastPublishedVersion}
                 language={language}
-                customTitle="form.previewProductionArticle.published"
+                customTitle={t('form.previewProductionArticle.published')}
                 activateButton={
                   <StyledFilledButton type="button">
                     <Eye /> {t('form.previewVersion')}

--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -20,6 +20,7 @@ import HeaderLanguagePicker from './HeaderLanguagePicker';
 import HeaderLanguagePill from './HeaderLanguagePill';
 import HeaderSupportedLanguages from './HeaderSupportedLanguages';
 import TranslateNbToNn from './TranslateNbToNn';
+import { PUBLISHED } from '../../constants';
 import { fetchDraftHistory } from '../../modules/draft/draftApi';
 import {
   toEditAudio,
@@ -151,9 +152,8 @@ const HeaderActions = ({
   useEffect(() => {
     const getVersions = async (article: IArticle) => {
       const versions = await fetchDraftHistory(article.id, article.title?.language);
-      if (versions.length) {
-        setLastPublishedVersion(versions[1]);
-      }
+      const publishedVersion = versions.find((v) => v.status.current === PUBLISHED);
+      if (publishedVersion) setLastPublishedVersion(publishedVersion);
     };
     if (article) {
       getVersions(article);
@@ -230,6 +230,7 @@ const HeaderActions = ({
                 type="version"
                 article={lastPublishedVersion}
                 language={language}
+                customTitle="form.previewProductionArticle.published"
                 activateButton={
                   <StyledFilledButton type="button">
                     <Eye /> {t('form.previewVersion')}

--- a/src/components/PreviewDraft/PreviewDraftLightboxV2.tsx
+++ b/src/components/PreviewDraft/PreviewDraftLightboxV2.tsx
@@ -153,9 +153,8 @@ const PreviewVersion = ({ article, language, customTitle }: VersionPreviewProps)
       <div>
         <div className="u-4/6@desktop u-push-1/6@desktop">
           <h2>
-            {customTitle
-              ? t(customTitle)
-              : t('form.previewProductionArticle.version', { revision: article.revision })}
+            {customTitle ??
+              t('form.previewProductionArticle.version', { revision: article.revision })}
           </h2>
         </div>
         <PreviewDraft

--- a/src/components/PreviewDraft/PreviewDraftLightboxV2.tsx
+++ b/src/components/PreviewDraft/PreviewDraftLightboxV2.tsx
@@ -45,6 +45,7 @@ interface MarkupPreviewProps extends BaseProps {
 interface VersionPreviewProps extends BaseProps {
   type: 'version';
   article: IArticle;
+  customTitle?: string;
 }
 
 interface ComparePreviewProps extends BaseProps {
@@ -118,7 +119,7 @@ const TwoArticleWrapper = styled(StyledPreviewWrapper)`
   }
 `;
 
-const PreviewVersion = ({ article, language }: VersionPreviewProps) => {
+const PreviewVersion = ({ article, language, customTitle }: VersionPreviewProps) => {
   const { t } = useTranslation();
   const { values, initialValues } = useFormikContext<LearningResourceFormType>();
   const { data: licenses = [] } = useLicenses();
@@ -151,7 +152,11 @@ const PreviewVersion = ({ article, language }: VersionPreviewProps) => {
       </div>
       <div>
         <div className="u-4/6@desktop u-push-1/6@desktop">
-          <h2>{t('form.previewProductionArticle.version', { revision: article.revision })}</h2>
+          <h2>
+            {customTitle
+              ? t(customTitle)
+              : t('form.previewProductionArticle.version', { revision: article.revision })}
+          </h2>
         </div>
         <PreviewDraft
           type="article"

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -774,6 +774,7 @@ const phrases = {
       button: 'Compare current version with old version',
       version: 'Version {{revision}}',
       current: 'Current version',
+      published: 'Published version',
       article: 'Article',
     },
     previewLanguageArticle: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -774,6 +774,7 @@ const phrases = {
       button: 'Sammenlign gjeldende versjon med gammel versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
+      published: 'Publisert versjon',
       article: 'Artikkel',
     },
     previewLanguageArticle: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -773,6 +773,7 @@ const phrases = {
       button: 'Samanlikn gjeldande versjon med gamal versjon',
       version: 'Versjon {{revision}}',
       current: 'Gjeldende versjon',
+      published: 'Publisert versjon',
       article: 'Artikkel',
     },
     previewLanguageArticle: {


### PR DESCRIPTION
https://trello.com/c/MsQWIPJR/651-sammenlign-med-publisert-tuning

Fikser:
- Fikser liten bug der sammenlign med publisert knappen på artikler ble vist når artikkelen ikke har en publisert versjon, men kun er lagret som ny versjon. 
- Oppdaterer tittel på publisert versjon