### PR TITLE
Small styling fix campaign block form

### DIFF
--- a/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
@@ -108,6 +108,12 @@ const StyledForm = styled(Form)`
   gap: ${spacing.small};
 `;
 
+const StyledFieldWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.xsmall};
+`;
+
 const placements: CampaignBlockEmbedData["imageSide"][] = ["left", "right"];
 
 const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
@@ -205,7 +211,7 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
                 </FormControl>
               )}
             </FormField>
-            <div>
+            <StyledFieldWrapper>
               <Text textStyle="label-small" margin="none">
                 {t("form.name.linkText")}
                 <RichTextIndicator />
@@ -223,7 +229,7 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
                   </FormControl>
                 )}
               </FormField>
-            </div>
+            </StyledFieldWrapper>
           </UrlWrapper>
           <FormField name="imageSide">
             {({ field, helpers }) => (


### PR DESCRIPTION
Liten styling fiks, fikser opp i avstanden her i kampanjeblokkform:
<img width="1073" alt="Skjermbilde 2024-05-07 kl  10 29 42" src="https://github.com/NDLANO/editorial-frontend/assets/26788204/21453850-1eda-4298-842b-c37d76ba3468">
