### PR TITLE
Fix autoscroll issue for inline comments

### DIFF
--- a/src/components/SlateEditor/plugins/comment/inline/SlateCommentInline.tsx
+++ b/src/components/SlateEditor/plugins/comment/inline/SlateCommentInline.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Editor, Element, Path, Transforms } from "slate";
 import { ReactEditor, RenderElementProps } from "slate-react";
@@ -94,10 +94,24 @@ const SlateCommentInline = ({ attributes, editor, element, children }: Props) =>
     }
   };
 
+  const preventAutoFocusInEditor = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      Transforms.select(editor, ReactEditor.findEventRange(editor, e));
+    },
+    [editor],
+  );
+
   return (
     <Root open={open} onOpenChange={(v) => setOpen(v)}>
       <Trigger asChild type={undefined}>
-        <InlineComment role="button" tabIndex={0} {...attributes}>
+        <InlineComment
+          role="button"
+          tabIndex={0}
+          onMouseDown={(e) => preventAutoFocusInEditor(e.nativeEvent)}
+          {...attributes}
+        >
           <InlineBugfix />
           {children}
           <InlineBugfix />


### PR DESCRIPTION
Ser ut som relatert til samme issue som dette: https://github.com/NDLANO/Issues/issues/4036

Dette ser ut til å fikse bugen BM meldte om: 
man ser feilen i for eksempel denne: https://ed.test.ndla.no/subject-matter/learning-resource/38686/edit/nb, hvis man i den prøver å trykke på kommentarer i de forskjellige tekstboksene så ser man at det plutselig scrolles til en annen kommentar uten at den åpnes.

Stjålet fiksen til @MaPoKen fra [her](https://github.com/NDLANO/editorial-frontend/pull/2382) og [her](https://github.com/NDLANO/frontend-packages/pull/2261), fremstår litt hacky, men ser ut til å fungere! Fint om flere verifiserer

