### PR TITLE
Fix editor footer z index to prevent content appearing behind

### DIFF
--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -67,7 +67,7 @@ const StyledPageContent = styled("div", {
   base: {
     position: "sticky",
     bottom: "4xsmall",
-    zIndex: "sticky",
+    zIndex: "docked",
   },
 });
 


### PR DESCRIPTION
https://trello.com/c/ULzcb6Dl/1176-spr%C3%A5kvelger-i-ed-footer-legger-seg-bak-knappene-prioritert-og-ansvarlig-i-artikkelvisning-p%C3%A5-dashboard-funker-det-fint

Denne fungerer med selects, comboboxer, venstre/høyre-plasserte bilder, tror ikke det skal brekke andre ting heller utifra det jeg har testet, men fint med dobbeltsjekk!