### PR TITLE
Bugfix for keyboard navigation in blockpicker

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -239,7 +239,8 @@ const SlateBlockPicker = ({
     if (Location.isLocation(editor.selection)) {
       setLastActiveSelection(editor.selection);
     }
-  }, [editor.selection]);
+    !editor.selection && lastActiveSelection && (editor.selection = lastActiveSelection);
+  }, [editor, editor.selection, lastActiveSelection]);
 
   const onOpenChange = useCallback(
     (open: boolean) => {

--- a/src/components/SlateEditor/plugins/blogPost/utils.ts
+++ b/src/components/SlateEditor/plugins/blogPost/utils.ts
@@ -9,4 +9,4 @@
 import { jsx as slatejsx } from "slate-hyperscript";
 import { TYPE_BLOGPOST } from "./types";
 
-export const defaultBlogPostBlock = () => slatejsx("element", { type: TYPE_BLOGPOST, isFirstEdit: true });
+export const defaultBlogPostBlock = () => slatejsx("element", { type: TYPE_BLOGPOST, isFirstEdit: true }, { text: "" });

--- a/src/components/SlateEditor/plugins/campaignBlock/utils.ts
+++ b/src/components/SlateEditor/plugins/campaignBlock/utils.ts
@@ -9,4 +9,5 @@
 import { jsx as slatejsx } from "slate-hyperscript";
 import { TYPE_CAMPAIGN_BLOCK } from "./types";
 
-export const defaultCampaignBlock = () => slatejsx("element", { type: TYPE_CAMPAIGN_BLOCK, isFirstEdit: true });
+export const defaultCampaignBlock = () =>
+  slatejsx("element", { type: TYPE_CAMPAIGN_BLOCK, isFirstEdit: true }, { text: "" });

--- a/src/components/SlateEditor/plugins/contactBlock/utils.ts
+++ b/src/components/SlateEditor/plugins/contactBlock/utils.ts
@@ -9,4 +9,5 @@
 import { jsx as slatejsx } from "slate-hyperscript";
 import { TYPE_CONTACT_BLOCK } from "./types";
 
-export const defaultContactBlock = () => slatejsx("element", { type: TYPE_CONTACT_BLOCK, isFirstEdit: true });
+export const defaultContactBlock = () =>
+  slatejsx("element", { type: TYPE_CONTACT_BLOCK, isFirstEdit: true }, { text: "" });

--- a/src/components/SlateEditor/plugins/external/utils.ts
+++ b/src/components/SlateEditor/plugins/external/utils.ts
@@ -9,6 +9,6 @@
 import { jsx as slatejsx } from "slate-hyperscript";
 import { TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
 
-export const defaultExternalBlock = () => slatejsx("element", { type: TYPE_EXTERNAL, isFirstEdit: true });
+export const defaultExternalBlock = () => slatejsx("element", { type: TYPE_EXTERNAL, isFirstEdit: true }, { text: "" });
 
-export const defaultIframeBlock = () => slatejsx("element", { type: TYPE_IFRAME, isFirstEdit: true });
+export const defaultIframeBlock = () => slatejsx("element", { type: TYPE_IFRAME, isFirstEdit: true }, { text: "" });


### PR DESCRIPTION
Disse 4 gir feilmelding dersom man bruker tastaturnavigasjon til å legge dem til (Ctr+Enter, tabtabtabtabtabtabtba, Enter):

- Ressurs fra lenke
- Bloggpost
- Kontaktblokk
- Kampanjeblokk

Denne fikser det.