### PR TITLE
Grid: Adjust z-index to prevent overlapping block picker menu button

### DIFF
--- a/src/components/SlateEditor/plugins/grid/SlateGridCell.tsx
+++ b/src/components/SlateEditor/plugins/grid/SlateGridCell.tsx
@@ -23,7 +23,7 @@ interface Props extends RenderElementProps {
 const StyledIconButton = styled(IconButton, {
   base: {
     position: "absolute",
-    zIndex: "docked",
+    zIndex: "base",
     top: "4xsmall",
     right: "4xsmall",
   },


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4285