### PR TITLE
Can now press right click and exit link node

### DIFF
--- a/src/components/SlateEditor/utils/keys.ts
+++ b/src/components/SlateEditor/utils/keys.ts
@@ -7,6 +7,7 @@
  */
 export const KEY_ARROW_UP = "ArrowUp";
 export const KEY_ARROW_DOWN = "ArrowDown";
+export const KEY_ARROW_RIGHT = "ArrowRight";
 export const KEY_TAB = "Tab";
 export const KEY_BACKSPACE = "Backspace";
 export const KEY_DELETE = "Delete";


### PR DESCRIPTION
Usikker om jeg er fan av måten jeg har løst det på men jeg vet ikke hva ellers man skal gjøre.

Denne fikser:
1. Lag en link
2. Flytt cursor inn i lenken, flytt cursor bort til enden av link elementet. 
3. Tastetrykk mot høyre vil ikke bevege slate ut av anchor elementet

Det er en minor bug med løsningen og det skjer når du har tekst og cursor ala dette:
`_asd|f_ asdf` og du trykker høyrepiltast så ender du opp 1 steg lenger mot høyre enn man skulle anta  `_asdf_| asdf`.

Kan legge mer tid i det, men er usikker på hvordan det kan løses da slate er ugrei mot meg. 