### PR TITLE
Allow tab in tables to not escape editor

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -24,6 +24,7 @@ import { onDragOver, onDragStart, onDrop } from "./plugins/DND";
 import { TYPE_HEADING } from "./plugins/heading/types";
 import { TYPE_LIST } from "./plugins/list/types";
 import { TYPE_PARAGRAPH } from "./plugins/paragraph/types";
+import { TYPE_TABLE } from "./plugins/table/types";
 import { SlateToolbar } from "./plugins/toolbar";
 import { AreaFilters, CategoryFilters } from "./plugins/toolbar/toolbarState";
 import { SlateProvider } from "./SlateContext";
@@ -245,8 +246,9 @@ const RichTextEditor = ({
 
       const selectedElement = getCurrentBlock(editor, TYPE_PARAGRAPH) || getCurrentBlock(editor, TYPE_HEADING) || [];
       const [listBlock] = getCurrentBlock(editor, TYPE_DEFINITION_LIST) || getCurrentBlock(editor, TYPE_LIST) || [];
+      const [tableBlock] = getCurrentBlock(editor, TYPE_TABLE) || [];
 
-      if (e.key === KEY_TAB && selectedElement && selectedElement.length > 0 && !listBlock) {
+      if (e.key === KEY_TAB && selectedElement && selectedElement.length > 0 && !listBlock && !tableBlock) {
         const path = ReactEditor.findPath(editor, selectedElement[0]!);
         if (!e.shiftKey && !Editor.after(editor, path)) return; // If there is no block after the current block, and shift is not pressed, move out from the editor
         if (e.shiftKey && !Editor.before(editor, path)) return; // If there is no block before the current block and shift is pressed, move out from the editor


### PR DESCRIPTION
Kjapp bugfix for å sikre at tab virker i tabeller igjen.