### PR TITLE
Support both report-uri and report-to in csp

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
 import express from "express";
 import { GetVerificationKey, expressjwt as jwt, Request } from "express-jwt";
 import jwksRsa from "jwks-rsa";
@@ -145,6 +146,18 @@ router.get(
     }
   },
 );
+
+router.post("/csp-reporting", (req, res) => {
+  const { body } = req;
+  if (body && body["type"] === "csp-violation") {
+    const cspReport = body["body"];
+    const errorMessage = `Refused to load the resource because it violates the following Content Security Policy directive: ${cspReport["effectiveDirective"]}`;
+    errorLogger.error(errorMessage, cspReport);
+    res.status(OK).json({ status: OK, text: "CSP Error recieved" });
+  } else {
+    res.status(NOT_ACCEPTABLE).json({ status: NOT_ACCEPTABLE, text: "CSP Error not recieved" });
+  }
+});
 
 router.post("/csp-report", (req, res) => {
   const { body } = req;

--- a/src/server/contentSecurityPolicy.ts
+++ b/src/server/contentSecurityPolicy.ts
@@ -244,6 +244,7 @@ const contentSecurityPolicy = {
     ],
     connectSrc,
     reportUri: "/csp-report",
+    reportTo: "csp-endpoint",
   },
 };
 export default contentSecurityPolicy;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -108,7 +108,13 @@ app.get("*", async (req, res) => {
       .replace(/"__CONFIG__"/, serializedConfig)
       .replaceAll("__ENVIRONMENT__", config.ndlaEnvironment);
 
-    res.status(200).set({ "Content-Type": "text/html" }).end(html);
+    res
+      .status(200)
+      .set({
+        "Content-Type": "text/html",
+        "Reporting-Endpoints": `csp-endpoint="${config.editorialFrontendDomain}/csp-reporting"`,
+      })
+      .end(html);
   } catch (e) {
     //@ts-ignore
     vite?.ssrFixStacktrace(e);


### PR DESCRIPTION
Oppdaterer ut csp-rapportering. Kunne sikkert delt kode mellom funksjonene.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to