### PR TITLE
Gjør det mulig å avpublisere uten taksonomi

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -17,6 +17,7 @@ import validateFormik, { getWarnings } from '../../../../components/formikValida
 import HeaderWithLanguage from '../../../../components/HeaderWithLanguage';
 import EditorFooter from '../../../../components/SlateEditor/EditorFooter';
 import StyledForm from '../../../../components/StyledFormComponents';
+import { ARCHIVED, UNPUBLISHED } from '../../../../constants';
 import { useSession } from '../../../../containers/Session/SessionProvider';
 import { validateDraft } from '../../../../modules/draft/draftApi';
 import { useLicenses, useDraftStatusStateMachine } from '../../../../modules/draft/draftQueries';
@@ -97,7 +98,11 @@ const LearningResourceForm = ({
 
   const handleSubmit: HandleSubmitFunc<LearningResourceFormType> = useCallback(
     async (values, helpers, saveAsNew) => {
-      if (!contexts?.length) {
+      if (
+        !contexts?.length &&
+        values.status?.current !== ARCHIVED &&
+        values.status?.current !== UNPUBLISHED
+      ) {
         setShowTaxWarning(true);
         return;
       }

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -17,6 +17,7 @@ import validateFormik, { getWarnings } from '../../../../components/formikValida
 import HeaderWithLanguage from '../../../../components/HeaderWithLanguage';
 import EditorFooter from '../../../../components/SlateEditor/EditorFooter';
 import StyledForm from '../../../../components/StyledFormComponents';
+import { ARCHIVED, UNPUBLISHED } from '../../../../constants';
 import { useSession } from '../../../../containers/Session/SessionProvider';
 import { validateDraft } from '../../../../modules/draft/draftApi';
 import { useLicenses, useDraftStatusStateMachine } from '../../../../modules/draft/draftQueries';
@@ -102,7 +103,11 @@ const TopicArticleForm = ({
 
   const handleSubmit: HandleSubmitFunc<TopicArticleFormType> = useCallback(
     async (values, helpers, saveAsNew) => {
-      if (!articleTaxonomy?.length) {
+      if (
+        !articleTaxonomy?.length &&
+        values.status?.current !== ARCHIVED &&
+        values.status?.current !== UNPUBLISHED
+      ) {
         setShowTaxWarning(true);
         return;
       }


### PR DESCRIPTION
Legger til unntak til validering for å kunne slette/avpublisere uten taksonomi

Sjekk at du kan endre status på artikkel til enten sletta eller avpublisert på artikkel uten taksonomi.