### PR TITLE
Show block comments in blockpicker for frontpage articles

### DIFF
--- a/src/components/SlateEditor/plugins/comment/CommentForm.tsx
+++ b/src/components/SlateEditor/plugins/comment/CommentForm.tsx
@@ -25,6 +25,11 @@ const CommentActions = styled.div`
   padding: ${spacing.normal} 0 0;
 `;
 
+const StyledTextArea = styled(TextAreaV3)`
+  max-height: 300px;
+  overflow-y: scroll;
+`;
+
 interface Props {
   initialData: CommentEmbedData | undefined;
   onSave: (data: CommentEmbedData) => void;
@@ -86,7 +91,7 @@ const CommentForm = ({
                 <Label visuallyHidden={labelVisuallyHidden} textStyle="label-small" margin="none">
                   {labelText}
                 </Label>
-                <TextAreaV3 {...field} />
+                <StyledTextArea {...field} />
                 <FieldErrorMessage>{meta.error}</FieldErrorMessage>
               </FormControl>
             )}

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -26,6 +26,7 @@ import { frontpageActions } from "../../../../components/SlateEditor/plugins/blo
 import { TYPE_BLOGPOST } from "../../../../components/SlateEditor/plugins/blogPost/types";
 import { TYPE_CAMPAIGN_BLOCK } from "../../../../components/SlateEditor/plugins/campaignBlock/types";
 import { TYPE_CODEBLOCK } from "../../../../components/SlateEditor/plugins/codeBlock/types";
+import { TYPE_COMMENT_BLOCK } from "../../../../components/SlateEditor/plugins/comment/block/types";
 import { TYPE_CONTACT_BLOCK } from "../../../../components/SlateEditor/plugins/contactBlock/types";
 import { TYPE_EXTERNAL } from "../../../../components/SlateEditor/plugins/external/types";
 import { TYPE_FILE } from "../../../../components/SlateEditor/plugins/file/types";
@@ -91,6 +92,7 @@ const actions = [
   TYPE_CAMPAIGN_BLOCK,
   TYPE_LINK_BLOCK_LIST,
   TYPE_DISCLAIMER,
+  TYPE_COMMENT_BLOCK,
 ].concat(visualElements);
 
 const actionsToShowInAreas = {


### PR DESCRIPTION
Ble visst aldri vist i blockpicker for frontpage articles, denne fikser! setter også makshøyde på kommentar input-feltet