### PR TITLE
Indicate lang attribute in compare language page

### DIFF
--- a/src/containers/ComparePage/ComparePage.tsx
+++ b/src/containers/ComparePage/ComparePage.tsx
@@ -75,9 +75,9 @@ const ComparePage = () => {
   const formArticle = useMemo(() => {
     return {
       id: article?.id!,
-      title: article?.title?.title ?? "",
+      title: article?.title?.htmlTitle ?? "",
       content: article?.content?.content ?? "",
-      introduction: article?.introduction?.introduction ?? "",
+      introduction: article?.introduction?.htmlIntroduction ?? "",
       visualElement: article?.visualElement?.visualElement ?? "",
       published: article?.published,
       copyright: article?.copyright,

--- a/src/containers/ComparePage/ComparePage.tsx
+++ b/src/containers/ComparePage/ComparePage.tsx
@@ -10,16 +10,11 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import styled from "@emotion/styled";
-import { spacing } from "@ndla/core";
+import { spacing, colors } from "@ndla/core";
 import { HelmetWithTracker } from "@ndla/tracker";
 import PreviewDraft from "../../components/PreviewDraft/PreviewDraft";
 import Spinner from "../../components/Spinner";
-import {
-  draftApiTypeToLearningResourceFormType,
-  learningResourceFormTypeToDraftApiType,
-} from "../../containers/ArticlePage/articleTransformers";
-import { LearningResourceFormType, useArticleFormHooks } from "../../containers/FormikForm/articleFormHooks";
-import { useDraft, useLicenses } from "../../modules/draft/draftQueries";
+import { useDraft } from "../../modules/draft/draftQueries";
 
 const StyledPreviewWrapper = styled.div`
   width: 100%;
@@ -51,6 +46,16 @@ const TwoArticleWrapper = styled(StyledPreviewWrapper)`
     }
     > article {
       max-width: unset;
+    }
+  }
+
+  span[lang] {
+    text-decoration: underline;
+    text-decoration-color: ${colors.brand.tertiary};
+    &::after {
+      content: "(" attr(lang) ")";
+      color: ${colors.brand.greyMedium};
+      font-style: italic;
     }
   }
 `;


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4018

Viser språkmerking på side for å sammenligne språkversjoner.

Testes: [https://editorial-frontend-pr-2354.vercel.app/nb/compare/38620/nb](https://editorial-frontend-pr-2354.vercel.app/nb/compare/38620/nb)

**NB:** Denne løsningen er ikke heelt 100% uu-messig, siden nå vil også språket leses opp for skjermlesere. Jeg har sett på litt ulike måter å løse det på, blant annet å legge til tom alt tekst i content-feltet ved å bruke '/' ([w3](https://www.w3.org/TR/css-content-3/#alt)), men dette er dessverre ikke støttet i firefox og safari. Bare å komme med forslag til andre løsninger hvis noen har! 