### PR TITLE
Use our own dropdown menus instead of focus-trap-react for most dropdowns.

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderLanguagePicker.tsx
+++ b/src/components/HeaderWithLanguage/HeaderLanguagePicker.tsx
@@ -6,54 +6,51 @@
  *
  */
 
-import FocusTrapReact from "focus-trap-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import styled from "@emotion/styled";
+import { DropdownMenuArrow } from "@radix-ui/react-dropdown-menu";
+import { spacing, colors } from "@ndla/core";
+import { DropdownItem, DropdownContent, DropdownMenu, DropdownTrigger } from "@ndla/dropdown-menu";
 import { Plus } from "@ndla/icons/action";
-import { StyledDropdownOverlay } from "../Dropdown";
 import Overlay from "../Overlay";
 import StyledFilledButton from "../StyledFilledButton";
 import { styledListElement } from "../StyledListElement/StyledListElement";
 
+const StyledDropdownContent = styled(DropdownContent)`
+  padding: ${spacing.normal};
+`;
+
+const StyledArrow = styled(DropdownMenuArrow)`
+  fill: ${colors.white};
+`;
+
 const LanguagePicker = ({ id, emptyLanguages, editUrl }: Props) => {
   const { t } = useTranslation();
-  const [display, setDisplay] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   return (
     <div>
-      {emptyLanguages.length > 0 && (
-        <StyledFilledButton type="button" onClick={() => setDisplay(true)}>
-          <Plus /> {t("form.variant.create")}
-        </StyledFilledButton>
-      )}
-      {display && (
-        <>
-          <FocusTrapReact
-            active
-            focusTrapOptions={{
-              onDeactivate: () => {
-                setDisplay(false);
-              },
-              clickOutsideDeactivates: true,
-              escapeDeactivates: true,
-            }}
-          >
-            <StyledDropdownOverlay withArrow>
-              {emptyLanguages.map((language) => (
-                <Link
-                  css={styledListElement}
-                  key={language.key}
-                  to={editUrl(id, language.key)}
-                  onClick={() => setDisplay(false)}
-                >
-                  {language.title}
-                </Link>
-              ))}
-            </StyledDropdownOverlay>
-          </FocusTrapReact>
-          <Overlay modifiers="zIndex" />
-        </>
-      )}
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        {!!emptyLanguages.length && (
+          <DropdownTrigger asChild>
+            <StyledFilledButton type="button">
+              <Plus /> {t("form.variant.create")}
+            </StyledFilledButton>
+          </DropdownTrigger>
+        )}
+        <StyledDropdownContent>
+          <StyledArrow width={20} height={10} />
+          {emptyLanguages.map((language) => (
+            <DropdownItem key={language.key} asChild>
+              <Link css={styledListElement} to={editUrl(id, language.key)}>
+                {language.title}
+              </Link>
+            </DropdownItem>
+          ))}
+        </StyledDropdownContent>
+      </DropdownMenu>
+      {isOpen && <Overlay modifiers={["zIndex", "absolute"]} />}
     </div>
   );
 };

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -13,7 +13,7 @@ import { animations, stackOrder } from "@ndla/core";
 
 const appearances: Record<string, SerializedStyles> = {
   zIndex: css`
-    z-index: ${stackOrder.offsetSingle};
+    z-index: ${stackOrder.dropdown - stackOrder.offsetSingle};
   `,
   absolute: css`
     position: absolute;

--- a/src/containers/Masthead/components/Navigation.tsx
+++ b/src/containers/Masthead/components/Navigation.tsx
@@ -152,7 +152,7 @@ const Navigation = () => {
                       Kvalitaisen
                     </SafeLink>
                   </LinkWrapper>
-                  <SessionContainer close={closeMenu} />
+                  <SessionContainer />
                 </StyledHeaderItems>
               </Column>
             </GridContainer>

--- a/src/containers/StructurePage/folderComponents/SettingsMenu.tsx
+++ b/src/containers/StructurePage/folderComponents/SettingsMenu.tsx
@@ -47,6 +47,10 @@ const StyledIconButton = styled(IconButtonV2)`
   }
 `;
 
+const StyledContent = styled(Content)`
+  z-index: ${stackOrder.dropdown};
+`;
+
 interface Props {
   node: Node;
   rootNodeId: string;
@@ -72,7 +76,7 @@ const SettingsMenu = ({ node, rootNodeId, onCurrentNodeChanged, nodeChildren }: 
       </Trigger>
       <Portal>
         <>
-          <Content side="right" sideOffset={10} asChild>
+          <StyledContent side="right" sideOffset={10} asChild>
             <StyledDivWrapper data-testid="settings-menu-modal">
               <Header>
                 <TitleWrapper>
@@ -90,7 +94,7 @@ const SettingsMenu = ({ node, rootNodeId, onCurrentNodeChanged, nodeChildren }: 
                 nodeChildren={nodeChildren}
               />
             </StyledDivWrapper>
-          </Content>
+          </StyledContent>
           <Overlay modifiers={["zIndex"]} />
         </>
       </Portal>
@@ -101,7 +105,6 @@ const SettingsMenu = ({ node, rootNodeId, onCurrentNodeChanged, nodeChildren }: 
 export const StyledDivWrapper = styled.div`
   position: absolute;
   ${animations.fadeIn()}
-  z-index: ${stackOrder.offsetDouble};
   padding: ${spacing.xsmall};
   width: 550px;
   background-color: ${colors.brand.greyLightest};


### PR DESCRIPTION
Kan snart droppe focus-trap-react som dep. Dette sørger også for at overlay dekker hele skjermen.