### PR TITLE
Work around sort being different types for different apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@emotion/eslint-plugin": "11.11.0",
     "@emotion/jest": "11.11.0",
     "@ndla/scripts": "^2.1.2",
-    "@ndla/types-backend": "^0.2.76",
+    "@ndla/types-backend": "^0.2.79",
     "@ndla/types-embed": "^4.1.6",
     "@ndla/types-taxonomy": "^1.0.24",
     "@playwright/test": "^1.42.0",

--- a/src/containers/NdlaFilm/filmUtil.ts
+++ b/src/containers/NdlaFilm/filmUtil.ts
@@ -14,7 +14,8 @@ export const sortMoviesByIdList = (
   movieList: IMultiSearchSummary[],
   i18n: i18n,
 ): IMultiSearchSummary[] => {
-  const notFoundMovie = {
+  const notFoundMovie: IMultiSearchSummary = {
+    id: -1,
     title: {
       title: i18n.t("ndlaFilm.editor.notFound"),
       language: i18n.language,
@@ -26,14 +27,16 @@ export const sortMoviesByIdList = (
     },
     url: "",
     contexts: [],
-    learningResourceType: "",
+    learningResourceType: "standard",
     traits: [],
     score: -1,
     highlights: [],
     paths: [],
     lastUpdated: "",
     revisions: [],
+    resultType: "article",
   };
+
   return idList.map(
     (id) =>
       movieList.find((movie) => movie.id === id) || {

--- a/src/containers/SearchPage/components/form/SearchForm.tsx
+++ b/src/containers/SearchPage/components/form/SearchForm.tsx
@@ -7,7 +7,7 @@
  */
 
 import queryString from "query-string";
-import { ISeriesSearchParams, ISearchParams as IAudioSearchParams } from "@ndla/types-backend/audio-api";
+import { ISearchParams as IAudioSearchParams, ISeriesSearchParams } from "@ndla/types-backend/audio-api";
 import { IDraftConceptSearchParams } from "@ndla/types-backend/concept-api";
 import { ISearchParams as IImageSearchParams } from "@ndla/types-backend/image-api";
 import { IDraftSearchParams } from "@ndla/types-backend/search-api";
@@ -44,11 +44,12 @@ export interface SearchParams {
   "filter-inactive"?: boolean;
 }
 
-export type SearchParamsBody = IDraftConceptSearchParams &
-  IDraftSearchParams &
-  IImageSearchParams &
-  IAudioSearchParams &
-  ISeriesSearchParams;
+/** Used to wraps backend types and replaces their `sort` with `sort?: string` */
+export type StringSort<T> = Omit<T, "sort"> & { sort?: string };
+
+export type SearchParamsBody = StringSort<
+  IDraftConceptSearchParams & IDraftSearchParams & IImageSearchParams & IAudioSearchParams & ISeriesSearchParams
+>;
 
 type ReturnType<T> = T extends true ? SearchParamsBody : SearchParams;
 

--- a/src/containers/WelcomePage/hooks/savedSearchHook.ts
+++ b/src/containers/WelcomePage/hooks/savedSearchHook.ts
@@ -32,16 +32,13 @@ import { usePostSearchNodes } from "../../../modules/nodes/nodeQueries";
 import { postSearch } from "../../../modules/search/searchApi";
 import { fetchResourceType } from "../../../modules/taxonomy";
 import { transformQuery } from "../../../util/searchHelpers";
-import { SearchParamsBody, parseSearchParams } from "../../SearchPage/components/form/SearchForm";
+import { SearchParamsBody, parseSearchParams, StringSort } from "../../SearchPage/components/form/SearchForm";
 import { useTaxonomyVersion } from "../../StructureVersion/TaxonomyVersionProvider";
 import { customFieldsBody, defaultSubjectIdObject, getResultSubjectIdObject, getSubjectsIdsQuery } from "../utils";
 
-type QueryType =
-  | IAudioSearchParams
-  | IDraftConceptSearchParams
-  | IImageSearchParams
-  | ISeriesSearchParams
-  | IDraftSearchParams;
+type QueryType = StringSort<
+  IAudioSearchParams & IDraftConceptSearchParams & IImageSearchParams & ISeriesSearchParams & IDraftSearchParams
+>;
 
 type SearchFetchReturnType =
   | IAudioSummarySearchResult

--- a/src/modules/audio/audioApi.ts
+++ b/src/modules/audio/audioApi.ts
@@ -16,6 +16,7 @@ import {
   ISeriesSearchParams,
   ISearchParams,
 } from "@ndla/types-backend/audio-api";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { apiResourceUrl, fetchAuthorized, resolveJsonOrRejectWithError } from "../../util/apiHelpers";
 import { resolveJsonOrVoidOrRejectWithError } from "../../util/resolveJsonOrRejectWithError";
 
@@ -43,7 +44,7 @@ export const updateAudio = (id: number, formData: FormData): Promise<IAudioMetaI
     body: formData,
   }).then((r) => resolveJsonOrRejectWithError<IAudioMetaInformation>(r));
 
-export const postSearchAudio = async (body: ISearchParams): Promise<IAudioSummarySearchResult> => {
+export const postSearchAudio = async (body: StringSort<ISearchParams>): Promise<IAudioSummarySearchResult> => {
   const response = await fetchAuthorized(`${baseUrl}/search/`, { method: "POST", body: JSON.stringify(body) });
   return resolveJsonOrRejectWithError(response);
 };
@@ -83,7 +84,7 @@ export const updateSeries = (id: number, newSeries: INewSeries): Promise<ISeries
     body: JSON.stringify(newSeries),
   }).then((r) => resolveJsonOrRejectWithError<ISeries>(r));
 
-export const postSearchSeries = async (body: ISeriesSearchParams): Promise<ISeriesSummarySearchResult> => {
+export const postSearchSeries = async (body: StringSort<ISeriesSearchParams>): Promise<ISeriesSummarySearchResult> => {
   const response = await fetchAuthorized(`${seriesBaseUrl}/search/`, { method: "POST", body: JSON.stringify(body) });
   return resolveJsonOrRejectWithError(response);
 };

--- a/src/modules/audio/audioQueries.ts
+++ b/src/modules/audio/audioQueries.ts
@@ -16,6 +16,7 @@ import {
   ISearchParams as IAudioSearchParams,
 } from "@ndla/types-backend/audio-api";
 import { fetchAudio, fetchSeries, postSearchAudio, postSearchSeries } from "./audioApi";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { AUDIO, PODCAST_SERIES, SEARCH_AUDIO, SEARCH_SERIES } from "../../queryKeys";
 
 export interface UseAudio {
@@ -25,9 +26,9 @@ export interface UseAudio {
 
 export const audioQueryKeys = {
   audio: (params?: Partial<UseAudio>) => [AUDIO, params] as const,
-  search: (params?: Partial<IAudioSearchParams>) => [SEARCH_AUDIO, params] as const,
+  search: (params?: Partial<StringSort<IAudioSearchParams>>) => [SEARCH_AUDIO, params] as const,
   podcastSeries: (params?: Partial<UseSeries>) => [PODCAST_SERIES, params] as const,
-  podcastSeriesSearch: (params?: Partial<ISeriesSearchParams>) => [SEARCH_SERIES, params] as const,
+  podcastSeriesSearch: (params?: Partial<StringSort<ISeriesSearchParams>>) => [SEARCH_SERIES, params] as const,
 };
 
 export const useAudio = (params: UseAudio, options?: Partial<UseQueryOptions<IAudioMetaInformation>>) =>
@@ -50,7 +51,7 @@ export const useSeries = (params: UseSeries, options?: Partial<UseQueryOptions<I
   });
 
 export const useSearchSeries = (
-  query: ISeriesSearchParams,
+  query: StringSort<ISeriesSearchParams>,
   options?: Partial<UseQueryOptions<ISeriesSummarySearchResult>>,
 ) => {
   return useQuery<ISeriesSummarySearchResult>({
@@ -61,7 +62,7 @@ export const useSearchSeries = (
 };
 
 export const useSearchAudio = (
-  query: IAudioSearchParams,
+  query: StringSort<IAudioSearchParams>,
   options?: Partial<UseQueryOptions<IAudioSummarySearchResult>>,
 ) => {
   return useQuery<IAudioSummarySearchResult>({

--- a/src/modules/concept/conceptApi.ts
+++ b/src/modules/concept/conceptApi.ts
@@ -14,6 +14,7 @@ import {
   ITagsSearchResult,
   IUpdatedConcept,
 } from "@ndla/types-backend/concept-api";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { ConceptStatusStateMachineType } from "../../interfaces";
 import { resolveJsonOrRejectWithError, apiResourceUrl, fetchAuthorized } from "../../util/apiHelpers";
 
@@ -70,7 +71,9 @@ export const updateConceptStatus = async (id: number, status: string): Promise<I
     method: "PUT",
   }).then((r) => resolveJsonOrRejectWithError<IConcept>(r));
 
-export const postSearchConcepts = async (body: IDraftConceptSearchParams): Promise<IConceptSearchResult> => {
+export const postSearchConcepts = async (
+  body: StringSort<IDraftConceptSearchParams>,
+): Promise<IConceptSearchResult> => {
   const response = await fetchAuthorized(`${draftConceptUrl}/search/`, {
     method: "POST",
     body: JSON.stringify(body),

--- a/src/modules/concept/conceptQueries.ts
+++ b/src/modules/concept/conceptQueries.ts
@@ -9,6 +9,7 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { IConcept, IDraftConceptSearchParams, IConceptSearchResult } from "@ndla/types-backend/concept-api";
 import { fetchConcept, fetchStatusStateMachine, postSearchConcepts } from "./conceptApi";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { ConceptStatusStateMachineType } from "../../interfaces";
 import { CONCEPT, CONCEPT_STATE_MACHINE, SEARCH_CONCEPTS } from "../../queryKeys";
 
@@ -19,7 +20,7 @@ export interface UseConcept {
 
 export const conceptQueryKeys = {
   concept: (params?: Partial<UseConcept>) => [CONCEPT, params] as const,
-  searchConcepts: (params?: Partial<IDraftConceptSearchParams>) => [SEARCH_CONCEPTS, params] as const,
+  searchConcepts: (params?: Partial<StringSort<IDraftConceptSearchParams>>) => [SEARCH_CONCEPTS, params] as const,
   statusStateMachine: [CONCEPT_STATE_MACHINE] as const,
 };
 
@@ -32,7 +33,7 @@ export const useConcept = (params: UseConcept, options?: Partial<UseQueryOptions
 };
 
 export const useSearchConcepts = (
-  query: IDraftConceptSearchParams,
+  query: StringSort<IDraftConceptSearchParams>,
   options?: Partial<UseQueryOptions<IConceptSearchResult>>,
 ) => {
   return useQuery<IConceptSearchResult>({

--- a/src/modules/image/imageApi.ts
+++ b/src/modules/image/imageApi.ts
@@ -13,6 +13,7 @@ import {
   ITagsSearchResult,
   ISearchParams,
 } from "@ndla/types-backend/image-api";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import {
   resolveJsonOrRejectWithError,
   apiResourceUrl,
@@ -46,7 +47,7 @@ export const updateImage = (
     body: formData || JSON.stringify(imageMetadata),
   }).then((r) => resolveJsonOrRejectWithError<IImageMetaInformationV3>(r));
 
-export const postSearchImages = async (body: ISearchParams): Promise<ISearchResultV3> => {
+export const postSearchImages = async (body: StringSort<ISearchParams>): Promise<ISearchResultV3> => {
   const response = await fetchAuthorized(`${baseUrl}/search/`, { method: "POST", body: JSON.stringify(body) });
   return resolveJsonOrRejectWithError(response);
 };

--- a/src/modules/image/imageQueries.ts
+++ b/src/modules/image/imageQueries.ts
@@ -14,6 +14,7 @@ import {
   ISearchParams as IImageSearchParams,
 } from "@ndla/types-backend/image-api";
 import { fetchImage, postSearchImages } from "./imageApi";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { IMAGE, SEARCH_IMAGES } from "../../queryKeys";
 
 export interface UseImage {
@@ -23,7 +24,7 @@ export interface UseImage {
 
 export const imageQueryKeys = {
   image: (params?: Partial<UseImage>) => [IMAGE, params] as const,
-  search: (params?: Partial<ISearchParams>) => [SEARCH_IMAGES, params] as const,
+  search: (params?: Partial<StringSort<ISearchParams>>) => [SEARCH_IMAGES, params] as const,
 };
 
 export const useImage = (params: UseImage, options?: Partial<UseQueryOptions<IImageMetaInformationV3>>) =>
@@ -33,7 +34,10 @@ export const useImage = (params: UseImage, options?: Partial<UseQueryOptions<IIm
     ...options,
   });
 
-export const useSearchImages = (query: IImageSearchParams, options?: Partial<UseQueryOptions<ISearchResultV3>>) => {
+export const useSearchImages = (
+  query: StringSort<IImageSearchParams>,
+  options?: Partial<UseQueryOptions<ISearchResultV3>>,
+) => {
   return useQuery<ISearchResultV3>({
     queryKey: imageQueryKeys.search(query),
     queryFn: () => postSearchImages(query),

--- a/src/modules/search/searchApi.ts
+++ b/src/modules/search/searchApi.ts
@@ -14,12 +14,13 @@ import {
   ISubjectAggsInput,
 } from "@ndla/types-backend/search-api";
 import { MultiSearchApiQuery } from "./searchApiInterfaces";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { resolveJsonOrRejectWithError, apiResourceUrl, fetchAuthorized } from "../../util/apiHelpers";
 import { transformQuery, transformSearchBody } from "../../util/searchHelpers";
 
 const baseUrl = apiResourceUrl("/search-api/v1/search");
 
-export const postSearch = async (body: IDraftSearchParams): Promise<IMultiSearchResult> => {
+export const postSearch = async (body: StringSort<IDraftSearchParams>): Promise<IMultiSearchResult> => {
   const response = await fetchAuthorized(`${baseUrl}/editorial/`, {
     method: "POST",
     body: JSON.stringify(transformSearchBody(body)),

--- a/src/modules/search/searchQueries.ts
+++ b/src/modules/search/searchQueries.ts
@@ -16,6 +16,7 @@ import {
 } from "@ndla/types-backend/search-api";
 import { postSearch, searchSubjectStats } from "./searchApi";
 import { DA_SUBJECT_ID, SA_SUBJECT_ID, LMA_SUBJECT_ID } from "../../constants";
+import { StringSort } from "../../containers/SearchPage/components/form/SearchForm";
 import { useTaxonomyVersion } from "../../containers/StructureVersion/TaxonomyVersionProvider";
 import {
   customFieldsBody,
@@ -30,11 +31,11 @@ import { useUserData } from "../draft/draftQueries";
 import { usePostSearchNodes } from "../nodes/nodeQueries";
 
 export const searchQueryKeys = {
-  search: (params?: Partial<IDraftSearchParams>) => [SEARCH, params] as const,
+  search: (params?: Partial<StringSort<IDraftSearchParams>>) => [SEARCH, params] as const,
   searchSubjectStats: (params?: Partial<ISubjectAggsInput>) => [SEARCH_SUBJECT_STATS, params] as const,
 };
 
-export interface UseSearch extends IDraftSearchParams {
+export interface UseSearch extends StringSort<IDraftSearchParams> {
   favoriteSubjects?: string[];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,10 +1691,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ndla/types-backend@npm:^0.2.76":
-  version: 0.2.76
-  resolution: "@ndla/types-backend@npm:0.2.76"
-  checksum: 10c0/0ab3d1001c00560797d18c5bf5a9b8a83198cf19333853e764bdb6ac13a5b0d631af70ef8c1cfe3c6356cffcdc33e9b6c56a8c9af061c4e66dcac617b756b6d5
+"@ndla/types-backend@npm:^0.2.79":
+  version: 0.2.80
+  resolution: "@ndla/types-backend@npm:0.2.80"
+  checksum: 10c0/96c30f21adbb6568d6f05804a2401c63a1988a3cc7429aa49bd961eddba5999bd8ef6ced83544256aea4fbf28c55096a8a4d583d9c982906bc33cc3c46d7d4c2
   languageName: node
   linkType: hard
 
@@ -5713,7 +5713,7 @@ __metadata:
     "@ndla/tabs": "npm:^4.0.6"
     "@ndla/tooltip": "npm:^8.0.0"
     "@ndla/tracker": "npm:^5.0.6"
-    "@ndla/types-backend": "npm:^0.2.76"
+    "@ndla/types-backend": "npm:^0.2.79"
     "@ndla/types-embed": "npm:^4.1.6"
     "@ndla/types-taxonomy": "npm:^1.0.24"
     "@ndla/typography": "npm:^0.4.20"


### PR DESCRIPTION
Depends on https://github.com/NDLANO/backend/pull/479 :heavy_check_mark: 

Ideelt sett så syns jeg hele søkesiden burde skrives om til å ikke være så veldig tett koblet sammen :sweat_smile: 
Dette gjør egentlig bare at alt fungerer som tidligere med at vi håndterer `sort` som en streng i frontenden selvom backend-typen sier at det er enums.

Gjør det ved å lage en generisk type som wrapper alle backend-typer som bytter ut hva-enn `sort` er med `sort?: string`.
Syns ikke det er det kuleste i verden, men det fungerer :shrug: 
