### PR TITLE
Invalidate child nodes when copying resources to a topic node, updating the quality evaluation average

### DIFF
--- a/src/containers/StructurePage/folderComponents/SettingsMenuDropdownType.tsx
+++ b/src/containers/StructurePage/folderComponents/SettingsMenuDropdownType.tsx
@@ -152,9 +152,19 @@ const SettingsMenuDropdownType = ({ rootNodeId, node, onCurrentNodeChanged, node
             onCurrentNodeChanged={onCurrentNodeChanged}
           />
         )}
-        <CopyNodeResources currentNode={node} editModeHandler={editModeHandler} type="copyResources" />
+        <CopyNodeResources
+          currentNode={node}
+          editModeHandler={editModeHandler}
+          type="copyResources"
+          rootNodeId={rootNodeId}
+        />
         {isTaxonomyAdmin && (
-          <CopyNodeResources currentNode={node} editModeHandler={editModeHandler} type="cloneResources" />
+          <CopyNodeResources
+            currentNode={node}
+            editModeHandler={editModeHandler}
+            type="cloneResources"
+            rootNodeId={rootNodeId}
+          />
         )}
         {isTaxonomyAdmin && <SetResourcesPrimary node={node} editModeHandler={editModeHandler} recursive />}
       </>

--- a/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
+++ b/src/containers/StructurePage/folderComponents/topicMenuOptions/CopyNodeResources.tsx
@@ -33,6 +33,7 @@ interface Props {
   currentNode: Node;
   editModeHandler: EditModeHandler;
   type: ActionType;
+  rootNodeId: string;
 }
 
 const StyledSpinner = styled(Spinner)`
@@ -71,7 +72,7 @@ const StyledDone = styled(Done)`
   color: green;
 `;
 
-const CopyNodeResources = ({ editModeHandler: { editMode, toggleEditMode }, currentNode, type }: Props) => {
+const CopyNodeResources = ({ editModeHandler: { editMode, toggleEditMode }, currentNode, type, rootNodeId }: Props) => {
   const {
     t,
     i18n: { language },
@@ -114,6 +115,12 @@ const CopyNodeResources = ({ editModeHandler: { editMode, toggleEditMode }, curr
     qc.invalidateQueries({
       queryKey: nodeQueryKeys.resources({
         id: currentNode.id,
+        taxonomyVersion,
+      }),
+    });
+    qc.invalidateQueries({
+      queryKey: nodeQueryKeys.childNodes({
+        id: rootNodeId,
         taxonomyVersion,
       }),
     });


### PR DESCRIPTION
Fikser https://github.com/NDLANO/Issues/issues/4152.

Dersom vi har lyst på oppdatert informasjon på rotnode må vi invalidere _hele_ struktur-treet, og det synes jeg virket som litt vel mye greier. Dette holder kanskje?