### PR TITLE
chore: drop forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@ndla/audio-search": "^7.0.50-alpha.0",
     "@ndla/button": "^15.0.35-alpha.0",
     "@ndla/error-reporter": "^2.0.4",
-    "@ndla/forms": "^10.0.50-alpha.0",
     "@ndla/icons": "^8.0.34-alpha.0",
     "@ndla/image-search": "^11.0.52-alpha.0",
     "@ndla/licenses": "^8.0.3-alpha.0",

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -7,12 +7,7 @@
  */
 
 import { FieldHelperProps, FieldInputProps, FieldMetaProps, useField } from "formik";
-import { ComponentProps, ReactNode, useId, useMemo } from "react";
-import { useTranslation } from "react-i18next";
-import styled from "@emotion/styled";
-import { utils } from "@ndla/core";
-import { FieldHelper, FormControlProps, FormControl as InternalFormControl } from "@ndla/forms";
-import useDebounce from "../util/useDebounce";
+import { ReactNode } from "react";
 
 interface FormFieldProps<T = any> {
   name: string;
@@ -23,37 +18,3 @@ export const FormField = <T = any,>({ name, children }: FormFieldProps<T>) => {
   const [field, meta, helpers] = useField(name);
   return children({ field, meta, helpers });
 };
-
-export const FormControl = (props: Omit<FormControlProps, "id"> & ComponentProps<"div">) => {
-  const id = useId();
-  return <InternalFormControl id={id} {...props} />;
-};
-
-const HiddenSpan = styled(FieldHelper)`
-  ${utils.visuallyHidden};
-`;
-
-interface Props extends ComponentProps<"div"> {
-  value: number;
-  maxLength: number;
-  children?: ReactNode;
-}
-
-export const FormRemainingCharacters = ({ value, maxLength, children, ...rest }: Props) => {
-  const { t } = useTranslation();
-  const debouncedValue = useDebounce(value, 300);
-  const debouncedTranslation = useMemo(() => {
-    return t("form.remainingCharacters", { maxLength, remaining: maxLength - debouncedValue });
-  }, [debouncedValue, maxLength, t]);
-
-  return (
-    <div {...rest}>
-      <span aria-hidden="true">{t("form.remainingCharacters", { maxLength, remaining: maxLength - value })}</span>
-      <HiddenSpan aria-live="polite">{debouncedTranslation}</HiddenSpan>
-    </div>
-  );
-};
-
-export const FieldWarning = styled(FieldHelper)`
-  color: #8c8c00;
-`;

--- a/src/components/SlateEditor/PlainTextEditor.tsx
+++ b/src/components/SlateEditor/PlainTextEditor.tsx
@@ -12,7 +12,6 @@ import { createEditor, Descendant } from "slate";
 import { withHistory } from "slate-history";
 import { Slate, Editable, ReactEditor, withReact } from "slate-react";
 import { EditableProps } from "slate-react/dist/components/editable";
-import { useFormControl } from "@ndla/forms";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { SlatePlugin } from "./interfaces";
@@ -50,10 +49,11 @@ interface Props extends Omit<EditableProps & JsxStyleProps, "value"> {
   plugins?: SlatePlugin[];
 }
 
+// TODO: Find a way to properly integrate this with `Field`
+
 const PlainTextEditor = forwardRef<HTMLTextAreaElement, Props>(
   ({ onChange, value, id, submitted, className, placeholder, plugins, ...rest }, ref) => {
     const [editor] = useState(() => withPlugins(withHistory(withReact(createEditor())), plugins));
-    const props = useFormControl({ id, readOnly: submitted, ...rest });
 
     const onBlur = useCallback(() => {
       ReactEditor.deselect(editor);
@@ -100,7 +100,7 @@ const PlainTextEditor = forwardRef<HTMLTextAreaElement, Props>(
             const { style, ...remainingAttributes } = attributes;
             return <StyledPlaceholder {...remainingAttributes}>{children}</StyledPlaceholder>;
           }}
-          {...props}
+          {...rest}
           // Weird typescript error. Let's just ignore it
           ref={ref as Ref<never>}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,27 +1999,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ndla/forms@npm:^10.0.50-alpha.0":
-  version: 10.0.50-alpha.0
-  resolution: "@ndla/forms@npm:10.0.50-alpha.0"
-  dependencies:
-    "@ndla/core": "npm:^5.0.2"
-    "@ndla/icons": "npm:^8.0.34-alpha.0"
-    "@ndla/pager": "npm:^5.0.50-alpha.0"
-    "@ndla/typography": "npm:^0.4.25"
-    "@ndla/util": "npm:^5.0.0-alpha.0"
-    "@radix-ui/react-checkbox": "npm:^1.0.4"
-    "@radix-ui/react-radio-group": "npm:^1.1.3"
-  peerDependencies:
-    "@emotion/react": ^11.10.4
-    "@emotion/styled": ^11.10.4
-    react: ">= 16.8.0"
-    react-dom: ">= 16.8.0"
-    react-i18next: ^14.1.1
-  checksum: 10c0/477121587434dd3b862a1441ea19e67e4ce3de888aabe8d6d3d84d44b0eb71a633cad04f6e128e48c79a3a7e688cad9e83040db9f7cc73dddd694bfcd6097623
-  languageName: node
-  linkType: hard
-
 "@ndla/icons@npm:^8.0.34-alpha.0":
   version: 8.0.34-alpha.0
   resolution: "@ndla/icons@npm:8.0.34-alpha.0"
@@ -2070,20 +2049,6 @@ __metadata:
     react-dom: ">= 16.8.0"
     react-i18next: ^14.1.1
   checksum: 10c0/93f9e1bd19607af1bb3093ccb221b9e409e72816682cbf5125200480f8b9889898ea3446a9c12951f8f7fcaa52780dc2f0e7fe47c399af3acfe9d0b9f694539a
-  languageName: node
-  linkType: hard
-
-"@ndla/pager@npm:^5.0.50-alpha.0":
-  version: 5.0.50-alpha.0
-  resolution: "@ndla/pager@npm:5.0.50-alpha.0"
-  dependencies:
-    "@ndla/core": "npm:^5.0.2"
-    "@ndla/safelink": "npm:^7.0.50-alpha.0"
-  peerDependencies:
-    "@emotion/react": ^11.10.4
-    "@emotion/styled": ^11.10.4
-    react: ">= 16.8.0"
-  checksum: 10c0/496e6b721a9b4030db1f9b21f7837f2ce30beb1c0766394809532e2b1f8422ba79f79b147205086bdf433e09de219f589535610a0be0f83180d4dd5232763045
   languageName: node
   linkType: hard
 
@@ -2179,19 +2144,6 @@ __metadata:
   version: 1.0.30
   resolution: "@ndla/types-taxonomy@npm:1.0.30"
   checksum: 10c0/d40961d063dd5a249d3937d77f7058c77ef1d802b16a95a53b190d68930fc898d729f2bc155e8f9a8bf5a06d28f13516be21146cab889670a87a0237bb4666e5
-  languageName: node
-  linkType: hard
-
-"@ndla/typography@npm:^0.4.25":
-  version: 0.4.25
-  resolution: "@ndla/typography@npm:0.4.25"
-  dependencies:
-    "@ndla/core": "npm:^5.0.2"
-    "@ndla/util": "npm:^5.0.0-alpha.0"
-  peerDependencies:
-    "@emotion/react": ^11.10.4
-    react: ">= 16.8.0"
-  checksum: 10c0/946f454b5491a7722b785b06274621ffdd36b1d94bc984e820d07f58851d2e5cce35b2fc3239883d50fd82f79067b0d32d74412fef0dfbaaa79b35488cb70e58
   languageName: node
   linkType: hard
 
@@ -2578,33 +2530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-checkbox@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@radix-ui/react-checkbox@npm:1.0.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.13.10"
-    "@radix-ui/primitive": "npm:1.0.1"
-    "@radix-ui/react-compose-refs": "npm:1.0.1"
-    "@radix-ui/react-context": "npm:1.0.1"
-    "@radix-ui/react-presence": "npm:1.0.1"
-    "@radix-ui/react-primitive": "npm:1.0.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.0.1"
-    "@radix-ui/react-use-previous": "npm:1.0.1"
-    "@radix-ui/react-use-size": "npm:1.0.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0
-    react-dom: ^16.8 || ^17.0 || ^18.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/a4bd259a7e15ad88f72524190ddcc2db0688d439aad954e06d0adf6038b2e17397ed8ae0ea26ab09bf6981f1b9dd883904b2b7e74b307b5c6b1a3765d27fe737
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-collection@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-collection@npm:1.0.3"
@@ -2970,35 +2895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-radio-group@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/react-radio-group@npm:1.1.3"
-  dependencies:
-    "@babel/runtime": "npm:^7.13.10"
-    "@radix-ui/primitive": "npm:1.0.1"
-    "@radix-ui/react-compose-refs": "npm:1.0.1"
-    "@radix-ui/react-context": "npm:1.0.1"
-    "@radix-ui/react-direction": "npm:1.0.1"
-    "@radix-ui/react-presence": "npm:1.0.1"
-    "@radix-ui/react-primitive": "npm:1.0.3"
-    "@radix-ui/react-roving-focus": "npm:1.0.4"
-    "@radix-ui/react-use-controllable-state": "npm:1.0.1"
-    "@radix-ui/react-use-previous": "npm:1.0.1"
-    "@radix-ui/react-use-size": "npm:1.0.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0
-    react-dom: ^16.8 || ^17.0 || ^18.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/a23264cc9e8cb3738db8edf50ae27b82f79093f57c2e9a4d319fdece280147f5615643ad6df480383dcd53f39078e321c25be5e18992ffda36b2c73ebfcad9c4
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-roving-focus@npm:1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-roving-focus@npm:1.0.4"
@@ -3196,21 +3092,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/13cd0c38395c5838bc9a18238020d3bcf67fb340039e6d1cbf438be1b91d64cf6900b78121f3dc9219faeb40dcc7b523ce0f17e4a41631655690e5a30a40886a
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-previous@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@radix-ui/react-use-previous@npm:1.0.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.13.10"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f5fbc602108668484a4ed506b7842482222d1d03094362e26abb7fdd593eee8794fc47d85b3524fb9d00884801c89a6eefd0bed0971eba1ec189c637b6afd398
   languageName: node
   linkType: hard
 
@@ -6982,7 +6863,6 @@ __metadata:
     "@ndla/audio-search": "npm:^7.0.50-alpha.0"
     "@ndla/button": "npm:^15.0.35-alpha.0"
     "@ndla/error-reporter": "npm:^2.0.4"
-    "@ndla/forms": "npm:^10.0.50-alpha.0"
     "@ndla/icons": "npm:^8.0.34-alpha.0"
     "@ndla/image-search": "npm:^11.0.52-alpha.0"
     "@ndla/licenses": "npm:^8.0.3-alpha.0"


### PR DESCRIPTION
Fjerner `useFormControl` fra `PlainTextEditor` inntil videre. Vi bruker ikke `FormControl` lenger, og ikke helt sikker på hvordan vi skal få integrert `Field` med `contenteditable`