### PR TITLE
Bump serialize-javascript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "react-image-crop": "^11.0.2",
     "react-router-dom": "^6.1.0",
     "react-simple-code-editor": "^0.13.1",
-    "serialize-javascript": "^6.0.1",
+    "serialize-javascript": "^6.0.2",
     "slate": "^0.102.0",
     "slate-history": "^0.100.0",
     "slate-hyperscript": "^0.100.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,7 +5832,7 @@ __metadata:
     react-router-dom: "npm:^6.1.0"
     react-simple-code-editor: "npm:^0.13.1"
     rimraf: "npm:^3.0.0"
-    serialize-javascript: "npm:^6.0.1"
+    serialize-javascript: "npm:^6.0.2"
     sirv: "npm:^2.0.4"
     slate: "npm:^0.102.0"
     slate-history: "npm:^0.100.0"
@@ -11812,12 +11812,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "serialize-javascript@npm:6.0.1"
+"serialize-javascript@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "serialize-javascript@npm:6.0.2"
   dependencies:
     randombytes: "npm:^2.1.0"
-  checksum: 10c0/1af427f4fee3fee051f54ffe15f77068cff78a3c96d20f5c1178d20630d3ab122d8350e639d5e13cde8111ef9db9439b871305ffb185e24be0a2149cec230988
+  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes vulnurability: https://security.snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607