### PR TITLE
fix: properly escape children

### DIFF
--- a/src/components/SlateEditor/plugins/mark/index.tsx
+++ b/src/components/SlateEditor/plugins/mark/index.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import escapeHtml from "escape-html";
 import { Descendant, Editor, Text, Transforms } from "slate";
 import { jsx as slatejsx } from "slate-hyperscript";
 import { createHtmlTag } from "../../../../util/embedTagHelpers";
@@ -52,7 +53,8 @@ export const markSerializer: SlateSerializer = {
     if (!Text.isText(node)) return;
     let ret;
 
-    const children = node.text.split("\n").reduce((acc, curr, i) => {
+    const escapedText: string = escapeHtml(node.text);
+    const children = escapedText.split("\n").reduce((acc, curr, i) => {
       if (i !== 0) {
         acc = acc.concat(createHtmlTag({ tag: "br", shorthand: true }));
       }

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import escapeHtml from "escape-html";
 import compact from "lodash/compact";
 import toArray from "lodash/toArray";
-import { Descendant, Node, Text } from "slate";
+import { Descendant, Element, Node } from "slate";
 import { AudioEmbedData, BrightcoveEmbedData, H5pEmbedData, ImageEmbedData } from "@ndla/types-embed";
 import { convertFromHTML } from "./convertFromHTML";
 import { parseEmbedTag, createHtmlTag, createDataAttributes } from "./embedTagHelpers";
@@ -155,15 +154,12 @@ const commonRules: SlateSerializer[] = [
 ];
 
 const serialize = (node: Descendant, rules: SlateSerializer[]): string | undefined => {
-  let children: string;
-  if (Text.isText(node)) {
-    children = escapeHtml(node.text);
-  } else {
-    children = node.children
-      .map((n) => serialize(n, rules))
-      .filter((n) => !!n)
-      .join("");
-  }
+  const children = Element.isElement(node)
+    ? node.children
+        .map((n) => serialize(n, rules))
+        .filter((n) => !!n)
+        .join("")
+    : "";
 
   for (const rule of rules) {
     if (!rule.serialize) {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4262
Sikkert lurt å teste dette ___uhyre___ nøye, men ser ut til å funke ganske så greit!

Vi kunne vurdert å bytte ut "escape-html" med "he" i samme slengen for å spare en liten kb på bundle, men da vil vi begynne å encode bokstaver som f.eks "æøå". Vet ikke hva dere tenker