### PR TITLE
Add missing "PRIVATE" translation for private learningpaths

### DIFF
--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1039,6 +1039,7 @@ const phrases = {
       archived: "Deleted",
       republish: "For republishing",
       sum: "Total",
+      private: "Private",
       actions: {
         PLANNED: "Planned",
         IN_PROGRESS: "In progress",

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1039,6 +1039,7 @@ const phrases = {
       archived: "Slettet",
       republish: "Til republisering",
       sum: "Totalt",
+      private: "Privat",
       actions: {
         PLANNED: "Planlagt",
         IN_PROGRESS: "I arbeid",

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1039,6 +1039,7 @@ const phrases = {
       archived: "Slettet",
       republish: "Til republisering",
       sum: "Totalt",
+      private: "Privat",
       actions: {
         PLANNED: "Planlagd",
         IN_PROGRESS: "I arbeid",


### PR DESCRIPTION
Fixes https://trello.com/c/EI6si56P/778-ed-l%C3%A6ringssti-med-status-privat-viser-formstatusprivate