### PR TITLE
refactor: ignore fragment warnings where they cannot be avoided. Return a JSX.Element where possible

### DIFF
--- a/src/components/SlateEditor/plugins/mark/index.tsx
+++ b/src/components/SlateEditor/plugins/mark/index.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ReactElement } from "react";
+import { Fragment } from "react";
 import { Descendant, Editor, Text, Transforms } from "slate";
 import { jsx as slatejsx } from "slate-hyperscript";
 import { SlateSerializer } from "../../interfaces";
@@ -51,11 +51,16 @@ export const markSerializer: SlateSerializer = {
   serialize(node: Descendant) {
     if (!Text.isText(node)) return;
     let ret;
-    const children = node.text.split("\n").reduce((array: (ReactElement | string)[], text, i) => {
-      if (i !== 0) array.push(<br key={i} />);
-      array.push(text);
-      return array;
-    }, []);
+    const children = (
+      <>
+        {node.text.split("\n").map((text, i) => (
+          <Fragment key={i}>
+            {i !== 0 && <br />}
+            {text}
+          </Fragment>
+        ))}
+      </>
+    );
     if (node.bold) {
       ret = <strong>{ret || children}</strong>;
     }
@@ -77,7 +82,7 @@ export const markSerializer: SlateSerializer = {
     if (ret) {
       return ret;
     }
-    return <>{children}</>;
+    return children;
   },
 };
 

--- a/src/components/SlateEditor/plugins/noop/index.tsx
+++ b/src/components/SlateEditor/plugins/noop/index.tsx
@@ -27,6 +27,7 @@ export const noopSerializer: SlateSerializer = {
   },
   serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node) || node.type !== TYPE_NOOP) return;
+    // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
   },
 };

--- a/src/components/SlateEditor/plugins/paragraph/index.tsx
+++ b/src/components/SlateEditor/plugins/paragraph/index.tsx
@@ -118,6 +118,7 @@ export const paragraphSerializer: SlateSerializer = {
     if (Node.string(node) === "" && node.children.length === 1 && Text.isText(node.children[0])) return null;
 
     if (node.serializeAsText) {
+      // eslint-disable-next-line react/jsx-no-useless-fragment
       return <>{children}</>;
     }
 

--- a/src/components/SlateEditor/plugins/span/index.tsx
+++ b/src/components/SlateEditor/plugins/span/index.tsx
@@ -61,6 +61,7 @@ export const spanSerializer: SlateSerializer = {
   serialize(node: Descendant, children: JSX.Element[]) {
     if (!Element.isElement(node) || node.type !== TYPE_SPAN) return;
     if (!Object.keys(node.data ?? {}).length) {
+      // eslint-disable-next-line react/jsx-no-useless-fragment
       return <>{children}</>;
     }
 

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -154,7 +154,7 @@ export const tableSerializer: SlateSerializer = {
 
     if (node.type === TYPE_TABLE_CAPTION) {
       if (Node.string(node) === "") {
-        return <></>;
+        return null;
       }
       return <caption>{children}</caption>;
     }

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -176,6 +176,7 @@ const articleContentToHTML = (value: Descendant[], rules: SlateSerializer[]) => 
         return cloneElement(ret, { key: nodeIdx });
       }
     }
+    // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
   };
 

--- a/src/util/compareHTMLHelpers.tsx
+++ b/src/util/compareHTMLHelpers.tsx
@@ -15,7 +15,7 @@ export const removeCommentTags = (html: string): string => {
     replace(domNode) {
       if (domNode instanceof Element && "attribs" in domNode) {
         if (domNode.attribs["data-resource"] === "comment" && domNode.attribs["data-type"] === "block") {
-          return <></>;
+          return null;
         }
         if (domNode.attribs["data-resource"] === "comment" && domNode.attribs["data-type"] === "inline") {
           return <>{domToReact((domNode as Element).children as DOMNode[])}</>;


### PR DESCRIPTION
Mer linting-fikser. Vi burde nok egentlig endre typen for dette globalt, men mistenker at det kommer til å kreve endring av serialiseringslogikken vår.