### PR TITLE
Fix overlappings buttons in SlateAudio

### DIFF
--- a/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
@@ -22,7 +22,6 @@ import AudioEmbedForm from "./AudioEmbedForm";
 import { AudioElement } from "./types";
 import { useAudioMeta } from "../../../../modules/embed/queries";
 import { useArticleLanguage } from "../../ArticleLanguageProvider";
-import { StyledFigureButtons } from "../embed/FigureButtons";
 
 interface Props extends RenderElementProps {
   element: AudioElement;
@@ -36,6 +35,17 @@ const StyledEmbedWrapper = styled(EmbedWrapper, {
       outline: "2px solid",
       outlineColor: "stroke.default",
     },
+  },
+});
+
+const ButtonContainer = styled("div", {
+  base: {
+    position: "absolute",
+    right: "0",
+    top: "-xlarge",
+    display: "flex",
+    gap: "3xsmall",
+    justifyContent: "flex-end",
   },
 });
 
@@ -117,13 +127,13 @@ const SlateAudio = ({ element, editor, attributes, children }: Props) => {
           <Spinner />
         ) : embed ? (
           <>
-            <StyledFigureButtons>
+            <ButtonContainer>
               {embed.embedData.type !== "podcast" && (
                 <DialogTrigger asChild>
                   <IconButton
                     title={t("form.audio.edit")}
                     aria-label={t("form.audio.edit")}
-                    variant="tertiary"
+                    variant="secondary"
                     size="small"
                   >
                     <PencilFill />
@@ -156,7 +166,7 @@ const SlateAudio = ({ element, editor, attributes, children }: Props) => {
                   </IconButton>
                 </>
               )}
-            </StyledFigureButtons>
+            </ButtonContainer>
             <AudioEmbed embed={embed} />
           </>
         ) : null}


### PR DESCRIPTION
https://trello.com/c/wMDh02fc/1146-lyd-med-tekstversjon-f%C3%A5r-overlappende-knapper