### PR TITLE
Disable left align button

### DIFF
--- a/src/containers/ImageEditor/ImageAlignButton.tsx
+++ b/src/containers/ImageEditor/ImageAlignButton.tsx
@@ -20,11 +20,12 @@ const icon: Record<string, JSX.Element> = {
 
 interface Props {
   currentAlign?: string;
+  disabled?: boolean;
   alignType: string;
   onFieldChange: (evt: MouseEvent<HTMLButtonElement>, field: string, value: string) => void;
 }
 
-const ImageAlignButton = ({ currentAlign, alignType, onFieldChange }: Props) => {
+const ImageAlignButton = ({ currentAlign, disabled, alignType, onFieldChange }: Props) => {
   const { t } = useTranslation();
   const onChange = (evt: MouseEvent<HTMLButtonElement>) => {
     onFieldChange(evt, 'align', alignType);
@@ -32,7 +33,12 @@ const ImageAlignButton = ({ currentAlign, alignType, onFieldChange }: Props) => 
 
   return (
     <Tooltip tooltip={t(`form.image.alignment.${alignType}`)}>
-      <ImageEditorButton tabIndex={-1} isActive={currentAlign === alignType} onClick={onChange}>
+      <ImageEditorButton
+        tabIndex={-1}
+        disabled={disabled}
+        isActive={currentAlign === alignType}
+        onClick={onChange}
+      >
         {icon[alignType]}
       </ImageEditorButton>
     </Tooltip>

--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -193,6 +193,7 @@ const ImageEditor = ({ embed, onUpdatedImageSettings, imageUpdates, language }: 
                 alignType={alignment}
                 onFieldChange={onFieldChange}
                 currentAlign={imageUpdates?.align}
+                disabled={alignment === 'left'}
               />
             ))}
           </StyledImageEditorMenu>

--- a/src/containers/ImageEditor/ImageEditorButton.tsx
+++ b/src/containers/ImageEditor/ImageEditorButton.tsx
@@ -26,14 +26,15 @@ const EditButton = styled(ButtonV2)<{ isActive: boolean }>`
 `;
 interface Props {
   isActive?: boolean;
+  disabled?: boolean;
   children: ReactNode;
   tabIndex: number;
   onClick: (evt: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const ImageEditorButton = forwardRef<HTMLButtonElement, Props>(
-  ({ isActive, children, ...rest }, ref) => (
-    <EditButton variant="stripped" isActive={!!isActive} ref={ref} {...rest}>
+  ({ isActive, disabled, children, ...rest }, ref) => (
+    <EditButton variant="stripped" isActive={!!isActive} disabled={disabled} ref={ref} {...rest}>
       {children}
     </EditButton>
   ),


### PR DESCRIPTION
Gjør det umulig (vanskelig) å venstrejustere bilder fra ed.

Test: sjekk at du ikkje lenger kan venstrejustere bilder i artikler. Allerede venstrejusterte bilder kan fremdeles finnes og redigeres.