### PR TITLE
Standardises on remove logic to focus editor after editor transformation

### DIFF
--- a/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
@@ -79,10 +79,16 @@ const SlateAudio = ({ element, editor, attributes, children }: Props) => {
   );
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onClose = () => {

--- a/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/SlateCampaignBlock.tsx
@@ -89,14 +89,18 @@ const SlateCampaignBlock = ({ element, editor, attributes, children }: Props) =>
     }
   }, [campaignBlock?.imageId]);
 
-  const handleRemove = useCallback(
-    () =>
-      Transforms.removeNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      }),
-    [editor, element],
-  );
+  const handleRemove = useCallback(() => {
+    const path = ReactEditor.findPath(editor, element);
+    Transforms.removeNodes(editor, {
+      at: path,
+      voids: true,
+    });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
+  }, [editor, element]);
 
   return (
     <DialogRoot size="large" open={isEditing} onOpenChange={(details) => setIsEditing(details.open)}>

--- a/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/CodeBlock.tsx
@@ -116,10 +116,16 @@ const CodeBlock = ({ attributes, editor, element, children }: Props) => {
   };
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const handleClose = useCallback(() => {

--- a/src/components/SlateEditor/plugins/comment/CommentPopoverPortal.tsx
+++ b/src/components/SlateEditor/plugins/comment/CommentPopoverPortal.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Portal } from "@ark-ui/react";
 import { CloseLine, DeleteBinLine } from "@ndla/icons";
@@ -43,7 +44,7 @@ const ButtonContainer = styled("div", {
 interface Props {
   onSave: (data: CommentEmbedData) => void;
   embed: CommentMetaData | undefined;
-  onDelete: () => void;
+  onDelete: (e: MouseEvent) => void;
   onClose: () => void;
   onOpenChange: (v: boolean) => void;
   variant: "inline" | "block";

--- a/src/components/SlateEditor/plugins/comment/block/SlateCommentBlock.tsx
+++ b/src/components/SlateEditor/plugins/comment/block/SlateCommentBlock.tsx
@@ -93,14 +93,18 @@ const SlateCommentBlock = ({ attributes, editor, element, children }: Props) => 
     [editor, element],
   );
 
-  const onRemove = useCallback(
-    () =>
-      Transforms.unwrapNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      }),
-    [editor, element],
-  );
+  const onRemove = useCallback(() => {
+    const path = ReactEditor.findPath(editor, element);
+    Transforms.removeNodes(editor, {
+      at: path,
+      voids: true,
+    });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
+  }, [editor, element]);
 
   const onOpenChange = useCallback(
     (open: boolean) => {

--- a/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/BlockWrapper.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useState, ReactNode, useCallback, useMemo, useEffect } from "react";
+import { useState, ReactNode, useCallback, useMemo, useEffect, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Editor, Element, Transforms, Path } from "slate";
 import { ReactEditor, RenderElementProps, useSelected } from "slate-react";
@@ -114,14 +114,18 @@ const BlockWrapper = ({ element, editor, attributes, children }: Props) => {
     [locale, editor, element],
   );
 
-  const handleRemove = useCallback(
-    () =>
-      Transforms.removeNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      }),
-    [editor, element],
-  );
+  const handleRemove = useCallback(() => {
+    const path = ReactEditor.findPath(editor, element);
+    Transforms.removeNodes(editor, {
+      at: path,
+      voids: true,
+    });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    });
+  }, [editor, element]);
 
   const onClose = useCallback(() => {
     ReactEditor.focus(editor);
@@ -176,7 +180,7 @@ const BlockWrapper = ({ element, editor, attributes, children }: Props) => {
 
 interface ButtonContainerProps {
   concept: IConceptDTO | IConceptSummaryDTO;
-  handleRemove: () => void;
+  handleRemove: (e: MouseEvent) => void;
   language: string;
   editor: Editor;
   element: ConceptBlockElement;

--- a/src/components/SlateEditor/plugins/contactBlock/SlateContactBlock.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/SlateContactBlock.tsx
@@ -90,11 +90,18 @@ const SlateContactBlock = ({ element, editor, attributes, children }: Props) => 
     }
   }, [contactBlock?.imageId, setImage]);
 
-  const handleRemove = () =>
+  const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
+  };
 
   return (
     <DialogRoot size="large" open={isEditing} onOpenChange={(details) => setIsEditing(details.open)}>

--- a/src/components/SlateEditor/plugins/external/SlateExternal.tsx
+++ b/src/components/SlateEditor/plugins/external/SlateExternal.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Editor, Path, Transforms } from "slate";
+import { Editor, Element, Path, Transforms } from "slate";
 import { ReactEditor, RenderElementProps, useSelected } from "slate-react";
 import { Portal } from "@ark-ui/react";
 import { PencilFill, DeleteBinLine, ErrorWarningLine, ExpandUpDownLine } from "@ndla/icons";
@@ -28,7 +28,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { IframeEmbedData, IframeMetaData, OembedEmbedData, OembedMetaData } from "@ndla/types-embed";
 import { EmbedWrapper, ExternalEmbed, IframeEmbed } from "@ndla/ui";
 import { ExternalEmbedForm } from "./ExternalEmbedForm";
-import { ExternalElement, IframeElement } from "./types";
+import { ExternalElement, IframeElement, TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
 import { EXTERNAL_WHITELIST_PROVIDERS } from "../../../../constants";
 import { WhitelistProvider } from "../../../../interfaces";
 import { useExternalEmbed } from "../../../../modules/embed/queries";
@@ -135,14 +135,19 @@ export const SlateExternal = ({ element, editor, attributes, children }: Props) 
     [editor, element],
   );
 
-  const handleRemove = useCallback(
-    () =>
-      Transforms.removeNodes(editor, {
-        at: ReactEditor.findPath(editor, element),
-        voids: true,
-      }),
-    [editor, element],
-  );
+  const handleRemove = useCallback(() => {
+    const path = ReactEditor.findPath(editor, element);
+    Transforms.removeNodes(editor, {
+      at: path,
+      match: (node) => Element.isElement(node) && (node.type === TYPE_EXTERNAL || node.type === TYPE_IFRAME),
+      voids: true,
+    });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
+  }, [editor, element]);
 
   const onMouseDown = useCallback(() => {
     const onMouseMove = (e: MouseEvent) => {

--- a/src/components/SlateEditor/plugins/file/SlateFileList.tsx
+++ b/src/components/SlateEditor/plugins/file/SlateFileList.tsx
@@ -84,11 +84,15 @@ const SlateFileList = ({ element, editor, attributes, children }: Props) => {
 
   const removeFileList = () => {
     const path = ReactEditor.findPath(editor, element);
-    ReactEditor.focus(editor);
     Transforms.removeNodes(editor, {
       at: path,
       match: (node) => Element.isElement(node) && node.type === TYPE_FILE,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onDeleteFile = (indexToDelete: number) => {

--- a/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
+++ b/src/components/SlateEditor/plugins/h5p/SlateH5p.tsx
@@ -110,10 +110,16 @@ const SlateH5p = ({ element, editor, attributes, children }: Props) => {
   }, [embed, isCopied]);
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onSave = useCallback(

--- a/src/components/SlateEditor/plugins/image/SlateImage.tsx
+++ b/src/components/SlateEditor/plugins/image/SlateImage.tsx
@@ -107,10 +107,16 @@ const SlateImage = ({ element, editor, attributes, children, allowDecorative = t
   const embedWithoutCaching = useMemo(() => disableImageCache(embed), [embed]);
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onClose = () => {

--- a/src/components/SlateEditor/plugins/keyFigure/SlateKeyFigure.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/SlateKeyFigure.tsx
@@ -47,10 +47,16 @@ const SlateKeyFigure = ({ element, editor, attributes, children }: Props) => {
   const { data } = element;
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onClose = () => {

--- a/src/components/SlateEditor/plugins/pitch/SlatePitch.tsx
+++ b/src/components/SlateEditor/plugins/pitch/SlatePitch.tsx
@@ -46,10 +46,16 @@ const SlatePitch = ({ element, editor, attributes, children }: Props) => {
   }, [element.isFirstEdit]);
 
   const handleRemove = () => {
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       voids: true,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   };
 
   const onClose = () => {

--- a/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
+++ b/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
@@ -155,9 +155,11 @@ const RelatedArticleBox = ({ attributes, editor, element, children }: Props) => 
 
   const deleteElement = () => {
     const path = ReactEditor.findPath(editor, element);
-    ReactEditor.focus(editor);
-    Transforms.select(editor, path);
-    Transforms.removeNodes(editor, { at: path });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.removeNodes(editor, { at: path });
+    }, 0);
   };
 
   const updateArticles = (newEmbeds: RelatedContentMetaData[]) => {

--- a/src/components/SlateEditor/plugins/uuDisclaimer/SlateDisclaimer.tsx
+++ b/src/components/SlateEditor/plugins/uuDisclaimer/SlateDisclaimer.tsx
@@ -9,7 +9,7 @@
 import parse from "html-react-parser";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Editor, Element, Path, Transforms } from "slate";
+import { Editor, Element, Transforms } from "slate";
 import { ReactEditor, RenderElementProps } from "slate-react";
 import { Portal } from "@ark-ui/react";
 import { PencilFill } from "@ndla/icons";
@@ -84,9 +84,9 @@ const SlateDisclaimer = ({ attributes, children, element, editor }: Props) => {
         });
       }
       const path = ReactEditor.findPath(editor, element);
-      if (Editor.hasPath(editor, Path.next(path))) {
+      if (Editor.hasPath(editor, path)) {
         setTimeout(() => {
-          Transforms.select(editor, Path.next(path));
+          Transforms.select(editor, path);
         }, 0);
       }
     },
@@ -98,6 +98,7 @@ const SlateDisclaimer = ({ attributes, children, element, editor }: Props) => {
     Transforms.removeNodes(editor, {
       at: path,
       match: (node) => Element.isElement(node) && node.type === TYPE_DISCLAIMER,
+      voids: true,
     });
     setTimeout(() => {
       ReactEditor.focus(editor);
@@ -111,18 +112,18 @@ const SlateDisclaimer = ({ attributes, children, element, editor }: Props) => {
     Transforms.unwrapNodes(editor, {
       at: path,
       match: (node) => Element.isElement(node) && node.type === TYPE_DISCLAIMER,
+      voids: true,
     });
     setTimeout(() => {
       ReactEditor.focus(editor);
       Transforms.select(editor, path);
-      Transforms.collapse(editor);
+      Transforms.collapse(editor, { edge: "start" });
     }, 0);
   };
 
   const onSaveDisclaimerText = useCallback(
     (values: UuDisclaimerEmbedData) => {
       setModalOpen(false);
-      ReactEditor.focus(editor);
       const path = ReactEditor.findPath(editor, element);
       Transforms.setNodes(
         editor,
@@ -132,11 +133,9 @@ const SlateDisclaimer = ({ attributes, children, element, editor }: Props) => {
         },
         { at: path },
       );
-      if (Editor.hasPath(editor, Path.next(path))) {
-        setTimeout(() => {
-          Transforms.select(editor, Path.next(path));
-        }, 0);
-      }
+      setTimeout(() => {
+        Transforms.select(editor, path.concat(0));
+      }, 0);
     },
     [setModalOpen, editor, element],
   );

--- a/src/components/SlateEditor/plugins/video/SlateVideo.tsx
+++ b/src/components/SlateEditor/plugins/video/SlateVideo.tsx
@@ -52,11 +52,16 @@ const SlateVideo = ({ attributes, element, editor, children }: Props) => {
   const brightcoveQuery = useBrightcoveMeta(element.data?.videoid.split("&t=")[0] ?? "", i18n.language);
 
   const removeVideo = useCallback(() => {
-    ReactEditor.focus(editor);
+    const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
-      at: ReactEditor.findPath(editor, element),
+      at: path,
       match: (n) => Element.isElement(n) && n.type === TYPE_EMBED_BRIGHTCOVE,
     });
+    setTimeout(() => {
+      ReactEditor.focus(editor);
+      Transforms.select(editor, path);
+      Transforms.collapse(editor);
+    }, 0);
   }, [editor, element]);
 
   const embed: BrightcoveMetaData | undefined = useMemo(


### PR DESCRIPTION
Liten improvment for å returnere fokus mer "riktig" i editoren. Nå setter jeg slik at blokkene returnerer fokus rett etter blokkene på insert og på remove så settes den til pathen der elementet skulle vært. 