### PR TITLE
Adjusted counter method to iterate over all nodes in array instead of…

### DIFF
--- a/src/components/FormikField/FormikField.tsx
+++ b/src/components/FormikField/FormikField.tsx
@@ -94,7 +94,13 @@ const FormikField = ({
         <FormikRemainingCharacters
           maxLength={maxLength}
           getRemainingLabel={getRemainingLabel}
-          value={isSlateValue ? Node.string(values[name][0]) : values[name]}
+          value={
+            isSlateValue
+              ? values[name]
+                  .map((node: Node) => Node.string(node))
+                  .reduce((str: string, acc: string) => (acc = acc + str), "")
+              : values[name]
+          }
         />
       )}
       {showError && get(errors, name) && (


### PR DESCRIPTION
… just the first

Merka att metafield sin counter ikke inkrementerte når vi skrev etter en newline. Oppdaterte så denne itererer over alle noder og summerer teksten i de. 