### PR TITLE
Pass article language into a context instead of passing it directly to plugins.

### DIFF
--- a/e2e/specs/toolbar.spec.ts
+++ b/e2e/specs/toolbar.spec.ts
@@ -88,21 +88,30 @@ test('can create headings', async ({ page }) => {
   await el.click();
   await el.getByRole('textbox').fill('text to style');
   await el.press(`${metaKey}+A`);
-  const button = page.getByTestId('toolbar-button-text');
+  let button = page.getByTestId('toolbar-button-text');
   await button.click();
   const h2Button = page.getByTestId('text-option-heading-2');
   await h2Button.click();
   await expect(page.locator('h2').getByText('text to style')).toBeVisible();
-  await el.press(`${metaKey}+A`);
+  await page.getByTestId('slate-editor').focus()
+  await page.getByTestId('slate-editor').press(`${metaKey}+A`)
+  button = page.getByTestId('toolbar-button-text');
   await expect(button).toBeVisible();
   await button.click();
   const h3Button = page.getByTestId('text-option-heading-3');
   await h3Button.click();
   await expect(page.locator('h3').getByText('text to style')).toBeVisible();
+  await page.getByTestId('slate-editor').focus()
+  await page.getByTestId('slate-editor').press(`${metaKey}+A`)
+  button = page.getByTestId('toolbar-button-text');
   await button.click();
   const h4Button = page.getByTestId('text-option-heading-4');
   await h4Button.click();
   await expect(page.locator('h4').getByText('text to style')).toBeVisible();
+  await page.getByTestId('slate-editor').focus()
+  await page.getByTestId('slate-editor').press(`${metaKey}+A`)
+  await el.press(`${metaKey}+A`);
+  button = page.getByTestId('toolbar-button-text');
   await button.click();
   const normalTextButton = page.getByTestId('text-option-normal-text');
   await normalTextButton.click();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ndla/types-backend": "^0.2.50",
     "@ndla/types-embed": "^4.0.15",
     "@ndla/types-taxonomy": "^1.0.22",
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.41.2",
     "@tanstack/react-query-devtools": "^5.7.2",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",

--- a/src/components/SlateEditor/ArticleLanguageProvider.tsx
+++ b/src/components/SlateEditor/ArticleLanguageProvider.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import { ReactNode, createContext, useContext } from "react";
+import config from "../../config";
+
+const ArticleLanguageContext = createContext<string>(config.defaultLanguage);
+
+interface Props {
+  language?: string;
+  children?: ReactNode;
+}
+
+export const ArticleLanguageProvider = ({ language, children }: Props) => (
+  <ArticleLanguageContext.Provider value={language ?? config.defaultLanguage}>
+    {children}
+  </ArticleLanguageContext.Provider>
+);
+
+export const useArticleLanguage = () => {
+  const context = useContext(ArticleLanguageContext);
+  return context;
+};

--- a/src/components/SlateEditor/PlainTextEditor.tsx
+++ b/src/components/SlateEditor/PlainTextEditor.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FormikHandlers, useFormikContext } from "formik";
-import { useMemo, useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { createEditor, Descendant } from "slate";
 import { withHistory } from "slate-history";
 import { Slate, Editable, ReactEditor, withReact } from "slate-react";
@@ -41,8 +41,7 @@ interface Props extends Omit<EditableProps, "value"> {
 }
 
 const PlainTextEditor = ({ onChange, value, id, submitted, className, placeholder, plugins, ...rest }: Props) => {
-  const _editor = useMemo(() => withHistory(withReact(createEditor())), []);
-  const editor = useMemo(() => withPlugins(_editor, plugins), [_editor, plugins]);
+  const [editor] = useState(() => withPlugins(withHistory(withReact(createEditor())), plugins));
   const props = useFormControl({ id, readOnly: submitted, ...rest });
 
   const onBlur = useCallback(() => {

--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -7,13 +7,14 @@
  */
 import { useFormikContext } from "formik";
 import isEqual from "lodash/isEqual";
-import { FocusEvent, KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FocusEvent, KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
 import { createEditor, Descendant, Editor, NodeEntry, Range, Transforms } from "slate";
 import { withHistory } from "slate-history";
 import { Slate, Editable, withReact, RenderElementProps, RenderLeafProps, ReactEditor } from "slate-react";
 import { EditableProps } from "slate-react/dist/components/editable";
 import styled from "@emotion/styled";
 import { fonts } from "@ndla/core";
+import { ArticleLanguageProvider } from "./ArticleLanguageProvider";
 import { SlatePlugin } from "./interfaces";
 import { Action, commonActions } from "./plugins/blockPicker/actions";
 import { BlockPickerOptions, createBlockpickerOptions } from "./plugins/blockPicker/options";
@@ -71,8 +72,7 @@ const RichTextEditor = ({
   hideToolbar,
   ...rest
 }: Props) => {
-  const _editor = useMemo(() => withReact(withHistory(createEditor())), []);
-  const editor = useMemo(() => withPlugins(_editor, plugins), [_editor, plugins]);
+  const [editor] = useState(() => withPlugins(withReact(withHistory(createEditor())), plugins));
   const [isFirstNormalize, setIsFirstNormalize] = useState(true);
   const prevSubmitted = useRef(submitted);
 
@@ -221,40 +221,42 @@ const RichTextEditor = ({
 
   return (
     <article>
-      <SlateProvider isSubmitted={submitted}>
-        <StyledSlateWrapper data-testid={testId}>
-          <Slate editor={editor} initialValue={value} onChange={onChange}>
-            {isFirstNormalize ? (
-              <Spinner />
-            ) : (
-              <>
-                <SlateToolbar options={toolbarOptions} areaOptions={toolbarAreaFilters} hideToolbar={hideToolbar} />
-                {!hideBlockPicker && (
-                  <SlateBlockPicker
-                    editor={editor}
-                    actions={actions}
-                    articleLanguage={language}
-                    {...createBlockpickerOptions(blockpickerOptions)}
+      <ArticleLanguageProvider language={language}>
+        <SlateProvider isSubmitted={submitted}>
+          <StyledSlateWrapper data-testid={testId}>
+            <Slate editor={editor} initialValue={value} onChange={onChange}>
+              {isFirstNormalize ? (
+                <Spinner />
+              ) : (
+                <>
+                  <SlateToolbar options={toolbarOptions} areaOptions={toolbarAreaFilters} hideToolbar={hideToolbar} />
+                  {!hideBlockPicker && (
+                    <SlateBlockPicker
+                      editor={editor}
+                      actions={actions}
+                      articleLanguage={language}
+                      {...createBlockpickerOptions(blockpickerOptions)}
+                    />
+                  )}
+                  <StyledEditable
+                    {...rest}
+                    onBlur={onBlur}
+                    decorate={decorations}
+                    onKeyDown={handleKeyDown}
+                    placeholder={placeholder}
+                    renderElement={renderElement}
+                    renderLeaf={renderLeaf}
+                    readOnly={submitted}
+                    onDragStart={onDragStartCallback}
+                    onDragOver={onDragOverCallback}
+                    onDrop={onDropCallback}
                   />
-                )}
-                <StyledEditable
-                  {...rest}
-                  onBlur={onBlur}
-                  decorate={decorations}
-                  onKeyDown={handleKeyDown}
-                  placeholder={placeholder}
-                  renderElement={renderElement}
-                  renderLeaf={renderLeaf}
-                  readOnly={submitted}
-                  onDragStart={onDragStartCallback}
-                  onDragOver={onDragOverCallback}
-                  onDrop={onDropCallback}
-                />
-              </>
-            )}
-          </Slate>
-        </StyledSlateWrapper>
-      </SlateProvider>
+                </>
+              )}
+            </Slate>
+          </StyledSlateWrapper>
+        </SlateProvider>
+      </ArticleLanguageProvider>
     </article>
   );
 };

--- a/src/components/SlateEditor/VisualElementEditor.tsx
+++ b/src/components/SlateEditor/VisualElementEditor.tsx
@@ -8,10 +8,11 @@
 
 import { FormikHandlers } from "formik";
 import isEqual from "lodash/isEqual";
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { Descendant, createEditor } from "slate";
 import { withHistory } from "slate-history";
 import { Slate, Editable, withReact, RenderElementProps } from "slate-react";
+import { ArticleLanguageProvider } from "./ArticleLanguageProvider";
 import { SlatePlugin } from "./interfaces";
 import { SlateProvider } from "./SlateContext";
 import withPlugins from "./utils/withPlugins";
@@ -30,8 +31,7 @@ interface Props {
 }
 
 const VisualElementEditor = ({ name, value, plugins, onChange, types, language }: Props) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const editor = useMemo(() => withHistory(withReact(withPlugins(createEditor(), plugins))), []);
+  const [editor] = useState(() => withHistory(withReact(withPlugins(createEditor(), plugins))));
 
   const renderElement = (elementProps: RenderElementProps) => {
     const { attributes, children } = elementProps;
@@ -55,27 +55,29 @@ const VisualElementEditor = ({ name, value, plugins, onChange, types, language }
 
   return (
     <SlateProvider>
-      <Slate
-        editor={editor}
-        initialValue={value}
-        onChange={(val: Descendant[]) => {
-          onChange({
-            target: {
-              name,
-              value: val,
-            },
-          });
-        }}
-      >
-        <VisualElementPicker editor={editor} types={types} language={language} />
-        <Editable
-          readOnly={true}
-          renderElement={renderElement}
-          onDragStart={(e) => {
-            e.stopPropagation();
+      <ArticleLanguageProvider language={language}>
+        <Slate
+          editor={editor}
+          initialValue={value}
+          onChange={(val: Descendant[]) => {
+            onChange({
+              target: {
+                name,
+                value: val,
+              },
+            });
           }}
-        />
-      </Slate>
+        >
+          <VisualElementPicker editor={editor} types={types} language={language} />
+          <Editable
+            readOnly={true}
+            renderElement={renderElement}
+            onDragStart={(e) => {
+              e.stopPropagation();
+            }}
+          />
+        </Slate>
+      </ArticleLanguageProvider>
     </SlateProvider>
   );
 };

--- a/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
@@ -25,12 +25,12 @@ import AudioEmbedForm from "./AudioEmbedForm";
 import { AudioElement } from "./types";
 import { useAudioMeta } from "../../../../modules/embed/queries";
 import parseMarkdown from "../../../../util/parseMarkdown";
+import { useArticleLanguage } from "../../ArticleLanguageProvider";
 import { StyledDeleteEmbedButton, StyledFigureButtons } from "../embed/FigureButtons";
 
 interface Props extends RenderElementProps {
   element: AudioElement;
   editor: Editor;
-  language: string;
 }
 
 const AudioWrapper = styled.div`
@@ -61,10 +61,11 @@ const FigureButtons = styled(StyledFigureButtons)`
   }
 `;
 
-const SlateAudio = ({ element, editor, attributes, language, children }: Props) => {
+const SlateAudio = ({ element, editor, attributes, children }: Props) => {
   const { t } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
   const isSelected = useSelected();
+  const language = useArticleLanguage();
 
   const audioMetaQuery = useAudioMeta(element.data?.resourceId!, language, {
     enabled: !!parseInt(element.data?.resourceId ?? ""),

--- a/src/components/SlateEditor/plugins/audio/render.tsx
+++ b/src/components/SlateEditor/plugins/audio/render.tsx
@@ -10,12 +10,12 @@ import { Editor } from "slate";
 import SlateAudio from "./SlateAudio";
 import { TYPE_AUDIO } from "./types";
 
-export const audioRenderer = (language: string) => (editor: Editor) => {
+export const audioRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_AUDIO) {
       return (
-        <SlateAudio attributes={attributes} editor={editor} element={element} language={language}>
+        <SlateAudio attributes={attributes} editor={editor} element={element}>
           {children}
         </SlateAudio>
       );

--- a/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
@@ -27,6 +27,7 @@ import { ConceptType } from "../../../../../containers/ConceptPage/conceptInterf
 import { useFetchConceptData } from "../../../../../containers/FormikForm/formikConceptHooks";
 import { useConceptVisualElement } from "../../../../../modules/embed/queries";
 import parseMarkdown from "../../../../../util/parseMarkdown";
+import { useArticleLanguage } from "../../../ArticleLanguageProvider";
 import ConceptModalContent from "../ConceptModalContent";
 import EditGlossExamplesModal from "../EditGlossExamplesModal";
 import { getGlossDataAttributes } from "../utils";
@@ -41,7 +42,6 @@ const getConceptDataAttributes = ({ id, conceptType, glossData }: IConceptSummar
 
 interface Props {
   element: ConceptBlockElement;
-  locale: string;
   editor: Editor;
   attributes: RenderElementProps["attributes"];
   children: ReactNode;
@@ -54,8 +54,9 @@ const StyledWrapper = styled.div`
   }
 `;
 
-const BlockWrapper = ({ element, locale, editor, attributes, children }: Props) => {
+const BlockWrapper = ({ element, editor, attributes, children }: Props) => {
   const isSelected = useSelected();
+  const locale = useArticleLanguage();
   const [isEditing, setIsEditing] = useState(element.isFirstEdit);
   const { concept, subjects, loading, ...conceptHooks } = useFetchConceptData(parseInt(element.data.contentId), locale);
 

--- a/src/components/SlateEditor/plugins/concept/block/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/render.tsx
@@ -10,12 +10,12 @@ import { Editor } from "slate";
 import BlockWrapper from "./BlockWrapper";
 import { TYPE_CONCEPT_BLOCK } from "./types";
 
-export const blockConceptRenderer = (locale: string) => (editor: Editor) => {
+export const blockConceptRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_CONCEPT_BLOCK) {
       return (
-        <BlockWrapper attributes={attributes} element={element} editor={editor} locale={locale}>
+        <BlockWrapper attributes={attributes} element={element} editor={editor}>
           {children}
         </BlockWrapper>
       );

--- a/src/components/SlateEditor/plugins/concept/inline/InlineWrapper.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineWrapper.tsx
@@ -28,6 +28,7 @@ import { ConceptType } from "../../../../../containers/ConceptPage/conceptInterf
 import { useFetchConceptData } from "../../../../../containers/FormikForm/formikConceptHooks";
 import { useConceptVisualElement } from "../../../../../modules/embed/queries";
 import parseMarkdown from "../../../../../util/parseMarkdown";
+import { useArticleLanguage } from "../../../ArticleLanguageProvider";
 import ConceptModalContent from "../ConceptModalContent";
 import EditGlossExamplesModal from "../EditGlossExamplesModal";
 import { getGlossDataAttributes } from "../utils";
@@ -44,7 +45,6 @@ const getConceptDataAttributes = (concept: IConcept | IConceptSummary, title: st
 
 interface Props {
   element: ConceptInlineElement;
-  locale: string;
   editor: Editor;
   attributes: RenderElementProps["attributes"];
   children: ReactNode;
@@ -81,9 +81,10 @@ const HiddenChildren = styled.div`
 
 const InlineWrapper = (props: Props) => {
   const { t } = useTranslation();
-  const { children, element, locale, editor, attributes } = props;
+  const { children, element, editor, attributes } = props;
   const nodeText = Node.string(element).trim();
   const [isEditing, setIsEditing] = useState(element.isFirstEdit);
+  const locale = useArticleLanguage();
   const { concept, subjects, loading, fetchSearchTags, conceptArticles, createConcept, updateConcept } =
     useFetchConceptData(parseInt(element.data.contentId), locale);
 

--- a/src/components/SlateEditor/plugins/concept/inline/render.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/render.tsx
@@ -10,12 +10,12 @@ import { Editor } from "slate";
 import InlineConcept from "./InlineWrapper";
 import { TYPE_CONCEPT_INLINE } from "./types";
 
-export const inlineConceptRenderer = (locale: string) => (editor: Editor) => {
+export const inlineConceptRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_CONCEPT_INLINE) {
       return (
-        <InlineConcept element={element} attributes={attributes} editor={editor} locale={locale}>
+        <InlineConcept element={element} attributes={attributes} editor={editor}>
           {children}
         </InlineConcept>
       );

--- a/src/components/SlateEditor/plugins/conceptList/ConceptList.tsx
+++ b/src/components/SlateEditor/plugins/conceptList/ConceptList.tsx
@@ -22,10 +22,10 @@ import { ConceptListElement } from ".";
 import ConceptTagPicker from "./ConceptTagPicker";
 import { useSearchConcepts } from "../../../../modules/concept/conceptQueries";
 import { useConceptListMeta } from "../../../../modules/embed/queries";
+import { useArticleLanguage } from "../../ArticleLanguageProvider";
 
 interface Props {
   element: ConceptListElement;
-  language: string;
   editor: Editor;
   attributes: RenderElementProps["attributes"];
   children: ReactNode;
@@ -48,10 +48,11 @@ const ButtonContainer = styled.div`
   transform: translateX(100%);
 `;
 
-const ConceptList = ({ element, language, editor, attributes, children }: Props) => {
+const ConceptList = ({ element, editor, attributes, children }: Props) => {
   const [editMode, setEditMode] = useState<boolean>(!!element.isFirstEdit);
   const isSelected = useSelected();
   const { t } = useTranslation();
+  const language = useArticleLanguage();
 
   const conceptsQuery = useSearchConcepts(
     {

--- a/src/components/SlateEditor/plugins/conceptList/render.tsx
+++ b/src/components/SlateEditor/plugins/conceptList/render.tsx
@@ -10,12 +10,12 @@ import { Editor } from "slate";
 import ConceptList from "./ConceptList";
 import { TYPE_CONCEPT_LIST } from "./types";
 
-export const conceptListRenderer = (language: string) => (editor: Editor) => {
+export const conceptListRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_CONCEPT_LIST) {
       return (
-        <ConceptList attributes={attributes} element={element} language={language} editor={editor}>
+        <ConceptList attributes={attributes} element={element} editor={editor}>
           {children}
         </ConceptList>
       );

--- a/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
+++ b/src/components/SlateEditor/plugins/embed/SlateFigure.tsx
@@ -15,13 +15,13 @@ import SlateImage from "./SlateImage";
 import SlateVideo from "./SlateVideo";
 import { isSlateEmbed } from "./utils";
 import DisplayExternal from "../../../DisplayEmbed/DisplayExternal";
+import { useArticleLanguage } from "../../ArticleLanguageProvider";
 import EditorErrorMessage from "../../EditorErrorMessage";
 
 interface Props {
   attributes: RenderElementProps["attributes"];
   editor: Editor;
   element: EmbedElements;
-  language: string;
   children: ReactNode;
   allowDecorative?: boolean;
 }
@@ -32,9 +32,10 @@ interface ChangesProp {
   [x: string]: string;
 }
 
-const SlateFigure = ({ attributes, editor, element, language, children, allowDecorative = true }: Props) => {
+const SlateFigure = ({ attributes, editor, element, children, allowDecorative = true }: Props) => {
   const embed = element.data;
   const { t } = useTranslation();
+  const language = useArticleLanguage();
 
   const saveEmbedUpdates = (updates: ChangesProp) => {
     Transforms.setNodes(editor, { data: { ...embed, ...updates } }, { at: ReactEditor.findPath(editor, element) });

--- a/src/components/SlateEditor/plugins/embed/render.tsx
+++ b/src/components/SlateEditor/plugins/embed/render.tsx
@@ -10,18 +10,12 @@ import { Editor } from "slate";
 import SlateFigure from "./SlateFigure";
 import { isSlateEmbedElement } from "./utils";
 
-export const embedRenderer = (language: string, allowDecorative?: boolean) => (editor: Editor) => {
+export const embedRenderer = (allowDecorative?: boolean) => (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (isSlateEmbedElement(element)) {
       return (
-        <SlateFigure
-          attributes={attributes}
-          editor={editor}
-          element={element}
-          language={language}
-          allowDecorative={allowDecorative}
-        >
+        <SlateFigure attributes={attributes} editor={editor} element={element} allowDecorative={allowDecorative}>
           {children}
         </SlateFigure>
       );

--- a/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
+++ b/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
@@ -21,12 +21,12 @@ import EditMetadataModal from "./EditMetadataModal";
 import { H5pElement } from "./types";
 import config from "../../../../config";
 import { useH5pMeta } from "../../../../modules/embed/queries";
+import { useArticleLanguage } from "../../ArticleLanguageProvider";
 import { StyledDeleteEmbedButton, StyledFigureButtons } from "../embed/FigureButtons";
 
 interface Props extends RenderElementProps {
   element: H5pElement;
   editor: Editor;
-  language: string;
 }
 
 const H5pWrapper = styled.div`
@@ -50,9 +50,10 @@ const FigureButtons = styled(StyledFigureButtons)`
   z-index: ${stackOrder.offsetSingle};
 `;
 
-const SlateH5p = ({ element, editor, attributes, language, children }: Props) => {
+const SlateH5p = ({ element, editor, attributes, children }: Props) => {
   const { t } = useTranslation();
   const isSelected = useSelected();
+  const language = useArticleLanguage();
 
   const h5pMetaQuery = useH5pMeta(element.data?.path!, element.data?.url!, {
     enabled: !!element.data?.path,

--- a/src/components/SlateEditor/plugins/h5p/render.tsx
+++ b/src/components/SlateEditor/plugins/h5p/render.tsx
@@ -10,12 +10,12 @@ import { Editor } from "slate";
 import SlateH5p from "./SlateH5p";
 import { TYPE_H5P } from "./types";
 
-export const h5pRenderer = (language: string) => (editor: Editor) => {
+export const h5pRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_H5P) {
       return (
-        <SlateH5p attributes={attributes} editor={editor} element={element} language={language}>
+        <SlateH5p attributes={attributes} editor={editor} element={element}>
           {children}
         </SlateH5p>
       );

--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -19,6 +19,7 @@ import { ContentLinkElement, LinkElement } from ".";
 import EditLink from "./EditLink";
 import config from "../../../../config";
 import { toEditGenericArticle, toLearningpathFull } from "../../../../util/routeHelpers";
+import { useArticleLanguage } from "../../ArticleLanguageProvider";
 import isNodeInCurrentSelection from "../../utils/isNodeInCurrentSelection";
 
 interface StyledLinkMenuProps {
@@ -56,7 +57,6 @@ interface Props {
   attributes: RenderElementProps["attributes"];
   editor: Editor;
   element: LinkElement | ContentLinkElement;
-  language: string;
   children: JSX.Element;
 }
 
@@ -71,11 +71,12 @@ const StyledLink = styled.a`
   cursor: text;
 `;
 
-const Link = ({ attributes, editor, element, language, children }: Props) => {
+const Link = ({ attributes, editor, element, children }: Props) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [model, setModel] = useState<Model | undefined>();
   const startOpen = useRef(!hasHrefOrContentId(element));
   const [editMode, setEditMode] = useState(!hasHrefOrContentId(element));
+  const language = useArticleLanguage();
 
   const { t } = useTranslation();
 

--- a/src/components/SlateEditor/plugins/link/render.tsx
+++ b/src/components/SlateEditor/plugins/link/render.tsx
@@ -9,12 +9,12 @@
 import { Editor } from "slate";
 import Link from "./Link";
 
-export const linkRenderer = (language: string) => (editor: Editor) => {
+export const linkRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === "link" || element.type === "content-link") {
       return (
-        <Link element={element} attributes={attributes} editor={editor} language={language}>
+        <Link element={element} attributes={attributes} editor={editor}>
           {children}
         </Link>
       );

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -115,15 +115,12 @@ interface Props {
   articleLanguage: string;
 }
 
+const editorPlugins = frontpagePlugins.concat(frontpageRenderers);
+
 const FrontpageArticleFormContent = ({ articleLanguage }: Props) => {
   const { userPermissions } = useSession();
   const { t } = useTranslation();
   const { isWideArticle } = useWideArticle();
-
-  const editorPlugins = useMemo(
-    () => frontpagePlugins.concat(frontpageRenderers(articleLanguage ?? "")),
-    [articleLanguage],
-  );
 
   const { dirty, initialValues, values } = useFormikContext<FrontpageArticleFormType>();
   const { slug, id, creators, published, language } = values;

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpageRenderers.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpageRenderers.ts
@@ -42,23 +42,23 @@ import { tableRenderer } from "../../../../components/SlateEditor/plugins/table/
 import { disclaimerRenderer } from "../../../../components/SlateEditor/plugins/uuDisclaimer/render";
 
 // Plugins are checked from last to first
-export const frontpageRenderers = (articleLanguage: string): SlatePlugin[] => [
+export const frontpageRenderers: SlatePlugin[] = [
   sectionRenderer,
   spanRenderer,
   divRenderer,
   paragraphRenderer,
   footnoteRenderer,
-  embedRenderer(articleLanguage),
-  audioRenderer(articleLanguage),
-  h5pRenderer(articleLanguage),
+  embedRenderer(),
+  audioRenderer,
+  h5pRenderer,
   framedContentRenderer,
   asideRenderer,
   detailsRenderer,
   blockQuoteRenderer,
-  linkRenderer(articleLanguage),
-  conceptListRenderer(articleLanguage),
-  inlineConceptRenderer(articleLanguage),
-  blockConceptRenderer(articleLanguage),
+  linkRenderer,
+  conceptListRenderer,
+  inlineConceptRenderer,
+  blockConceptRenderer,
   headingRenderer,
   // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
   // // Blockquote and editList actions need to be triggered before paragraph action, else

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -160,6 +160,8 @@ interface ContentFieldProps extends FieldProps<Descendant[]> {
   articleLanguage: string;
 }
 
+const editorPlugins = learningResourcePlugins.concat(learningResourceRenderers);
+
 const ContentField = ({ articleId, field: { name, onChange, value }, articleLanguage }: ContentFieldProps) => {
   const { t } = useTranslation();
   const { userPermissions } = useSession();
@@ -177,11 +179,6 @@ const ContentField = ({ articleId, field: { name, onChange, value }, articleLang
       });
     },
     [onChange, name],
-  );
-
-  const editorPlugins = useMemo(
-    () => learningResourcePlugins.concat(learningResourceRenderers(articleLanguage)),
-    [articleLanguage],
   );
 
   return (

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourceRenderers.ts
@@ -37,38 +37,36 @@ import { tableRenderer } from "../../../../components/SlateEditor/plugins/table/
 import { disclaimerRenderer } from "../../../../components/SlateEditor/plugins/uuDisclaimer/render";
 
 // Plugins are checked from last to first
-export const learningResourceRenderers = (articleLanguage: string): SlatePlugin[] => {
-  return [
-    sectionRenderer,
-    spanRenderer,
-    divRenderer,
-    paragraphRenderer,
-    footnoteRenderer,
-    audioRenderer(articleLanguage),
-    h5pRenderer(articleLanguage),
-    embedRenderer(articleLanguage),
-    framedContentRenderer,
-    asideRenderer,
-    detailsRenderer,
-    blockQuoteRenderer,
-    linkRenderer(articleLanguage),
-    conceptListRenderer(articleLanguage),
-    inlineConceptRenderer(articleLanguage),
-    blockConceptRenderer(articleLanguage),
-    headingRenderer,
-    // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
-    // // Blockquote and editList actions need to be triggered before paragraph action, else
-    // // unwrapping (jumping out of block) will not work.
-    tableRenderer,
-    relatedRenderer,
-    fileRenderer,
-    mathRenderer,
-    codeblockRenderer,
-    breakRenderer,
-    markRenderer,
-    definitionListRenderer,
-    listRenderer,
-    gridRenderer,
-    disclaimerRenderer,
-  ];
-};
+export const learningResourceRenderers: SlatePlugin[] = [
+  sectionRenderer,
+  spanRenderer,
+  divRenderer,
+  paragraphRenderer,
+  footnoteRenderer,
+  audioRenderer,
+  h5pRenderer,
+  embedRenderer(),
+  framedContentRenderer,
+  asideRenderer,
+  detailsRenderer,
+  blockQuoteRenderer,
+  linkRenderer,
+  conceptListRenderer,
+  inlineConceptRenderer,
+  blockConceptRenderer,
+  headingRenderer,
+  // // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
+  // // Blockquote and editList actions need to be triggered before paragraph action, else
+  // // unwrapping (jumping out of block) will not work.
+  tableRenderer,
+  relatedRenderer,
+  fileRenderer,
+  mathRenderer,
+  codeblockRenderer,
+  breakRenderer,
+  markRenderer,
+  definitionListRenderer,
+  listRenderer,
+  gridRenderer,
+  disclaimerRenderer,
+];

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
 import { FieldHeader } from "@ndla/forms";
@@ -16,7 +15,6 @@ import { topicArticlePlugins } from "./topicArticlePlugins";
 import { topicArticleRenderers } from "./topicArticleRenderers";
 import { EditMarkupLink } from "../../../../components/EditMarkupLink";
 import FormikField from "../../../../components/FormikField";
-import { SlatePlugin } from "../../../../components/SlateEditor/interfaces";
 import {
   createToolbarAreaOptions,
   createToolbarDefaultValues,
@@ -36,10 +34,7 @@ const StyledByLineFormikField = styled(FormikField)`
   justify-content: space-between;
 `;
 
-const createPlugins = (language: string): SlatePlugin[] => {
-  // Plugins are checked from last to first
-  return topicArticlePlugins.concat(topicArticleRenderers(language));
-};
+const plugins = topicArticlePlugins.concat(topicArticleRenderers);
 
 const toolbarOptions = createToolbarDefaultValues();
 const toolbarAreaFilters = createToolbarAreaOptions();
@@ -54,9 +49,6 @@ const TopicArticleContent = (props: Props) => {
     values: { id, language, creators, published },
   } = props;
   const { userPermissions } = useSession();
-  const plugins = useMemo(() => {
-    return createPlugins(language ?? "");
-  }, [language]);
 
   return (
     <>

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticleRenderers.ts
@@ -23,13 +23,13 @@ import { sectionRenderer } from "../../../../components/SlateEditor/plugins/sect
 import { spanRenderer } from "../../../../components/SlateEditor/plugins/span/render";
 
 // Plugins are checked from last to first
-export const topicArticleRenderers = (articleLanguage: string): SlatePlugin[] => [
+export const topicArticleRenderers: SlatePlugin[] = [
   sectionRenderer,
   spanRenderer,
   divRenderer,
   paragraphRenderer,
   noEmbedRenderer,
-  linkRenderer(articleLanguage),
+  linkRenderer,
   headingRenderer,
   // Paragraph-, blockquote- and editList-plugin listens for Enter press on empty lines.
   // Blockquote and editList actions need to be triggered before paragraph action, else
@@ -37,7 +37,7 @@ export const topicArticleRenderers = (articleLanguage: string): SlatePlugin[] =>
   blockQuoteRenderer,
   definitionListRenderer,
   listRenderer,
-  inlineConceptRenderer(articleLanguage),
+  inlineConceptRenderer,
   mathRenderer,
   markRenderer,
   breakRenderer,

--- a/src/containers/VisualElement/VisualElement.tsx
+++ b/src/containers/VisualElement/VisualElement.tsx
@@ -41,14 +41,13 @@ const VisualElement = ({
   const plugins = useMemo(() => {
     return [
       audioPlugin(true),
-      audioRenderer(language),
+      audioRenderer,
       h5pPlugin(true),
-      h5pRenderer(language),
+      h5pRenderer,
       embedPlugin(true),
-      embedRenderer(language, allowDecorative),
+      embedRenderer(allowDecorative),
     ];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedResource]);
+  }, [allowDecorative]);
 
   return (
     <VisualElementEditor

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,14 +1755,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.39.0":
-  version: 1.39.0
-  resolution: "@playwright/test@npm:1.39.0"
+"@playwright/test@npm:^1.41.2":
+  version: 1.41.2
+  resolution: "@playwright/test@npm:1.41.2"
   dependencies:
-    playwright: "npm:1.39.0"
+    playwright: "npm:1.41.2"
   bin:
     playwright: cli.js
-  checksum: 10c0/d808ca36f0a411ae09eece19fc93fcbd048541253c6c9e341fc9488613395bb94ebf65ad64e920d6be0fb20e887cf317c532a45d2c30e1804d6842e55c1fe6e9
+  checksum: 10c0/071fe307e7e46f550e8608ce3c2c207b7cfbda37b39f3dcbe3875eaa18e79f2a768a5795a8cfe21df9361ec63594de0359f5542dd3a3a7f6625300a98452a344
   languageName: node
   linkType: hard
 
@@ -5527,7 +5527,7 @@ __metadata:
     "@ndla/ui": "npm:^50.9.14"
     "@ndla/util": "npm:^4.0.4"
     "@ndla/video-search": "npm:^5.0.18"
-    "@playwright/test": "npm:^1.39.0"
+    "@playwright/test": "npm:^1.41.2"
     "@radix-ui/react-accordion": "npm:^1.1.2"
     "@radix-ui/react-popover": "npm:^1.0.3"
     "@radix-ui/react-portal": "npm:^1.0.3"
@@ -9936,27 +9936,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.39.0":
-  version: 1.39.0
-  resolution: "playwright-core@npm:1.39.0"
+"playwright-core@npm:1.41.2":
+  version: 1.41.2
+  resolution: "playwright-core@npm:1.41.2"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/dbd719ae77ae84a43f831beb89514ca5cca62840a2f0cce445645002ac045c256c19b5f4f3cf9a7aa205428a1571e9e8d946ff1937cc316033ea58090c549a76
+  checksum: 10c0/1e80a24b0e93dd5aa643fb926d23c055f2c1a0a1e711c0d798edcfd8c3e46a6716d4ca59d72ed076191e6c713d09a0f14387d96e60f5221abd4ff65aef1ac3b3
   languageName: node
   linkType: hard
 
-"playwright@npm:1.39.0":
-  version: 1.39.0
-  resolution: "playwright@npm:1.39.0"
+"playwright@npm:1.41.2":
+  version: 1.41.2
+  resolution: "playwright@npm:1.41.2"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.39.0"
+    playwright-core: "npm:1.41.2"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/b55adb3453a9c2a02fe61dbcbd5fcb0cbae1038ea6115158c7933d203ae5b62a13cb294905d6661836751a5825bc2cfdc71b67988082ec47ac6930ca744af724
+  checksum: 10c0/1b487387c1bc003291a9dbd098e8e3c6a31efbb4d7a2ce4f2bf9d5e7f9fbf4a406352ab70e5266eab9a2a858bd42d8955343ea30c0286c3912e81984aa0220a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This also fixes a bug when hot-reloading the editor during development