### PR TITLE
Remove redundant keyboard logic for blockpicker

### DIFF
--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -205,9 +205,6 @@ const SlateBlockPicker = ({
     if (Location.isLocation(editor.selection)) {
       setLastActiveSelection(editor.selection);
     }
-    if (!editor.selection && lastActiveSelection) {
-      editor.selection = lastActiveSelection;
-    }
   }, [editor, editor.selection, lastActiveSelection]);
 
   const onOpenChange = useCallback(
@@ -310,7 +307,7 @@ const SlateBlockPicker = ({
         break;
       }
       case TYPE_GRID: {
-        onInsertBlock(defaultGridBlock());
+        onInsertBlock(defaultGridBlock(), true);
         break;
       }
       case TYPE_KEY_FIGURE: {


### PR DESCRIPTION
Dette løser de tilfeldige buggene hvor om du lagrer så kræsjer editoren.

Ser ut som koden er redundant da den ble introdusert i [denne](https://github.com/NDLANO/editorial-frontend/pull/2301) og det fungerer selv etter koden er slettet. 

Linje 310 skulle være med i en annen PR men den gjør bare at du setter fokus inn i grid når du setter inn en gridblock som er mer logisk. Så den kan stå. 