### PR TITLE
Allow inline comments in definition-list

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -173,7 +173,7 @@ export const defaultAreaOptions: AreaFilters = {
   },
   "definition-list": {
     block: { quote: { disabled: true } },
-    inline: { disabled: true },
+    inline: { disabled: true, "comment-inline": { disabled: false } },
   },
   quote: { inline: { disabled: true } },
 };


### PR DESCRIPTION
Fikser opp i at inline kommentar var disablet for definisjonsliste i framed content

eksempel her: `/subject-matter/learning-resource/39023/edit/nb`