### PR TITLE
Do not automatically close Link popover when editor loses focus

### DIFF
--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Editor, Node } from "slate";
+import { BaseSelection, Editor, Node, Transforms } from "slate";
 import { ReactEditor, RenderElementProps, useSelected } from "slate-react";
 import styled from "@emotion/styled";
 import { Portal } from "@radix-ui/react-portal";
@@ -35,6 +35,9 @@ const StyledLinkMenu = styled.div<StyledLinkMenuProps>`
   background-clip: padding-box;
   border: 1px solid ${colors.brand.greyLight};
   z-index: ${stackOrder.offsetSingle};
+  &[data-visible="false"] {
+    display: none;
+  }
 `;
 
 const fetchResourcePath = (node: ContentLinkElement, language: string, contentType: string) => {
@@ -75,6 +78,7 @@ const Link = ({ attributes, editor, element, children }: Props) => {
   const [model, setModel] = useState<Model | undefined>();
   const startOpen = useRef(!hasHrefOrContentId(element));
   const [editMode, setEditMode] = useState(!hasHrefOrContentId(element));
+  const [editorSelection, setEditorSelection] = useState<BaseSelection | undefined>(undefined);
   const language = useArticleLanguage();
   const selected = useSelected();
   const { t } = useTranslation();
@@ -93,9 +97,18 @@ const Link = ({ attributes, editor, element, children }: Props) => {
     };
   };
 
-  const toggleEditMode = () => {
-    setEditMode((prev) => !prev);
-  };
+  const toggleEditMode = useCallback(
+    (open: boolean) => {
+      if (!open && editorSelection) {
+        ReactEditor.focus(editor);
+        setTimeout(() => Transforms.select(editor, editorSelection), 0);
+      }
+      setEditMode(open);
+    },
+    [editor, editorSelection],
+  );
+
+  const closeModal = useCallback(() => toggleEditMode(false), [toggleEditMode]);
 
   useEffect(() => {
     const setStateFromNode = async () => {
@@ -125,9 +138,18 @@ const Link = ({ attributes, editor, element, children }: Props) => {
     <Modal defaultOpen={startOpen.current} open={editMode} onOpenChange={toggleEditMode}>
       <StyledLink {...attributes} href={model?.href} ref={linkRef}>
         {children}
-        {model && selected && (
-          <Portal>
-            <StyledLinkMenu top={top} left={left}>
+        {model && (
+          <Portal asChild>
+            <StyledLinkMenu
+              top={top}
+              left={left}
+              data-visible={selected}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setEditorSelection(editor.selection);
+              }}
+            >
               <ModalTrigger>
                 <ButtonV2 variant="link">{t("form.content.link.change")}</ButtonV2>
               </ModalTrigger>{" "}
@@ -140,12 +162,18 @@ const Link = ({ attributes, editor, element, children }: Props) => {
         )}
       </StyledLink>
       <ModalContent
+        onEscapeKeyDown={(e) => {
+          e.stopPropagation();
+        }}
         onCloseAutoFocus={(e) => {
           e.preventDefault();
-          ReactEditor.focus(editor);
+          if (editorSelection) {
+            ReactEditor.focus(editor);
+            setTimeout(() => Transforms.select(editor, editorSelection), 0);
+          }
         }}
       >
-        {model && <EditLink editor={editor} element={element} model={model} closeEditMode={toggleEditMode} />}
+        {model && <EditLink editor={editor} element={element} model={model} closeEditMode={closeModal} />}
       </ModalContent>
     </Modal>
   );

--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -97,18 +97,22 @@ const Link = ({ attributes, editor, element, children }: Props) => {
     };
   };
 
+  const focusEditor = useCallback(() => {
+    if (editorSelection) {
+      ReactEditor.focus(editor);
+      setTimeout(() => Transforms.select(editor, editorSelection), 0);
+    }
+  }, [editor, editorSelection]);
+
   const toggleEditMode = useCallback(
     (open: boolean) => {
-      if (!open && editorSelection) {
-        ReactEditor.focus(editor);
-        setTimeout(() => Transforms.select(editor, editorSelection), 0);
+      if (!open) {
+        focusEditor();
       }
       setEditMode(open);
     },
-    [editor, editorSelection],
+    [focusEditor],
   );
-
-  const closeModal = useCallback(() => toggleEditMode(false), [toggleEditMode]);
 
   useEffect(() => {
     const setStateFromNode = async () => {
@@ -162,18 +166,15 @@ const Link = ({ attributes, editor, element, children }: Props) => {
         )}
       </StyledLink>
       <ModalContent
-        onEscapeKeyDown={(e) => {
-          e.stopPropagation();
-        }}
+        onEscapeKeyDown={(e) => e.stopPropagation()}
         onCloseAutoFocus={(e) => {
           e.preventDefault();
-          if (editorSelection) {
-            ReactEditor.focus(editor);
-            setTimeout(() => Transforms.select(editor, editorSelection), 0);
-          }
+          focusEditor();
         }}
       >
-        {model && <EditLink editor={editor} element={element} model={model} closeEditMode={closeModal} />}
+        {model && (
+          <EditLink editor={editor} element={element} model={model} closeEditMode={() => toggleEditMode(false)} />
+        )}
       </ModalContent>
     </Modal>
   );


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3984

Makan til vanskelig fokus er å jobbe med. Det er en liten delay før cursor flytter seg når man lukker dialogen med ESC, men cursor plasserer seg riktig til slutt.