### PR TITLE
Create a separate search hook which handles custom subject filtering

### DIFF
--- a/src/containers/App/SearchPage.tsx
+++ b/src/containers/App/SearchPage.tsx
@@ -17,7 +17,7 @@ import Footer from "./components/FooterWrapper";
 import { SearchType } from "../../interfaces";
 import { useSearchAudio, useSearchSeries } from "../../modules/audio/audioQueries";
 import { useSearchImages } from "../../modules/image/imageQueries";
-import { useSearch } from "../../modules/search/searchQueries";
+import { useSearchWithCustomSubjectsFiltering } from "../../modules/search/searchQueries";
 import { toSearch } from "../../util/routeHelpers";
 import SubNavigation from "../Masthead/components/SubNavigation";
 import NotFoundPage from "../NotFoundPage/NotFoundPage";
@@ -48,7 +48,7 @@ const SearchPage = () => {
       ),
       icon: <SearchContent />,
       path: "content",
-      searchHook: useSearch,
+      searchHook: useSearchWithCustomSubjectsFiltering,
     },
     {
       title: t("subNavigation.searchAudio"),

--- a/src/queryKeys.ts
+++ b/src/queryKeys.ts
@@ -11,6 +11,7 @@ export const SEARCH_CONCEPTS = "searchConcepts";
 export const SEARCH_SERIES = "searchSeries";
 export const SEARCH_IMAGES = "searchImages";
 export const SEARCH = "search";
+export const SEARCH_WITH_CUSTOM_SUBJECTS_FILTERING = "searchWithCustomSubjectsFiltering";
 export const SEARCH_SUBJECT_STATS = "searchSubjectStats";
 export const MYNDLA_RESOURCE_STATS = "myNdlaResourceStats";
 


### PR DESCRIPTION
Flytter ut logikken som håndterer custom filtrering av favoritt-/da-/lma-/sa-fag, så kan vi bruke en helt clean search-hook ellers!