### PR TITLE
Send isVisible to not filter invisible contexts for resources

### DIFF
--- a/src/containers/StructurePage/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePage/resourceComponents/StructureResources.tsx
@@ -65,6 +65,7 @@ const StructureResources = ({ currentChildNode, setCurrentNode, showQuality, use
       language: i18n.language,
       includeContexts: true,
       filterProgrammes: true,
+      isVisible: false,
       taxonomyVersion,
     },
     {

--- a/src/modules/nodes/nodeApi.ts
+++ b/src/modules/nodes/nodeApi.ts
@@ -103,11 +103,12 @@ export const fetchChildNodes = ({
   language,
   taxonomyVersion,
   includeContexts,
+  isVisible,
 }: ChildNodesGetParams): Promise<NodeChild[]> =>
   fetchAndResolve({
     url: `${baseUrl}/${id}/nodes`,
     taxonomyVersion,
-    queryParams: { recursive, nodeType, language, includeContexts },
+    queryParams: { recursive, nodeType, language, includeContexts, isVisible },
   });
 
 interface NodeTranslationsGetParams extends WithTaxonomyVersion {

--- a/src/modules/nodes/nodeApiTypes.ts
+++ b/src/modules/nodes/nodeApiTypes.ts
@@ -33,6 +33,7 @@ export interface GetChildNodesParams {
   recursive?: boolean;
   includeContexts?: boolean;
   filterProgrammes?: boolean;
+  isVisible?: boolean;
 }
 
 export interface GetNodeResourcesParams {
@@ -42,4 +43,5 @@ export interface GetNodeResourcesParams {
   type?: string;
   includeContexts?: boolean;
   filterProgrammes?: boolean;
+  isVisible?: boolean;
 }

--- a/src/modules/nodes/nodeQueries.ts
+++ b/src/modules/nodes/nodeQueries.ts
@@ -184,6 +184,7 @@ const fetchChildNodesWithArticleType = async ({
     language,
     recursive: true,
     nodeType,
+    isVisible: false,
   });
   if (childNodes.length === 0) return [];
 


### PR DESCRIPTION
isVisible defaulter til true, og dermed filtreres disse bort ved henting av noder. Men i struktur ønsker vi at alle kontekster skal vises og derfor må vi sende isVisible=false for å få til det.

Øverste fagstoff har to kontekster men en er usynlig så derfor vises ikkje advarsel om fleire kontekster: https://ed.test.ndla.no/structure/urn:subject:644e5655-75e5-49c3-9f5a-e2a98271bb3d/urn:topic:cc9689b4-94c3-40cd-8876-7f8111678b2e/urn:topic:2ad32cb8-c350-4680-bb03-a4c56c0c3f0c

På https://editorial-frontend-pr-2835.vercel.app/structure/urn:subject:644e5655-75e5-49c3-9f5a-e2a98271bb3d/urn:topic:cc9689b4-94c3-40cd-8876-7f8111678b2e/urn:topic:2ad32cb8-c350-4680-bb03-a4c56c0c3f0c så vises den med advarsel.

