### PR TITLE
Fix comment content stripping for tooltip in preview comment

### DIFF
--- a/src/util/formHelper.ts
+++ b/src/util/formHelper.ts
@@ -326,6 +326,6 @@ export const getTagName = (id: string | undefined, data: { id: string; name: str
 };
 
 export const stripInlineContentHtmlTags = (html: string): string =>
-  inlineContentToEditorValue(html)
+  inlineContentToEditorValue(html, true)
     .map((n) => Node.string(n))
     .join("");


### PR DESCRIPTION
Fikser opp i preview visning av kommentarer i arbeidsliste:

<img width="149" alt="Skjermbilde 2024-03-13 kl  08 48 07" src="https://github.com/NDLANO/editorial-frontend/assets/26788204/2db44539-79d3-4180-b1f6-28b6c9e3ea93">
