### PR TITLE
Added return when unwrapping link

### DIFF
--- a/src/components/SlateEditor/plugins/link/utils.ts
+++ b/src/components/SlateEditor/plugins/link/utils.ts
@@ -33,6 +33,7 @@ export const unwrapLink = (editor: Editor) => {
 const wrapLink = (editor: Editor) => {
   if (isLinkActive(editor)) {
     unwrapLink(editor);
+    return;
   }
 
   const { selection } = editor;


### PR DESCRIPTION
Om du klikka på lenke knappen når du markerte en lenke fikk du opp dialog for insetting av ny lenke. Tenker at det er mer logisk å fjerne lenken som andre editorer gjør.