### PR TITLE
Viser fram url-domain på ekstern relatert artikkel

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "monaco-editor": "0.47.0",
     "prettier": "^3.1.1",
     "prismjs": "^1.29.0",
+    "punycode": "2.3.1",
     "query-string": "^5.1.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.8.0",

--- a/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
+++ b/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { toUnicode } from "punycode";
 import { useEffect, useRef, useState, MouseEvent, ReactNode, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Editor, Transforms } from "slate";
@@ -126,6 +127,7 @@ const RelatedArticleBox = ({ attributes, editor, element, onRemoveClick, childre
       resource: "related-content",
       title,
       url,
+      urlDomain: toUnicode(new URL(url).hostname),
     };
     const nodeData = (element.data ?? []).concat(newEmbed);
     setNodeData(nodeData);

--- a/src/components/SlateEditor/plugins/related/index.tsx
+++ b/src/components/SlateEditor/plugins/related/index.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { toUnicode } from "punycode";
 import { Descendant, Editor, Element } from "slate";
 import { jsx as slatejsx } from "slate-hyperscript";
 import { RelatedContentEmbedData } from "@ndla/types-embed";
@@ -45,7 +46,16 @@ export const relatedSerializer: SlateSerializer = {
       "element",
       {
         type: TYPE_RELATED,
-        data: Array.from(el.children ?? []).map((el) => reduceElementDataAttributesV2(Array.from(el.attributes))),
+        data: Array.from(el.children ?? []).map((el) => {
+          const attributes = reduceElementDataAttributesV2(Array.from(el.attributes));
+          if (attributes["url"]) {
+            return {
+              ...attributes,
+              urlDomain: toUnicode(new URL(attributes["url"]).hostname),
+            };
+          }
+          return attributes;
+        }),
       },
       [{ text: "" }],
     );

--- a/src/util/__tests__/__snapshots__/embedTagHelpers-test.ts.snap
+++ b/src/util/__tests__/__snapshots__/embedTagHelpers-test.ts.snap
@@ -65,7 +65,8 @@ exports[`deserializing related-content works 1`] = `
       {
         "resource": "related-content",
         "title": "Forsiden vg",
-        "url": "www.vg.no",
+        "url": "http://www.vg.no",
+        "urlDomain": "www.vg.no",
       },
       {
         "articleId": "54",

--- a/src/util/__tests__/embedTagHelpers-test.ts
+++ b/src/util/__tests__/embedTagHelpers-test.ts
@@ -199,7 +199,7 @@ test("isUserProvidedEmbedDataValid for image", () => {
 
 test("deserializing related-content works", () => {
   const deserialized = blockContentToEditorValue(
-    '<div data-type="related-content"><ndlaembed data-url="www.vg.no" data-resource="related-content" data-title="Forsiden vg"></ndlaembed><ndlaembed data-resource="related-content" data-article-id="54"></ndlaembed></div>',
+    '<div data-type="related-content"><ndlaembed data-url="http://www.vg.no" data-resource="related-content" data-title="Forsiden vg"></ndlaembed><ndlaembed data-resource="related-content" data-article-id="54"></ndlaembed></div>',
   );
 
   expect(deserialized).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,6 +7101,7 @@ __metadata:
     postcss-reporter: "npm:^7.1.0"
     prettier: "npm:^3.1.1"
     prismjs: "npm:^1.29.0"
+    punycode: "npm:2.3.1"
     query-string: "npm:^5.1.1"
     react: "npm:^18.3.1"
     react-day-picker: "npm:^8.8.0"
@@ -12036,7 +12037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
+"punycode@npm:2.3.1, punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9


### PR DESCRIPTION
Ref https://trello.com/c/OQEMgdd0/1062-relatert-innhold-feil-visning-i-ed

Bruker punycode siden dette kjører i klient.