### PR TITLE
Handle val=undefined if same align button is pressed

### DIFF
--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -162,9 +162,9 @@ const ImageEditor = ({ language, image }: Props) => {
             <StyledToggleGroupRoot
               value={[field.value]}
               onValueChange={(details) => {
-                const val = details.value[0] ?? "center"; // default to center if no value is set
+                const val = details.value[0] ?? "";
                 helpers.setValue(val);
-                if (val === "center") {
+                if (val !== "right" && val !== "left") {
                   setFieldValue("size", "full");
                 }
               }}

--- a/src/containers/ImageEditor/ImageEditor.tsx
+++ b/src/containers/ImageEditor/ImageEditor.tsx
@@ -162,7 +162,7 @@ const ImageEditor = ({ language, image }: Props) => {
             <StyledToggleGroupRoot
               value={[field.value]}
               onValueChange={(details) => {
-                const val = details.value[0];
+                const val = details.value[0] ?? "center"; // default to center if no value is set
                 helpers.setValue(val);
                 if (val === "center") {
                   setFieldValue("size", "full");


### PR DESCRIPTION
Dersom du har satt align=right og så skrur det av ved å klikke på align=right, så settes undefined som verdi og dermed slettes feltet. Då feiler lagringa fordi valideringa forventer en data-align, sjølv om denne kan være tom.