### PR TITLE
Fikse nynorsk oversettelse av podkaster

### DIFF
--- a/src/components/NynorskTranslateProvider.tsx
+++ b/src/components/NynorskTranslateProvider.tsx
@@ -68,7 +68,7 @@ export const useTranslateToNN = () => {
           // the entire html string and reencode it using an xmlSerializer.
           const parsed =
             type === "html" && !isArray
-              ? xmlSerializer.serializeToString(domParser.parseFromString(content, "text/html").body.firstChild!)
+              ? xmlSerializer.serializeToString(domParser.parseFromString(content, "text/html").body!)
               : content;
           acc[field] = { content: parsed, type, isArray };
         }
@@ -85,6 +85,7 @@ export const useTranslateToNN = () => {
                 .replace(/\sxmlns=".*?"/g, "")
                 .replace(/&?lt;/g, "<")
                 .replace(/&?gt;/g, ">")
+                .replace(/<\/?body>/g, "")
             : value;
         set(cloned, key, parsed);
       });

--- a/src/containers/Podcast/EditPodcast.tsx
+++ b/src/containers/Podcast/EditPodcast.tsx
@@ -25,7 +25,7 @@ interface Props {
 const translateFields: TranslateType[] = [
   {
     field: "manuscript.manuscript",
-    type: "text",
+    type: "html",
   },
   {
     field: "title.title",

--- a/src/containers/Podcast/components/PodcastForm.tsx
+++ b/src/containers/Podcast/components/PodcastForm.tsx
@@ -29,7 +29,7 @@ import Spinner from "../../../components/Spinner";
 import { SAVE_BUTTON_ID } from "../../../constants";
 import { PodcastFormValues } from "../../../modules/audio/audioApiInterfaces";
 import { useLicenses } from "../../../modules/draft/draftQueries";
-import { editorValueToPlainText } from "../../../util/articleContentConverter";
+import { editorValueToPlainText, inlineContentToHTML } from "../../../util/articleContentConverter";
 import { audioApiTypeToPodcastFormType } from "../../../util/audioHelpers";
 import { isFormikFormDirty } from "../../../util/formHelper";
 import handleError from "../../../util/handleError";
@@ -150,7 +150,7 @@ const PodcastForm = ({
     actions.setSubmitting(true);
     const podcastMetaData: INewAudioMetaInformation = {
       title: values.title ? editorValueToPlainText(values.title) : "",
-      manuscript: values.manuscript ? editorValueToPlainText(values.manuscript) : "",
+      manuscript: values.manuscript ? inlineContentToHTML(values.manuscript) : "",
       tags: values.tags,
       audioType: "podcast",
       language: values.language,


### PR DESCRIPTION
Handle translation cases where we pass a HTML string containing several HTML elements. The nynorsk translates automatically exits once a top-level element has been properly parsed. By passing in a body element, we guarantee that there's always a shared top level element that we can remove once the translation has passed