### PR TITLE
Only allow image as new visual element for topic

### DIFF
--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -53,7 +53,7 @@ const TopicArticleContent = (props: Props) => {
         )}
       </FormField>
       <IngressField />
-      <VisualElementField />
+      <VisualElementField types={["image"]} />
       <FormikField name="content" label={t("form.content.label")} noBorder>
         {({ field: { value, name, onChange }, form: { isSubmitting } }) => (
           <>


### PR DESCRIPTION
Gjør at kun bilder kan legges til som visuelt element. Eksisterende emner med video og h5p funker å redigere.