### PR TITLE
Lowercase contributor type in select to account for uppercased db values

### DIFF
--- a/src/containers/FormikForm/components/ContributorsField.tsx
+++ b/src/containers/FormikForm/components/ContributorsField.tsx
@@ -113,7 +113,7 @@ const Contributor = ({ type, onAddNew, onRemove }: ContributorProps) => {
                 <Label margin="none" textStyle="label-small">
                   {t("form.name.type")}
                 </Label>
-                <Select {...field} data-testid="contributor-selector">
+                <Select {...field} value={field.value.toLowerCase()} data-testid="contributor-selector">
                   <option value="" />
                   {contributorTypeItems.map((item: ContributorTypeItem) => (
                     <option value={item.type} key={item.type}>


### PR DESCRIPTION
Man vil ikke klare å "gå tilbake" til `Originator`, men verdien parses ordentlig.