### PR TITLE
Fetch single node at lowest if there is only 1 fragment

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -160,8 +160,7 @@ export const defaultAreaOptions: AreaFilters = {
   },
   "comment-inline": { inline: { disabled: true, "comment-inline": { disabled: false } } },
   list: { inline: { disabled: true } },
-  "definition-term": { block: { quote: { disabled: true } }, inline: { disabled: true } },
-  "definition-description": { block: { quote: { disabled: true } }, inline: { disabled: true } },
+  "definition-list": { block: { quote: { disabled: true } }, inline: { disabled: true } },
   quote: { inline: { disabled: true } },
 };
 
@@ -220,15 +219,8 @@ interface ToolbarStateProps {
 export const getSelectionElements = (editor: Editor, selection: BaseSelection): Element[] => {
   // Get elements in the selection only
   if (selection) {
-    const fragments = Editor.fragment(editor, selection);
-    const elementFragments = fragments.filter(Element.isElement);
-
-    if (elementFragments.length === 1) {
-      const [[node]] = Editor.nodes(editor, { at: selection.focus, mode: "lowest", match: Element.isElement });
-      return [node];
-    }
-
-    return elementFragments;
+    const nodes = Node.fragment(editor, selection) as Element[];
+    return nodes.flatMap((node) => node?.children).filter(Element.isElement);
   }
   return [];
 };

--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -160,7 +160,8 @@ export const defaultAreaOptions: AreaFilters = {
   },
   "comment-inline": { inline: { disabled: true, "comment-inline": { disabled: false } } },
   list: { inline: { disabled: true } },
-  "definition-list": { block: { quote: { disabled: true } }, inline: { disabled: true } },
+  "definition-term": { block: { quote: { disabled: true } }, inline: { disabled: true } },
+  "definition-description": { block: { quote: { disabled: true } }, inline: { disabled: true } },
   quote: { inline: { disabled: true } },
 };
 
@@ -219,8 +220,10 @@ interface ToolbarStateProps {
 export const getSelectionElements = (editor: Editor, selection: BaseSelection): Element[] => {
   // Get elements in the selection only
   if (selection) {
-    const nodes = Node.fragment(editor, selection) as Element[];
-    return nodes.flatMap((node) => node?.children).filter(Element.isElement);
+    return Node.fragment(editor, selection)
+      .filter(Element.isElement)
+      .flatMap((node) => node?.children as Element[])
+      .flatMap((node) => node?.children as Element[]);
   }
   return [];
 };

--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -7,9 +7,10 @@
  */
 
 import merge from "lodash/merge";
-import { Editor, Element, Node, BaseSelection, Text, Range, Transforms } from "slate";
+import { Editor, Element, Node, BaseSelection, Text } from "slate";
 import { ElementType } from "../../interfaces";
 import { TYPE_NOOP } from "../noop/types";
+import { TYPE_PARAGRAPH } from "../paragraph/types";
 import { TYPE_SECTION } from "../section/types";
 
 export const languages = [
@@ -163,6 +164,7 @@ export const defaultAreaOptions: AreaFilters = {
   list: { inline: { disabled: true } },
   "definition-term": { block: { quote: { disabled: true } }, inline: { disabled: true } },
   "definition-description": { block: { quote: { disabled: true } }, inline: { disabled: true } },
+  "definition-list": { block: { quote: { disabled: true } }, inline: { disabled: true } },
   quote: { inline: { disabled: true } },
 };
 
@@ -223,6 +225,7 @@ export const getSelectionElements = (editor: Editor, selection: BaseSelection): 
   if (selection) {
     const fragments = editor.getFragment();
     const elementFragments = fragments.filter(Element.isElement);
+
     // When a fragment selects multiple blocks it seems to return the blocks in a section,
     // if it is a section we have to flatten it and find the inline children.
     // TODO: This logic works for the current nodes we have, further nested might provide a problem and must be solved in a different way.
@@ -230,7 +233,10 @@ export const getSelectionElements = (editor: Editor, selection: BaseSelection): 
       return elementFragments
         .flatMap((node) => node?.children as Element[])
         .flatMap((node) => node?.children as Element[]);
+    } else if (elementFragments?.[0]?.type === TYPE_PARAGRAPH) {
+      return elementFragments.flatMap((node) => node?.children as Element[]);
     }
+
     return elementFragments;
   }
   return [];

--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -7,7 +7,7 @@
  */
 
 import merge from "lodash/merge";
-import { Editor, Element, Node, BaseSelection, Text, fragment } from "slate";
+import { Editor, Element, Node, BaseSelection, Text, Range, Transforms } from "slate";
 import { ElementType } from "../../interfaces";
 import { TYPE_NOOP } from "../noop/types";
 
@@ -160,7 +160,8 @@ export const defaultAreaOptions: AreaFilters = {
   },
   "comment-inline": { inline: { disabled: true, "comment-inline": { disabled: false } } },
   list: { inline: { disabled: true } },
-  "definition-term": { inline: { disabled: true } },
+  "definition-term": { block: { quote: { disabled: true } }, inline: { disabled: true } },
+  "definition-description": { block: { quote: { disabled: true } }, inline: { disabled: true } },
   quote: { inline: { disabled: true } },
 };
 
@@ -219,8 +220,14 @@ interface ToolbarStateProps {
 export const getSelectionElements = (editor: Editor, selection: BaseSelection): Element[] => {
   // Get elements in the selection only
   if (selection) {
-    const fragments = editor.getFragment();
-    const elementFragments = fragments.filter((fragment) => Element.isElement(fragment)) as Element[];
+    const fragments = Editor.fragment(editor, selection);
+    const elementFragments = fragments.filter(Element.isElement);
+
+    if (elementFragments.length === 1) {
+      const [[node]] = Editor.nodes(editor, { at: selection.focus, mode: "lowest", match: Element.isElement });
+      return [node];
+    }
+
     return elementFragments;
   }
   return [];


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4179

Fikser at toolbar state håndteringen fungerer som den skal i henhold til toolbar reglene. Regler som: Ikke lov med inlines i definition term og description 