### PR TITLE
Cast request to express request to allow `is()`

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -62,8 +62,7 @@ app.use(
     limit: "1mb",
     type: (req) => {
       for (const allowedType of allowedBodyContentTypes) {
-        // @ts-ignore - TODO: type definition doesn't include `is()`
-        if (req.is(allowedType)) {
+        if ((req as express.Request).is(allowedType)) {
           return true;
         }
       }


### PR DESCRIPTION
Vet ikke om dette er beste måten å gjøre det på jeg, men det er vel bittelitt bedre enn en `@ts-ignore` i alle fall.