### PR TITLE
Fix right aside buttons

### DIFF
--- a/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
+++ b/src/components/SlateEditor/plugins/aside/SlateRightAside.tsx
@@ -24,6 +24,7 @@ const StyledAsideType = styled.div`
   position: absolute;
   width: 100%;
   padding: 3.2px;
+  z-index: ${stackOrder.offsetSingle};
 `;
 
 const StyledAside = styled(Aside)`


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3935

Burde kanskje ikke fjerna denne helt. Halv-høye verdier gjorde at det delvis overskrev forklaringer i teksten. Fjerne dem helt gjorde altså at knappene ikke lenger var klikkbare. Satt en minimal verdi nå, slik at de igjen kan trykkes på.