### PR TITLE
handle encoded oembed_url

### DIFF
--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -77,7 +77,8 @@ const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: P
       return;
     }
     // Currently, we need to strip oembed part of H5P-url to support NDLA proxy oembed service
-    const path = new URL(event.data.oembed_url).searchParams.get("url");
+    const url = new URL(event.data.oembed_url).searchParams.get("url");
+    const path = url?.replace(/https?:\/\/h5p.{0,8}.ndla.no/, "");
     try {
       const metadata = await fetchH5PInfo(event.data.embed_id);
       const title = metadata.title;

--- a/src/components/H5PElement/H5PElement.tsx
+++ b/src/components/H5PElement/H5PElement.tsx
@@ -77,9 +77,7 @@ const H5PElement = ({ h5pUrl, onSelect, onClose, locale, canReturnResources }: P
       return;
     }
     // Currently, we need to strip oembed part of H5P-url to support NDLA proxy oembed service
-    const { oembed_url: oembedUrl } = event.data;
-    const url = oembedUrl.match(/url=([^&]*)/)?.[0].replace("url=", "");
-    const path = url?.replace(/https?:\/\/h5p.{0,8}.ndla.no/, "");
+    const path = new URL(event.data.oembed_url).searchParams.get("url");
     try {
       const metadata = await fetchH5PInfo(event.data.embed_id);
       const title = metadata.title;


### PR DESCRIPTION
The `H5PElement` component assumes the `url` parameter in a `https://h5p.ndla.no/oembed?url=...` URL isn't URL-encoded. While currently true, this will change after the H5P API is reimplemented.

This PR solves the issue by using appropriate functions for reading query params, and is compatible with both new and old implementations of the H5P API.