### PR TITLE
Fix breadcrumb generation in taxonomy block

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/taxonomy/TaxonomyBlock.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/taxonomy/TaxonomyBlock.tsx
@@ -237,6 +237,7 @@ const TaxonomyBlock = ({
         connectionId: "",
         name: node.name,
         nodeType: node.nodeType,
+        context: node.context,
       };
       return { ...res, placements: res.placements.concat(newPlacement) };
     });


### PR DESCRIPTION
Feil brødsmulesti genereres når man legger til emnetilknytninger/emneplassering før man har lagret taksonomi, denne fikser!