### PR TITLE
Always calculate slate form differences with blockContentToHTML

### DIFF
--- a/src/util/formHelper.ts
+++ b/src/util/formHelper.ts
@@ -9,7 +9,7 @@
 import isEqual from "lodash/fp/isEqual";
 import { Descendant, Node } from "slate";
 import { IArticle, ILicense, IArticleMetaImage } from "@ndla/types-backend/draft-api";
-import { blockContentToHTML, inlineContentToEditorValue, inlineContentToHTML } from "./articleContentConverter";
+import { blockContentToHTML, inlineContentToEditorValue } from "./articleContentConverter";
 import { isGrepCodeValid } from "./articleUtil";
 import { diffHTML } from "./diffHTML";
 import { isUserProvidedEmbedDataValid } from "./embedTagHelpers";
@@ -30,12 +30,9 @@ export const DEFAULT_LICENSE: ILicense = {
   url: "https://creativecommons.org/licenses/by-sa/4.0/",
 };
 
-const checkIfContentHasChanged = (currentValue: Descendant[], initialContent: Descendant[], type: string) => {
+const checkIfContentHasChanged = (currentValue: Descendant[], initialContent: Descendant[]) => {
   if (currentValue.length !== initialContent.length) return true;
-  const toHTMLFunction = type === "standard" || type === "frontpage-article" ? blockContentToHTML : inlineContentToHTML;
-  const newHTML = toHTMLFunction(currentValue);
-
-  const diff = diffHTML(newHTML, toHTMLFunction(initialContent));
+  const diff = diffHTML(blockContentToHTML(currentValue), blockContentToHTML(initialContent));
   return diff;
 };
 
@@ -75,7 +72,7 @@ export const isFormikFormDirty = <T extends FormikFields>({
     .filter(([key]) => !skipFields.includes(key))
     .forEach(([key, value]) => {
       if (Array.isArray(value) && value.length > 0 && Node.isNodeList(value)) {
-        if (checkIfContentHasChanged(values[key]!, initialValues[key]!, initialValues.articleType!)) {
+        if (checkIfContentHasChanged(values[key]!, initialValues[key]!)) {
           dirtyFields.push(value);
         }
       } else if (!isEqual(value, initialValues[key as keyof T])) {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4001

Kan testes ved å bytte visuelt element på enten forklaring eller emneartikkel.

`inlineContentToHTML` har aldri klart å parse ´ndlaembed`. Vi har tidligere jobbet rundt dette ved å opprettholde en liste med slate-felter, men gikk vekk fra dette da det ikke fungerte bra nok med f.eks HTML-captions. Tipper det var da feilen oppsto. 

Eneste konsekvensen jeg kan se for meg at dette vil ha er at vi tar en liten hit i ytelse, men gjerne test det litt på forskjellige felter.