### PR TITLE
refactor: remove remaining ndla/select usage

### DIFF
--- a/e2e/specs/status_change.spec.ts
+++ b/e2e/specs/status_change.spec.ts
@@ -26,19 +26,18 @@ test("can change status correctly", async ({ page, harCheckpoint }) => {
   await harCheckpoint();
   await saveButton.click();
   await saveButton.getByText("Lagret").waitFor();
-  await expect(statusSelect.getByText("I arbeid")).toBeVisible();
+  await expect(statusSelect.locator('[data-part="value-text"]')).toHaveText("I arbeid");
 
   await statusSelect.click();
   await page.getByText("Sisteblikk", { exact: true }).click();
   await harCheckpoint();
   await saveButton.click();
   await saveButton.getByText("Lagret").waitFor();
-  await expect(statusSelect.getByText("Sisteblikk")).toBeVisible();
+  await expect(statusSelect.locator('[data-part="value-text"]')).toHaveText("Sisteblikk");
 
   await statusSelect.click();
   await harCheckpoint();
   await page.getByText("Publiser", { exact: true }).click();
-
   await saveButton.getByText("Lagret").waitFor();
-  await expect(statusSelect.getByText("Publisert")).toBeVisible();
+  await expect(statusSelect.locator('[data-part="value-text"]')).toHaveText("Publisert");
 });

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@ndla/modal": "^8.0.34-alpha.0",
     "@ndla/primitives": "^1.0.49-alpha.0",
     "@ndla/safelink": "^7.0.50-alpha.0",
-    "@ndla/select": "^6.0.34-alpha.0",
     "@ndla/styled-system": "^0.0.24",
     "@ndla/tracker": "^5.0.9",
     "@ndla/typography": "^0.4.25",

--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -14,7 +14,6 @@ import { colors, spacing } from "@ndla/core";
 import { Launch } from "@ndla/icons/common";
 import { Button } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
-import { SingleValue } from "@ndla/select";
 import { IStatus as ConceptStatus } from "@ndla/types-backend/concept-api";
 import { IStatus as DraftStatus } from "@ndla/types-backend/draft-api";
 import { ARCHIVED, PUBLISHED, SAVE_BUTTON_ID, UNPUBLISHED } from "../../constants";
@@ -72,6 +71,10 @@ const Wrapper = styled.div`
   width: 200px;
 `;
 
+const ResponsibleWrapper = styled.div`
+  width: 250px;
+`;
+
 const StyledFooterControls = styled.div`
   display: flex;
   gap: ${spacing.normal};
@@ -107,8 +110,8 @@ function EditorFooter<T extends FormValues>({
   selectedLanguage,
   supportedLanguages,
 }: Props) {
-  const [status, setStatus] = useState<SingleValue>(null);
-  const [responsible, setResponsible] = useState<SingleValue>(null);
+  const [status, setStatus] = useState<string | undefined>(undefined);
+  const [responsible, setResponsible] = useState<string | undefined>(undefined);
 
   const { ndlaId } = useSession();
   const { t } = useTranslation();
@@ -116,7 +119,7 @@ function EditorFooter<T extends FormValues>({
   const { createMessage, formatErrorMessage } = useMessages();
 
   // Wait for newStatus to be set to trigger since formik doesn't update fields instantly
-  const [newStatus, setNewStatus] = useState<SingleValue>(null);
+  const [newStatus, setNewStatus] = useState<string | undefined>(undefined);
 
   const articleOrConcept = isArticle || isConcept;
 
@@ -145,9 +148,9 @@ function EditorFooter<T extends FormValues>({
   }, [articleId, articleType, selectedLanguage, supportedLanguages, t]);
 
   useEffect(() => {
-    if (newStatus?.value === PUBLISHED) {
+    if (newStatus === PUBLISHED) {
       onSaveClick();
-      setNewStatus(null);
+      setNewStatus(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newStatus]);
@@ -164,10 +167,10 @@ function EditorFooter<T extends FormValues>({
   );
 
   const updateResponsible = useCallback(
-    async (responsible: SingleValue) => {
+    async (responsible: string | undefined) => {
       try {
         setResponsible(responsible);
-        setFieldValue("responsibleId", responsible ? responsible.value : null);
+        setFieldValue("responsibleId", responsible ? responsible : null);
       } catch (error) {
         catchError(error, createMessage);
       }
@@ -177,23 +180,23 @@ function EditorFooter<T extends FormValues>({
 
   const onSave = useCallback(
     (saveAsNewVersion?: boolean | undefined) => {
-      if (STATUSES_RESET_RESPONSIBLE.find((s) => s === status?.value)) {
-        updateResponsible(null);
+      if (STATUSES_RESET_RESPONSIBLE.find((s) => s === status)) {
+        updateResponsible(undefined);
       }
       onSaveClick(saveAsNewVersion);
     },
-    [onSaveClick, status?.value, updateResponsible],
+    [onSaveClick, status, updateResponsible],
   );
 
   const updateStatus = useCallback(
-    async (status: SingleValue) => {
+    async (status: string | undefined) => {
       try {
         // Set new status field and update form (which we listen for changes to in the useEffect above)
         setNewStatus(status);
-        if (status?.value !== PUBLISHED) {
+        if (status !== PUBLISHED) {
           setStatus(status);
         }
-        setFieldValue("status", { current: status?.value });
+        setFieldValue("status", { current: status });
       } catch (error) {
         catchError(error, createMessage);
       }
@@ -202,7 +205,7 @@ function EditorFooter<T extends FormValues>({
   );
 
   const updatePriority = useCallback(
-    (p: SingleValue) => setFieldValue("priority", p ? p.value : "unspecified"),
+    (value: string | undefined) => setFieldValue("priority", value ?? "unspecified"),
     [setFieldValue],
   );
 
@@ -211,9 +214,7 @@ function EditorFooter<T extends FormValues>({
       <Footer isArticle={isArticle}>
         <StyledFooter>
           <StyledFooterControls>
-            {isArticle && (
-              <PrioritySelect id="priority-select" priority={values.priority} updatePriority={updatePriority} />
-            )}
+            {isArticle && <PrioritySelect priority={values.priority} updatePriority={updatePriority} />}
             {articleOrConcept && (
               <Wrapper>
                 <ResponsibleSelect
@@ -267,18 +268,16 @@ function EditorFooter<T extends FormValues>({
 
         <StyledFooterControls>
           <Wrapper>
-            {isArticle && (
-              <PrioritySelect id="priority-select" priority={values.priority} updatePriority={updatePriority} />
-            )}
+            {isArticle && <PrioritySelect priority={values.priority} updatePriority={updatePriority} />}
           </Wrapper>
-          <Wrapper>
+          <ResponsibleWrapper>
             <ResponsibleSelect
               responsible={responsible}
               setResponsible={setResponsible}
               onSave={updateResponsible}
               responsibleId={responsibleId}
             />
-          </Wrapper>
+          </ResponsibleWrapper>
           <Wrapper>
             <StatusSelect
               status={status}

--- a/src/containers/FormikForm/components/PrioritySelect.tsx
+++ b/src/containers/FormikForm/components/PrioritySelect.tsx
@@ -5,8 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Select, SingleValue } from "@ndla/select";
+import { createListCollection } from "@ark-ui/react";
+import { SelectContent, SelectLabel, SelectPositioner, SelectRoot, SelectValueText } from "@ndla/primitives";
+import { GenericSelectItem, GenericSelectTrigger } from "../../../components/abstractions/Select";
 
 const priorityMapping = {
   prioritized: "editorFooter.prioritized",
@@ -14,36 +18,43 @@ const priorityMapping = {
 };
 
 interface Props {
-  id: string;
   priority: string | undefined;
-  updatePriority: (p: SingleValue) => void;
-  menuPlacement?: "top" | "bottom" | "auto";
-  inModal?: boolean;
+  updatePriority: (value: string | undefined) => void;
 }
 
-const PrioritySelect = ({ id, priority, updatePriority, menuPlacement = "top", inModal = false }: Props) => {
+const PrioritySelect = ({ priority, updatePriority }: Props) => {
   const { t } = useTranslation();
 
-  return (
-    <Select<false>
-      id={id}
-      options={[
+  const collection = useMemo(() => {
+    return createListCollection({
+      items: [
         { label: t(priorityMapping["prioritized"]), value: "prioritized" },
         { label: t(priorityMapping["on-hold"]), value: "on-hold" },
-      ]}
-      menuPlacement={menuPlacement}
-      placeholder={t("editorFooter.placeholderPrioritized")}
-      aria-label={t("editorFooter.placeholderPrioritized")}
-      inModal={inModal}
-      value={
-        priority === "prioritized" || priority === "on-hold"
-          ? { value: priority, label: t(priorityMapping[priority!]) }
-          : null
-      }
-      onChange={updatePriority}
-      isClearable
-      closeMenuOnSelect
-    />
+      ],
+    });
+  }, [t]);
+
+  return (
+    <SelectRoot
+      collection={collection}
+      positioning={{ sameWidth: true }}
+      value={priority && Object.keys(priorityMapping).includes(priority) ? [priority] : undefined}
+      onValueChange={(details) => updatePriority(details.value[0])}
+    >
+      <SelectLabel srOnly>{t("taxonomy.addPriority")}</SelectLabel>
+      <GenericSelectTrigger variant="secondary" clearable>
+        <SelectValueText placeholder={t("editorFooter.placeholderPrioritized")} />
+      </GenericSelectTrigger>
+      <SelectPositioner>
+        <SelectContent>
+          {collection.items.map((item) => (
+            <GenericSelectItem item={item} key={item.value}>
+              {item.label}
+            </GenericSelectItem>
+          ))}
+        </SelectContent>
+      </SelectPositioner>
+    </SelectRoot>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.24.5
   resolution: "@babel/runtime@npm:7.24.5"
   dependencies:
@@ -1000,7 +1000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.11.0, @emotion/cache@npm:^11.4.0":
+"@emotion/cache@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/cache@npm:11.11.0"
   dependencies:
@@ -1076,7 +1076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:^11.11.1, @emotion/react@npm:^11.8.1":
+"@emotion/react@npm:^11.11.1":
   version: 11.11.1
   resolution: "@emotion/react@npm:11.11.1"
   dependencies:
@@ -1708,7 +1708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:1.6.11, @floating-ui/dom@npm:^1.0.1, @floating-ui/dom@npm:^1.2.7":
+"@floating-ui/dom@npm:1.6.11, @floating-ui/dom@npm:^1.2.7":
   version: 1.6.11
   resolution: "@floating-ui/dom@npm:1.6.11"
   dependencies:
@@ -2134,22 +2134,6 @@ __metadata:
   bin:
     ndla-scripts: src/index.js
   checksum: 10c0/4b95468a7f7696e119a32f908853347cfe4239cb8177876a7355987786df30fbf8be99049fa0f171503aafdbe5bac3454d9e85ff66fa229188b62fd4d13aed70
-  languageName: node
-  linkType: hard
-
-"@ndla/select@npm:^6.0.34-alpha.0":
-  version: 6.0.34-alpha.0
-  resolution: "@ndla/select@npm:6.0.34-alpha.0"
-  dependencies:
-    "@ndla/core": "npm:^5.0.2"
-    "@ndla/icons": "npm:^8.0.34-alpha.0"
-    react-select: "npm:^5.8.0"
-  peerDependencies:
-    "@emotion/react": ^11.10.4
-    "@emotion/styled": ^11.10.4
-    react: ">= 16.8.0"
-    react-i18next: ^14.1.1
-  checksum: 10c0/f6630621aa50711128dc3a975a1a47193ae0c315669a48d8004e2035cc0feb4ab43b376a13bf9e3a75a3a41d37fa3e0232d70ce0539c2dcd2e41a3e9adae7c81
   languageName: node
   linkType: hard
 
@@ -3872,15 +3856,6 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10c0/6c90d2ed72c5a0e440d2c75d99287e4b5df3e7b011838cdc03ae5cd518ab52164d86990e73246b9d812eaf02ec351d74e3b4f5bd325bf341e13bf980392fd53b
-  languageName: node
-  linkType: hard
-
-"@types/react-transition-group@npm:^4.4.0":
-  version: 4.4.5
-  resolution: "@types/react-transition-group@npm:4.4.5"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/c0d81634ca5e1efac3ca6f6f006245976d584833ab9e933edf08b66551c1c7b9f0bc7878897f57ba44b137d3754583d623c932fe4b7721840ae5218ec2414942
   languageName: node
   linkType: hard
 
@@ -6891,16 +6866,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-helpers@npm:^5.0.1":
-  version: 5.2.1
-  resolution: "dom-helpers@npm:5.2.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.8.7"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/f735074d66dd759b36b158fa26e9d00c9388ee0e8c9b16af941c38f014a37fc80782de83afefd621681b19ac0501034b4f1c4a3bff5caa1b8667f0212b5e124c
-  languageName: node
-  linkType: hard
-
 "dom-serializer@npm:^2.0.0":
   version: 2.0.0
   resolution: "dom-serializer@npm:2.0.0"
@@ -7026,7 +6991,6 @@ __metadata:
     "@ndla/primitives": "npm:^1.0.49-alpha.0"
     "@ndla/safelink": "npm:^7.0.50-alpha.0"
     "@ndla/scripts": "npm:^2.1.2"
-    "@ndla/select": "npm:^6.0.34-alpha.0"
     "@ndla/styled-system": "npm:^0.0.24"
     "@ndla/tracker": "npm:^5.0.9"
     "@ndla/types-backend": "npm:^0.2.92"
@@ -10383,13 +10347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoize-one@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "memoize-one@npm:6.0.0"
-  checksum: 10c0/45c88e064fd715166619af72e8cf8a7a17224d6edf61f7a8633d740ed8c8c0558a4373876c9b8ffc5518c2b65a960266adf403cc215cb1e90f7e262b58991f54
-  languageName: node
-  linkType: hard
-
 "merge-anything@npm:5.1.7":
   version: 5.1.7
   resolution: "merge-anything@npm:5.1.7"
@@ -11962,7 +11919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -12296,26 +12253,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-select@npm:^5.8.0":
-  version: 5.8.0
-  resolution: "react-select@npm:5.8.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.0"
-    "@emotion/cache": "npm:^11.4.0"
-    "@emotion/react": "npm:^11.8.1"
-    "@floating-ui/dom": "npm:^1.0.1"
-    "@types/react-transition-group": "npm:^4.4.0"
-    memoize-one: "npm:^6.0.0"
-    prop-types: "npm:^15.6.0"
-    react-transition-group: "npm:^4.3.0"
-    use-isomorphic-layout-effect: "npm:^1.1.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/b4b98aaf117ee5cc4642871b7bd51fd0e2697988d0b880f30b21e933ca90258959147117d8aada36713b622e0e4cb06bd18ec02069f3f108896e0d31e69e3c16
-  languageName: node
-  linkType: hard
-
 "react-simple-code-editor@npm:^0.13.1":
   version: 0.13.1
   resolution: "react-simple-code-editor@npm:0.13.1"
@@ -12340,21 +12277,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/6d66f3bdb65e1ec79089f80314da97c9a005087a04ee034255a5de129a4c0d9fd0bf99fa7bf642781ac2dc745ca687aae3de082bd8afdd0d117bc953241e15ad
-  languageName: node
-  linkType: hard
-
-"react-transition-group@npm:^4.3.0":
-  version: 4.4.5
-  resolution: "react-transition-group@npm:4.4.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.5.5"
-    dom-helpers: "npm:^5.0.1"
-    loose-envify: "npm:^1.4.0"
-    prop-types: "npm:^15.6.2"
-  peerDependencies:
-    react: ">=16.6.0"
-    react-dom: ">=16.6.0"
-  checksum: 10c0/2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
   languageName: node
   linkType: hard
 
@@ -14101,18 +14023,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/8a0867ffd441f358c66d79567970a745cc78ac2f98840a81c1fa749a525e8716116c645497d886a815e1dcf40ad81a107ebd6a7d15fd9ab5925c44a994a1d89a
-  languageName: node
-  linkType: hard
-
-"use-isomorphic-layout-effect@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/d8deea8b85e55ac6daba237a889630bfdbf0ebf60e9e22b6a78a78c26fabe6025e04ada7abef1e444e6786227d921e648b2707db8b3564daf757264a148a6e23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Skriver om alt bruk av ndla/select i EditorFooter til å bruke vår nye select. Resultatet av dette er at ansvarlig ikke lenger er like "søkbar". Det skal dog sies at man kan hoppe i listen ved å skrive som en vanligvis gjør.