### PR TITLE
Toolbar: prevent inline insertion when multiple paragraph blocks are selected

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -276,10 +276,13 @@ const disableInlineOnMultipleBlocksSelected = (
   const ancestors =
     editorAncestors?.[0]?.type === TYPE_NOOP ? (editorAncestors[0].children as Element[]) : editorAncestors;
 
+  // Filter ancestors that contain inline elements or text blocks
+  // We need to handle both flattened text element and paragraph blocks
   const filteredAncestors =
     ancestors?.filter(
       (fragment) =>
         fragment.children?.length > 1 ||
+        (Text.isText(fragment) && fragment.text !== "") ||
         (fragment.children?.length === 1 && Text.isText(fragment.children[0]) && fragment.children[0].text !== ""),
     ) ?? [];
 


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4226

Trengte visst å oppdatere filtreringen her etter [denne](https://github.com/NDLANO/editorial-frontend/pull/2455) ble tatt inn