### PR TITLE
Do not rely on editor.selection to display the link modal/popover.

### DIFF
--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -27,7 +27,7 @@ interface StyledLinkMenuProps {
   left: number;
 }
 
-const StyledLinkMenu = styled("span")<StyledLinkMenuProps>`
+const StyledLinkMenu = styled.div<StyledLinkMenuProps>`
   position: absolute;
   top: ${(p) => p.top}px;
   left: ${(p) => p.left}px;
@@ -76,6 +76,7 @@ const Link = ({ attributes, editor, element, children }: Props) => {
   const [model, setModel] = useState<Model | undefined>();
   const startOpen = useRef(!hasHrefOrContentId(element));
   const [editMode, setEditMode] = useState(!hasHrefOrContentId(element));
+  const [isLinkSelected, setIsLinkSelected] = useState(false);
   const language = useArticleLanguage();
 
   const { t } = useTranslation();
@@ -120,30 +121,30 @@ const Link = ({ attributes, editor, element, children }: Props) => {
     setStateFromNode();
   }, [element, language]);
 
+  useEffect(() => {
+    if (!editor.selection) return;
+    setIsLinkSelected(isNodeInCurrentSelection(editor, element));
+  }, [editor, editor.selection, element]);
+
   const { top, left } = getMenuPosition();
-  const isInline = isNodeInCurrentSelection(editor, element);
 
   return (
     <Modal defaultOpen={startOpen.current} open={editMode} onOpenChange={toggleEditMode}>
       <StyledLink {...attributes} href={model?.href} ref={linkRef}>
         {children}
-        {model && (
-          <>
-            {isInline && (
-              <Portal>
-                <StyledLinkMenu top={top} left={left}>
-                  <ModalTrigger>
-                    <ButtonV2 variant="link">{t("form.content.link.change")}</ButtonV2>
-                  </ModalTrigger>{" "}
-                  | {t("form.content.link.goTo")}{" "}
-                  <a href={model?.href} target="_blank" rel="noopener noreferrer">
-                    {" "}
-                    {model?.href}
-                  </a>
-                </StyledLinkMenu>
-              </Portal>
-            )}
-          </>
+        {model && isLinkSelected && (
+          <Portal>
+            <StyledLinkMenu top={top} left={left}>
+              <ModalTrigger>
+                <ButtonV2 variant="link">{t("form.content.link.change")}</ButtonV2>
+              </ModalTrigger>{" "}
+              | {t("form.content.link.goTo")}{" "}
+              <a href={model?.href} target="_blank" rel="noopener noreferrer">
+                {" "}
+                {model?.href}
+              </a>
+            </StyledLinkMenu>
+          </Portal>
         )}
       </StyledLink>
       <ModalContent>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3956
The editor.selection can be reset when Slate loses focus, causing both the popover and the modal to disappear.
