### PR TITLE
Vise visuelt element-knapper på filmside.

### DIFF
--- a/src/containers/VisualElement/VisualElementPicker.tsx
+++ b/src/containers/VisualElement/VisualElementPicker.tsx
@@ -14,7 +14,6 @@ import VisualElementMenu, { VisualElementType } from "./VisualElementMenu";
 import SlateVisualElementPicker from "../../components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker";
 import { defaultExternalBlock } from "../../components/SlateEditor/plugins/external/utils";
 import { defaultH5pBlock } from "../../components/SlateEditor/plugins/h5p/utils";
-import { isEmpty } from "../../components/validators";
 
 interface Props {
   editor: Editor;
@@ -46,10 +45,6 @@ const VisualElementPicker = ({ editor, language, types }: Props) => {
     }
     setSelectedResource(visualElement);
   };
-
-  if (!isEmpty(editor.children)) {
-    return null;
-  }
 
   return (
     <div contentEditable={false}>


### PR DESCRIPTION
Denne har visst forsvunnet på et eller annet tidspunkt. Usikker på om dette egentlig er den beste løsningen, men det fikser da problemet! På sikt kan vi sikkert fjerne slate fullstendig fra visuelt element

