### PR TITLE
Enable brightcove to support playlists

### DIFF
--- a/src/components/SlateEditor/plugins/external/SlateExternal.tsx
+++ b/src/components/SlateEditor/plugins/external/SlateExternal.tsx
@@ -168,8 +168,9 @@ export const SlateExternal = ({ element, editor, attributes, children }: Props) 
 
   const providerName =
     embed?.resource === "external" && embed?.status === "success" ? embed.data.oembed.providerName : undefined;
+
   const [allowedProvider] = EXTERNAL_WHITELIST_PROVIDERS.filter((whitelistProvider) => {
-    return element.type === "iframe" && embed?.embedData.url
+    return embed?.resource === "iframe" && embed?.embedData.url
       ? urlOrigin(embed.embedData.url)
       : whitelistProvider.name === providerName;
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -194,6 +194,7 @@ export const EXTERNAL_WHITELIST_PROVIDERS: WhitelistProvider[] = [
   { name: "Facebook", url: ["www.facebook.com", "fb.watch"] },
   { name: "Sketchfab", url: ["sketchfab.com"] },
   { name: "JeopardyLabs", url: ["jeopardylabs.com"] },
+  { name: "Brightcove", url: ["players.brightcove.net"] },
 ];
 
 export const SearchTypeValues = [


### PR DESCRIPTION
Ref https://trello.com/c/FEmxc8Mq/724-godkjenne-brightcove-p%C3%A5-ressurs-fra-lenke-for-%C3%A5-fjerne-h5p-iframe

Gjør det mulig å sette inn https://players.brightcove.net/4806596774001/experience_618457388771de00248efb67/index.html via ressurs fra lenke. Dette er en spilleliste og trengs for å slutte å bruke h5p iframe-type.