### PR TITLE
fix: ensure details content can be selection in chromium.

### DIFF
--- a/src/components/SlateEditor/plugins/details/Details.tsx
+++ b/src/components/SlateEditor/plugins/details/Details.tsx
@@ -43,6 +43,35 @@ const StyledIconButton = styled(IconButton, {
   },
 });
 
+const StyledExpandableBox = styled(ExpandableBox, {
+  base: {
+    "& [data-embed-type='expandable-box-summary']": {
+      cursor: "text",
+      position: "relative",
+      placeSelf: "center",
+      _before: {
+        position: "absolute",
+        content: "'▶'",
+        fontSize: "0.7em",
+        display: "block",
+      },
+      "& >:first-child": {
+        marginInlineStart: "small",
+      },
+    },
+    "&:not([open]) >:not([data-embed-type='expandable-box-summary'])": {
+      display: "none",
+    },
+    _open: {
+      "& [data-embed-type='expandable-box-summary']": {
+        _before: {
+          content: "'▼'",
+        },
+      },
+    },
+  },
+});
+
 const Details = ({ children, editor, element, attributes }: Props & RenderElementProps) => {
   const [isOpen, setIsOpen] = useState(true);
   const { t } = useTranslation();
@@ -88,7 +117,9 @@ const Details = ({ children, editor, element, attributes }: Props & RenderElemen
         <MoveContentButton onMouseDown={onMoveContent} aria-label={t("form.moveContent")} />
         <DeleteButton data-testid="remove-details" aria-label={t("form.remove")} onMouseDown={onRemoveClick} />
       </ButtonContainer>
-      <ExpandableBox open={isOpen}>{children}</ExpandableBox>
+      <StyledExpandableBox open={isOpen} asChild consumeCss>
+        <div>{children}</div>
+      </StyledExpandableBox>
     </EmbedWrapper>
   );
 };

--- a/src/components/SlateEditor/plugins/details/render.tsx
+++ b/src/components/SlateEditor/plugins/details/render.tsx
@@ -9,25 +9,18 @@
 import { Editor, Path, Element, Node } from "slate";
 import { ReactEditor, RenderLeafProps } from "slate-react";
 import { ExpandableBoxSummary } from "@ndla/primitives";
-import { styled } from "@ndla/styled-system/jsx";
 import Details from "./Details";
 import { TYPE_DETAILS, TYPE_SUMMARY } from "./types";
 import WithPlaceHolder from "../../common/WithPlaceHolder";
-
-const StyledExpandableBoxSummary = styled(ExpandableBoxSummary, {
-  base: {
-    cursor: "default",
-  },
-});
 
 export const detailsRenderer = (editor: Editor) => {
   const { renderElement, renderLeaf } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
     if (element.type === TYPE_SUMMARY) {
       return (
-        <StyledExpandableBoxSummary {...attributes} onClick={(e) => e.preventDefault()}>
-          {children}
-        </StyledExpandableBoxSummary>
+        <ExpandableBoxSummary {...attributes} onClick={(e) => e.preventDefault()} asChild consumeCss>
+          <div>{children}</div>
+        </ExpandableBoxSummary>
       );
     } else if (element.type === TYPE_DETAILS) {
       return (


### PR DESCRIPTION
Chromium-based browsers do not allow for selection of more than one element when we use `details` and `summary` directly. This could either be intended, or it could be a bug with details/contenteditable. Either way, we render divs instead.