### PR TITLE
Revert "Remove zIndex on EditorFooter to prevent wrong stacking order"

### DIFF
--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -67,6 +67,7 @@ const StyledPageContent = styled("div", {
   base: {
     position: "sticky",
     bottom: "4xsmall",
+    zIndex: "sticky",
   },
 });
 


### PR DESCRIPTION
Reverts NDLANO/editorial-frontend#2799

Oppdaget tilfeller som dette der innhold i artikkelen har z-index: `/subject-matter/learning-resource/29773/edit/nb`

Lager ny PR med mer robust fix!