### PR TITLE
Added htmlContent to be translated also

### DIFF
--- a/src/containers/ConceptPage/EditConcept.tsx
+++ b/src/containers/ConceptPage/EditConcept.tsx
@@ -24,6 +24,10 @@ const translateFields: TranslateType[] = [
   },
   {
     field: "content.content",
+    type: "text",
+  },
+  {
+    field: "content.htmlContent",
     type: "html",
   },
   {


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4053

Ser ut som vi ikke tok hensyn til at htmlContent er separat fra text. La til `content.htmlContent` som et field i concept som skulle bli translated, tok samtidig og forandret `content.content` typen til å kun være tekst. 