### PR TITLE
Use `req.is()` to check content-type rather than a simple string compare

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -56,13 +56,18 @@ app.get("*splat", (req, res, next) => {
 if (!config.isVercel) {
   app.use(compression());
 }
+
 app.use(
   express.json({
     limit: "1mb",
     type: (req) => {
-      const contentType = req.headers["content-type"];
-      if (typeof contentType === "string") return allowedBodyContentTypes.includes(contentType);
-      else return false;
+      for (const allowedType of allowedBodyContentTypes) {
+        // @ts-ignore - TODO: type definition doesn't include `is()`
+        if (req.is(allowedType)) {
+          return true;
+        }
+      }
+      return false;
     },
   }),
 );


### PR DESCRIPTION
This fixes an issue with the `nynorsk-robot` that includes `charset` directive with its `content-type` header.

This patch also introduces a TODO with a `ts-ignore` since it seems that the `req.is()` function isn't defined in the typescript type definition.