### PR TITLE
Wrap header controls på welcome page

### DIFF
--- a/src/containers/WelcomePage/components/GoToSearch.tsx
+++ b/src/containers/WelcomePage/components/GoToSearch.tsx
@@ -13,6 +13,7 @@ import { SafeLinkButton } from "@ndla/safelink";
 
 const StyledSafeLinkButton = styled(SafeLinkButton)`
   height: fit-content;
+  white-space: nowrap;
 `;
 
 interface Props {

--- a/src/containers/WelcomePage/styles.tsx
+++ b/src/containers/WelcomePage/styles.tsx
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
 import styled from "@emotion/styled";
 import { spacing, colors, mq, breakpoints, fonts } from "@ndla/core";
 import { SafeLink } from "@ndla/safelink";
@@ -89,6 +90,7 @@ export const StyledSwitch = styled(Switch)`
 export const TopRowControls = styled.div`
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: ${spacing.xsmall};
   ${mq.range({ until: breakpoints.tabletWide })} {
     justify-content: flex-start;


### PR DESCRIPTION
Mellom ca 981 og ca 1249 pixler bredde, blir knappene på Revisjon seende slik ut:
![image](https://github.com/NDLANO/editorial-frontend/assets/33912044/55b61eed-467a-434a-aa84-9db4fad7b813)

Det er jo ikke så pent. Så nå wrapper en etter en knapp fra toppen istedet, fortsatt høyrejustert, slik at det heller blir seende slik ut:
![image](https://github.com/NDLANO/editorial-frontend/assets/33912044/154da8c5-5d99-483c-8603-2003bc1de795)
