### PR TITLE
Bug fix: Properly remove slate elements on exit

### DIFF
--- a/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/CampaignBlockForm.tsx
@@ -18,6 +18,7 @@ import {
   CheckboxHiddenInput,
   CheckboxLabel,
   CheckboxRoot,
+  DialogCloseTrigger,
   FieldErrorMessage,
   FieldInput,
   FieldLabel,
@@ -47,7 +48,6 @@ import { RichTextIndicator } from "../../RichTextIndicator";
 interface Props {
   initialData?: CampaignBlockEmbedData;
   onSave: (data: CampaignBlockEmbedData) => void;
-  onCancel: () => void;
 }
 
 export interface CampaignBlockFormValues {
@@ -120,7 +120,7 @@ const UrlWrapper = styled("div", {
 
 const placements: CampaignBlockEmbedData["imageSide"][] = ["left", "right"];
 
-const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
+const CampaignBlockForm = ({ initialData, onSave }: Props) => {
   const { t } = useTranslation();
   const initialValues = useMemo(() => toInitialValues(initialData), [initialData]);
   const initialErrors = useMemo(() => validateFormik(initialValues, rules, t), [initialValues, t]);
@@ -282,9 +282,9 @@ const CampaignBlockForm = ({ initialData, onSave, onCancel }: Props) => {
             </FormField>
           )}
           <FormActionsContainer>
-            <Button variant="secondary" onClick={onCancel}>
-              {t("cancel")}
-            </Button>
+            <DialogCloseTrigger asChild>
+              <Button variant="secondary">{t("cancel")}</Button>
+            </DialogCloseTrigger>
             <Button disabled={!isFormikFormDirty({ values, initialValues, dirty }) || !isValid} type="submit">
               {t("save")}
             </Button>

--- a/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
@@ -45,22 +45,26 @@ const SlateCampaignBlock = ({ element, editor, attributes, children }: Props) =>
     setIsEditing(!!element.isFirstEdit);
   }, [element.isFirstEdit]);
 
-  const onClose = useCallback(() => {
-    ReactEditor.focus(editor);
-    setIsEditing(false);
-    if (element.isFirstEdit) {
-      Transforms.removeNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      });
-    }
-    const path = ReactEditor.findPath(editor, element);
-    if (Editor.hasPath(editor, Path.next(path))) {
-      setTimeout(() => {
-        Transforms.select(editor, Path.next(path));
-      }, 0);
-    }
-  }, [editor, element]);
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      setIsEditing(open);
+      if (open) return;
+      ReactEditor.focus(editor);
+      if (element.isFirstEdit) {
+        Transforms.removeNodes(editor, {
+          at: ReactEditor.findPath(editor, element),
+          voids: true,
+        });
+      }
+      const path = ReactEditor.findPath(editor, element);
+      if (Editor.hasPath(editor, Path.next(path))) {
+        setTimeout(() => {
+          Transforms.select(editor, Path.next(path));
+        }, 0);
+      }
+    },
+    [editor, element],
+  );
 
   const onSave = useCallback(
     (data: CampaignBlockEmbedData) => {
@@ -99,7 +103,7 @@ const SlateCampaignBlock = ({ element, editor, attributes, children }: Props) =>
   );
 
   return (
-    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => setIsEditing(details.open)}>
+    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => onOpenChange(details.open)}>
       <EmbedWrapper {...attributes} data-testid="slate-campaign-block" contentEditable={false}>
         {!!campaignBlock && (
           <>
@@ -151,7 +155,7 @@ const SlateCampaignBlock = ({ element, editor, attributes, children }: Props) =>
               <DialogCloseButton />
             </DialogHeader>
             <DialogBody>
-              <CampaignBlockForm initialData={campaignBlock} onSave={onSave} onCancel={onClose} />
+              <CampaignBlockForm initialData={campaignBlock} onSave={onSave} />
             </DialogBody>
           </DialogContent>
         </Portal>

--- a/src/components/SlateEditor/plugins/comment/block/SlateCommentBlock.tsx
+++ b/src/components/SlateEditor/plugins/comment/block/SlateCommentBlock.tsx
@@ -105,14 +105,19 @@ const SlateCommentBlock = ({ attributes, editor, element, children }: Props) => 
   const onOpenChange = useCallback(
     (open: boolean) => {
       setModalOpen(open);
-      if (open === false) {
-        ReactEditor.focus(editor);
-        const path = ReactEditor.findPath(editor, element);
-        if (Editor.hasPath(editor, Path.next(path))) {
-          setTimeout(() => {
-            Transforms.select(editor, Path.next(path));
-          }, 0);
-        }
+      if (open) return;
+      ReactEditor.focus(editor);
+      if (element.isFirstEdit) {
+        Transforms.removeNodes(editor, {
+          at: ReactEditor.findPath(editor, element),
+          voids: true,
+        });
+      }
+      const path = ReactEditor.findPath(editor, element);
+      if (Editor.hasPath(editor, Path.next(path))) {
+        setTimeout(() => {
+          Transforms.select(editor, Path.next(path));
+        }, 0);
       }
     },
     [editor, element],

--- a/src/components/SlateEditor/plugins/concept/ConceptModalContent.tsx
+++ b/src/components/SlateEditor/plugins/concept/ConceptModalContent.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import {
   Button,
   DialogBody,
+  DialogCloseTrigger,
   DialogHeader,
   TabsContent,
   TabsIndicator,
@@ -46,7 +47,6 @@ interface Props {
   concept?: IConceptDTO;
   createConcept: (createdConcept: INewConceptDTO) => Promise<IConceptDTO>;
   handleRemove: () => void;
-  onClose: () => void;
   locale: string;
   selectedText?: string;
   subjects: Node[];
@@ -56,7 +56,6 @@ interface Props {
 }
 
 const ConceptModalContent = ({
-  onClose,
   subjects,
   locale,
   handleRemove,
@@ -128,7 +127,9 @@ const ConceptModalContent = ({
   return (
     <div>
       <DialogHeader>
-        <DialogCloseButton onClick={onClose} />
+        <DialogCloseTrigger asChild>
+          <DialogCloseButton />
+        </DialogCloseTrigger>
       </DialogHeader>
       <DialogBody>
         {!!concept?.id && <Button onClick={handleRemove}>{t(`form.content.${concept.conceptType}.remove`)}</Button>}
@@ -180,7 +181,6 @@ const ConceptModalContent = ({
                 <GlossForm
                   onUpserted={addConcept}
                   inModal
-                  onClose={onClose}
                   subjects={subjects}
                   upsertProps={upsertProps}
                   language={locale}
@@ -193,7 +193,6 @@ const ConceptModalContent = ({
                 <ConceptForm
                   onUpserted={addConcept}
                   inModal
-                  onClose={onClose}
                   subjects={subjects}
                   upsertProps={upsertProps}
                   language={locale}

--- a/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
@@ -123,25 +123,29 @@ const BlockWrapper = ({ element, editor, attributes, children }: Props) => {
     [editor, element],
   );
 
-  const onClose = useCallback(() => {
-    ReactEditor.focus(editor);
-    setIsEditing(false);
-    if (element.isFirstEdit) {
-      Transforms.removeNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      });
-    }
-    const path = ReactEditor.findPath(editor, element);
-    if (Editor.hasPath(editor, Path.next(path))) {
-      setTimeout(() => {
-        Transforms.select(editor, Path.next(path));
-      }, 0);
-    }
-  }, [editor, element]);
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      setIsEditing(open);
+      if (open) return;
+      ReactEditor.focus(editor);
+      if (element.isFirstEdit) {
+        Transforms.removeNodes(editor, {
+          at: ReactEditor.findPath(editor, element),
+          voids: true,
+        });
+      }
+      const path = ReactEditor.findPath(editor, element);
+      if (Editor.hasPath(editor, Path.next(path))) {
+        setTimeout(() => {
+          Transforms.select(editor, Path.next(path));
+        }, 0);
+      }
+    },
+    [editor, element],
+  );
 
   return (
-    <DialogRoot size="large" open={isEditing} onOpenChange={({ open }) => setIsEditing(open)}>
+    <DialogRoot size="large" open={isEditing} onOpenChange={({ open }) => onOpenChange(open)}>
       <StyledEmbedWrapper {...attributes} data-solid-border={isSelected} draggable={true} contentEditable={false}>
         {!!concept && !!embed && (
           <>
@@ -158,7 +162,6 @@ const BlockWrapper = ({ element, editor, attributes, children }: Props) => {
         )}
         <DialogContent>
           <ConceptModalContent
-            onClose={onClose}
             addConcept={addConcept}
             locale={locale}
             concept={concept}

--- a/src/components/SlateEditor/plugins/concept/inline/InlineWrapper.tsx
+++ b/src/components/SlateEditor/plugins/concept/inline/InlineWrapper.tsx
@@ -164,7 +164,9 @@ const InlineWrapper = (props: Props) => {
     });
   };
 
-  const onClose = () => {
+  const onOpenChange = (open: boolean) => {
+    setIsEditing(open);
+    if (open) return;
     if (!element.data.contentId) {
       handleRemove();
     } else {
@@ -253,10 +255,7 @@ const InlineWrapper = (props: Props) => {
       )}
       <DialogRoot
         open={isEditing}
-        onOpenChange={({ open }) => {
-          setIsEditing(open);
-          onClose();
-        }}
+        onOpenChange={(details) => onOpenChange(details.open)}
         onEscapeKeyDown={(e) => e.stopPropagation()}
         onExitComplete={() => ReactEditor.focus(editor)}
         size="large"
@@ -264,7 +263,6 @@ const InlineWrapper = (props: Props) => {
         <Portal>
           <DialogContent>
             <ConceptModalContent
-              onClose={onClose}
               addConcept={addConcept}
               locale={locale}
               concept={concept}

--- a/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/ContactBlockForm.tsx
@@ -28,6 +28,7 @@ import {
   CheckboxIndicator,
   CheckboxLabel,
   CheckboxHiddenInput,
+  DialogCloseTrigger,
 } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { ContactBlockEmbedData } from "@ndla/types-embed";
@@ -84,7 +85,6 @@ const rules: RulesType<ContactBlockFormValues> = {
 interface Props {
   initialData?: ContactBlockEmbedData;
   onSave: (data: ContactBlockEmbedData) => void;
-  onCancel: () => void;
 }
 
 const toInitialValues = (initialData?: ContactBlockEmbedData): ContactBlockFormValues => {
@@ -102,7 +102,7 @@ const toInitialValues = (initialData?: ContactBlockEmbedData): ContactBlockFormV
 };
 const colors: ContactBlockEmbedData["background"][] = ["subtle", "moderate", "strong"];
 
-const ContactBlockForm = ({ initialData, onSave, onCancel }: Props) => {
+const ContactBlockForm = ({ initialData, onSave }: Props) => {
   const { t } = useTranslation();
   const initialValues = useMemo(() => toInitialValues(initialData), [initialData]);
   const initialErrors = useMemo(() => validateFormik(initialValues, rules, t), [initialValues, t]);
@@ -233,9 +233,9 @@ const ContactBlockForm = ({ initialData, onSave, onCancel }: Props) => {
             </FormField>
           )}
           <FormActionsContainer>
-            <Button variant="secondary" onClick={onCancel}>
-              {t("cancel")}
-            </Button>
+            <DialogCloseTrigger asChild>
+              <Button variant="secondary">{t("cancel")}</Button>
+            </DialogCloseTrigger>
             <Button disabled={!dirty || !isValid} type="submit">
               {t("save")}
             </Button>

--- a/src/components/SlateEditor/plugins/contactBlock/SlateContactBlock.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/SlateContactBlock.tsx
@@ -45,9 +45,10 @@ const SlateContactBlock = ({ element, editor, attributes, children }: Props) => 
     setIsEditing(!!element.isFirstEdit);
   }, [element.isFirstEdit]);
 
-  const onClose = () => {
+  const onOpenChange = (open: boolean) => {
+    setIsEditing(open);
+    if (open) return;
     ReactEditor.focus(editor);
-    setIsEditing(false);
     if (element.isFirstEdit) {
       Transforms.removeNodes(editor, {
         at: ReactEditor.findPath(editor, element),
@@ -97,7 +98,7 @@ const SlateContactBlock = ({ element, editor, attributes, children }: Props) => 
     });
 
   return (
-    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => setIsEditing(details.open)}>
+    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => onOpenChange(details.open)}>
       <EmbedWrapper {...attributes} contentEditable={false} data-testid="slate-contact-block">
         {!!contactBlock && !!image && (
           <>
@@ -143,7 +144,7 @@ const SlateContactBlock = ({ element, editor, attributes, children }: Props) => 
             <DialogCloseButton />
           </DialogHeader>
           <DialogBody>
-            <ContactBlockForm initialData={contactBlock} onSave={onSave} onCancel={onClose} />
+            <ContactBlockForm initialData={contactBlock} onSave={onSave} />
           </DialogBody>
         </DialogContent>
       </Portal>

--- a/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/KeyFigureForm.tsx
@@ -18,6 +18,7 @@ import {
   CheckboxIndicator,
   CheckboxLabel,
   CheckboxRoot,
+  DialogCloseTrigger,
   FieldErrorMessage,
   FieldInput,
   FieldLabel,
@@ -39,7 +40,6 @@ import { RichTextIndicator } from "../../RichTextIndicator";
 interface Props {
   onSave: (data: KeyFigureEmbedData) => void;
   initialData: KeyFigureEmbedData;
-  onCancel: () => void;
 }
 
 interface KeyFigureFormValue {
@@ -82,7 +82,7 @@ const rules: RulesType<KeyFigureFormValue> = {
   },
 };
 
-const KeyFigureForm = ({ onSave, initialData, onCancel }: Props) => {
+const KeyFigureForm = ({ onSave, initialData }: Props) => {
   const { t } = useTranslation();
   const initialValues = useMemo(() => toInitialValues(initialData), [initialData]);
   const initialErrors = useMemo(() => validateFormik(initialValues, rules, t), [initialValues, t]);
@@ -177,9 +177,9 @@ const KeyFigureForm = ({ onSave, initialData, onCancel }: Props) => {
             </FormField>
           )}
           <FormActionsContainer>
-            <Button variant="secondary" onClick={onCancel}>
-              {t("cancel")}
-            </Button>
+            <DialogCloseTrigger asChild>
+              <Button variant="secondary">{t("cancel")}</Button>
+            </DialogCloseTrigger>
             <Button disabled={!isFormikFormDirty({ values, initialValues, dirty }) || !isValid} type="submit">
               {t("save")}
             </Button>

--- a/src/components/SlateEditor/plugins/keyFigure/SlateKeyFigure.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/SlateKeyFigure.tsx
@@ -53,9 +53,10 @@ const SlateKeyFigure = ({ element, editor, attributes, children }: Props) => {
     });
   };
 
-  const onClose = () => {
+  const onOpenChange = (open: boolean) => {
+    setIsEditing(open);
+    if (open) return;
     ReactEditor.focus(editor);
-    setIsEditing(false);
     if (element.isFirstEdit) {
       Transforms.removeNodes(editor, {
         at: ReactEditor.findPath(editor, element),
@@ -98,7 +99,7 @@ const SlateKeyFigure = ({ element, editor, attributes, children }: Props) => {
   }, [data?.imageId, setImage]);
 
   return (
-    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => setIsEditing(details.open)}>
+    <DialogRoot size="large" open={isEditing} onOpenChange={(details) => onOpenChange(details.open)}>
       <EmbedWrapper {...attributes} contentEditable={false} data-testid="slate-key-figure">
         {!!data && (
           <>
@@ -140,7 +141,7 @@ const SlateKeyFigure = ({ element, editor, attributes, children }: Props) => {
             <DialogCloseButton />
           </DialogHeader>
           <DialogBody>
-            <KeyFigureForm onSave={onSave} initialData={data} onCancel={onClose} />
+            <KeyFigureForm onSave={onSave} initialData={data} />
           </DialogBody>
         </DialogContent>
       </Portal>

--- a/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
@@ -47,7 +47,6 @@ interface Props {
   inModal: boolean;
   isNewlyCreated?: boolean;
   conceptArticles: IArticleDTO[];
-  onClose?: () => void;
   language: string;
   subjects: Node[];
   initialTitle?: string;
@@ -118,7 +117,6 @@ const ConceptForm = ({
   conceptChanged,
   inModal,
   isNewlyCreated = false,
-  onClose,
   subjects,
   language,
   upsertProps,
@@ -245,7 +243,6 @@ const ConceptForm = ({
               savedToServer={savedToServer}
               isNewlyCreated={isNewlyCreated}
               showSimpleFooter={!concept?.id}
-              onClose={onClose}
               responsibleId={concept?.responsible?.responsibleId}
             />
           </FormWrapper>

--- a/src/containers/ConceptPage/ConceptForm/ConceptFormFooter.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptFormFooter.tsx
@@ -8,7 +8,7 @@
 
 import { useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
-import { Button } from "@ndla/primitives";
+import { Button, DialogCloseTrigger } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { IStatusDTO } from "@ndla/types-backend/concept-api";
 import { FormActionsContainer } from "../../../components/FormikForm";
@@ -27,7 +27,6 @@ interface Props {
   savedToServer: boolean;
   isNewlyCreated: boolean;
   showSimpleFooter: boolean;
-  onClose?: () => void;
   responsibleId?: string;
 }
 
@@ -44,7 +43,6 @@ const ConceptFormFooter = ({
   savedToServer,
   isNewlyCreated,
   showSimpleFooter,
-  onClose,
   responsibleId,
 }: Props) => {
   const { t } = useTranslation();
@@ -63,9 +61,9 @@ const ConceptFormFooter = ({
   if (inModal) {
     return (
       <StyledFormActionsContainer>
-        <Button variant="secondary" onClick={onClose}>
-          {t("form.abort")}
-        </Button>
+        <DialogCloseTrigger asChild>
+          <Button variant="secondary">{t("form.abort")}</Button>
+        </DialogCloseTrigger>
         <SaveButton
           id={SAVE_BUTTON_ID}
           type={!inModal ? "submit" : "button"}

--- a/src/containers/GlossPage/components/GlossForm.tsx
+++ b/src/containers/GlossPage/components/GlossForm.tsx
@@ -48,7 +48,6 @@ interface Props {
   inModal: boolean;
   isNewlyCreated?: boolean;
   conceptArticles: IArticleDTO[];
-  onClose?: () => void;
   language: string;
   subjects: Node[];
   initialTitle?: string;
@@ -89,7 +88,6 @@ export const GlossForm = ({
   conceptChanged,
   inModal,
   isNewlyCreated = false,
-  onClose,
   subjects,
   language,
   upsertProps,
@@ -204,7 +202,6 @@ export const GlossForm = ({
             savedToServer={savedToServer}
             isNewlyCreated={isNewlyCreated}
             showSimpleFooter={!concept?.id}
-            onClose={onClose}
             responsibleId={concept?.responsible?.responsibleId}
           />
         </FormWrapper>


### PR DESCRIPTION
Ettersom onClose tidligere bare har blitt kjørt når man trykker på "Avbryt" så skjedde det ofte at slate-elementet faktisk ikke ble fjernet fra editor. Dette ser man ved å inspecte htmlen etter man har trykket på et av elementene i block picker også lukke dialogen ved å trykke utenfor. Denne fikser sånn at elementet alltid fjernes helt når dialogen lukkes!