### PR TITLE
Fix and simplify logic for opening/closing comments

### DIFF
--- a/src/containers/ArticlePage/components/Comment.tsx
+++ b/src/containers/ArticlePage/components/Comment.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -82,25 +82,14 @@ interface Props {
   setComments: (c: CommentType[]) => void;
   onDelete: (index: number) => void;
   index: number;
-  setCommentsOpen: (commentsOpen: boolean[]) => void;
-  commentsOpen: boolean[];
 }
 
-const Comment = ({
-  comments,
-  setComments,
-  onDelete,
-  index,
-  setCommentsOpen,
-  commentsOpen,
-}: Props) => {
+const Comment = ({ comments, setComments, onDelete, index }: Props) => {
   const { t } = useTranslation();
   const comment = comments[index];
 
   const [inputValue, setInputValue] = useState(comment?.content);
   const [modalOpen, setModalOpen] = useState(false);
-
-  const open = useMemo(() => commentsOpen[index], [commentsOpen, index]);
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>): void => {
     setInputValue(e.target.value);
@@ -113,11 +102,7 @@ const Comment = ({
   };
 
   const toggleOpen = (value?: boolean) => {
-    const _open = value !== undefined ? value : !open;
-    const updatedCommentsOpen: boolean[] = commentsOpen?.map((c: boolean, i: number) =>
-      i === index ? _open : c,
-    );
-    setCommentsOpen(updatedCommentsOpen);
+    const _open = value !== undefined ? value : !comment.isOpen;
     const updatedComments = comments.map((c, i) => (index === i ? { ...c, isOpen: _open } : c));
     setComments(updatedComments);
   };
@@ -131,7 +116,7 @@ const Comment = ({
     }
   };
 
-  const tooltipText = open ? t('form.hideComment') : t('form.showComment');
+  const tooltipText = comment.isOpen ? t('form.hideComment') : t('form.showComment');
   const commentId = `${'id' in comment ? comment.id : comment.generatedId}-comment-section`;
 
   return (
@@ -144,10 +129,10 @@ const Comment = ({
             aria-label={tooltipText}
             title={tooltipText}
             onClick={() => toggleOpen()}
-            aria-expanded={open}
+            aria-expanded={comment.isOpen}
             aria-controls={commentId}
           >
-            {open ? <ExpandMore /> : <RightArrow />}
+            {comment.isOpen ? <ExpandMore /> : <RightArrow />}
           </IconButtonV2>
 
           <IconButtonV2
@@ -173,7 +158,7 @@ const Comment = ({
           }}
           onBlur={() => focusUpdate(false)}
           id={commentId}
-          data-open={open}
+          data-open={comment.isOpen}
         />
       </CardContent>
 

--- a/src/containers/ArticlePage/components/CommentSection.tsx
+++ b/src/containers/ArticlePage/components/CommentSection.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useField } from 'formik';
-import { useState, useCallback, useMemo, memo } from 'react';
+import { useCallback, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { ButtonV2 } from '@ndla/button';
@@ -55,19 +55,17 @@ const CommentSection = ({ savedStatus }: Props) => {
   const { t } = useTranslation();
 
   const [_, { value }, { setValue }] = useField<CommentType[]>('comments');
-  const [commentsOpen, setCommentsOpen] = useState<boolean[]>(value.map((c) => c.isOpen));
-  const allOpen = useMemo(() => commentsOpen.every((o) => !!o) ?? undefined, [commentsOpen]);
+  const allOpen = useMemo(() => value.every((v) => v.isOpen), [value]);
 
   const onDelete = useCallback(
     (index: number) => {
-      const updatedList = value?.filter((_c, i) => i !== index);
+      const updatedList = value.filter((_, i) => i !== index);
       setValue(updatedList);
     },
     [value, setValue],
   );
 
   const toggleAllOpen = (allOpen: boolean) => {
-    setCommentsOpen(value.map(() => allOpen));
     setValue(value.map((c) => ({ ...c, isOpen: allOpen })));
   };
   const commentsHidden = RESET_COMMENTS_STATUSES.some((s) => s === savedStatus?.current);
@@ -92,8 +90,6 @@ const CommentSection = ({ savedStatus }: Props) => {
             comments={value ?? []}
             onDelete={onDelete}
             index={index}
-            setCommentsOpen={setCommentsOpen}
-            commentsOpen={commentsOpen}
           />
         ))}
       </StyledList>


### PR DESCRIPTION
Oppdaget litt buggy oppførsel på å toggle kommentarer mellom åpen/lukket, feks. når man oppretter kommentarer så var det ikke mulig å åpne/lukke.

Denne fikser opp i det og gjør koden litt ryddigere!