### PR TITLE
feat: add logging to defaultBlockNormalizer

### DIFF
--- a/src/components/SlateEditor/plugins/aside/index.tsx
+++ b/src/components/SlateEditor/plugins/aside/index.tsx
@@ -68,10 +68,10 @@ export const asidePlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_ASIDE) {
-      if (!defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return nextNormalizeNode(entry);
       }
     } else {

--- a/src/components/SlateEditor/plugins/audio/index.tsx
+++ b/src/components/SlateEditor/plugins/audio/index.tsx
@@ -46,9 +46,9 @@ export const audioPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_AUDIO) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/campaignBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/campaignBlock/index.tsx
@@ -54,9 +54,9 @@ export const campaignBlockPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_CAMPAIGN_BLOCK) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/codeBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/codeBlock/index.tsx
@@ -54,10 +54,10 @@ export const codeblockPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_CODEBLOCK) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/comment/block/index.tsx
+++ b/src/components/SlateEditor/plugins/comment/block/index.tsx
@@ -47,10 +47,10 @@ export const commentBlockPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_COMMENT_BLOCK) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/concept/block/index.tsx
+++ b/src/components/SlateEditor/plugins/concept/block/index.tsx
@@ -53,10 +53,10 @@ export const blockConceptPlugin = (editor: Editor) => {
   const { isVoid, normalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_CONCEPT_BLOCK) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/contactBlock/index.tsx
+++ b/src/components/SlateEditor/plugins/contactBlock/index.tsx
@@ -54,9 +54,9 @@ export const contactBlockPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_CONTACT_BLOCK) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/copyright/index.ts
+++ b/src/components/SlateEditor/plugins/copyright/index.ts
@@ -72,10 +72,10 @@ export const copyrightPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_COPYRIGHT) {
-      if (!defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return nextNormalizeNode(entry);
       }
     } else {

--- a/src/components/SlateEditor/plugins/definitionList/index.tsx
+++ b/src/components/SlateEditor/plugins/definitionList/index.tsx
@@ -111,15 +111,15 @@ export const definitionListPlugin = (editor: Editor) => {
         }
       }
 
-      if (defaultBlockNormalizer(editor, entry, normalizerDLConfig)) {
+      if (defaultBlockNormalizer(editor, node, nodepath, normalizerDLConfig)) {
         return;
       }
     } else if (Element.isElement(node) && node.type === TYPE_DEFINITION_TERM) {
-      if (defaultBlockNormalizer(editor, entry, normalizerDTConfig)) {
+      if (defaultBlockNormalizer(editor, node, nodepath, normalizerDTConfig)) {
         return;
       }
     } else if (Element.isElement(node) && node.type === TYPE_DEFINITION_DESCRIPTION) {
-      if (defaultBlockNormalizer(editor, entry, normalizerDDConfig)) {
+      if (defaultBlockNormalizer(editor, node, nodepath, normalizerDDConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/details/index.tsx
+++ b/src/components/SlateEditor/plugins/details/index.tsx
@@ -176,12 +176,12 @@ export const detailsPlugin = (editor: Editor) => {
 
     if (Element.isElement(node)) {
       if (node.type === TYPE_DETAILS) {
-        if (defaultBlockNormalizer(editor, entry, detailsNormalizerConfig)) {
+        if (defaultBlockNormalizer(editor, node, path, detailsNormalizerConfig)) {
           return;
         }
       }
       if (node.type === TYPE_SUMMARY) {
-        if (defaultBlockNormalizer(editor, entry, summaryNormalizerConfig)) {
+        if (defaultBlockNormalizer(editor, node, path, summaryNormalizerConfig)) {
           return;
         }
 

--- a/src/components/SlateEditor/plugins/embed/index.tsx
+++ b/src/components/SlateEditor/plugins/embed/index.tsx
@@ -55,10 +55,10 @@ export const embedPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (isSlateEmbed(node)) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
       return undefined;

--- a/src/components/SlateEditor/plugins/external/index.ts
+++ b/src/components/SlateEditor/plugins/external/index.ts
@@ -48,9 +48,9 @@ export const externalPlugin = (disableNormalize?: boolean) => (editor: Editor) =
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && (node.type === TYPE_EXTERNAL || node.type === TYPE_IFRAME)) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/file/index.tsx
+++ b/src/components/SlateEditor/plugins/file/index.tsx
@@ -69,10 +69,10 @@ export const filePlugin = (editor: Editor) => {
   };
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_FILE) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/framedContent/index.tsx
+++ b/src/components/SlateEditor/plugins/framedContent/index.tsx
@@ -75,10 +75,10 @@ export const framedContentPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_FRAMED_CONTENT) {
-      if (!defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return nextNormalizeNode(entry);
       }
     } else {

--- a/src/components/SlateEditor/plugins/grid/index.tsx
+++ b/src/components/SlateEditor/plugins/grid/index.tsx
@@ -130,11 +130,11 @@ export const gridPlugin = (editor: Editor) => {
         return;
       }
 
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     } else if (Element.isElement(node) && node.type === TYPE_GRID_CELL) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfigGridCell)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfigGridCell)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/h5p/index.tsx
+++ b/src/components/SlateEditor/plugins/h5p/index.tsx
@@ -46,9 +46,9 @@ export const h5pPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_H5P) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/image/index.ts
+++ b/src/components/SlateEditor/plugins/image/index.ts
@@ -46,9 +46,9 @@ export const imagePlugin = (disableNormalize?: boolean) => (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_IMAGE) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/keyFigure/index.tsx
+++ b/src/components/SlateEditor/plugins/keyFigure/index.tsx
@@ -57,9 +57,9 @@ export const keyFigurePlugin = (editor: Editor) => {
   const { normalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_KEY_FIGURE) {
-      if (!defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return normalizeNode(entry);
       }
     } else {

--- a/src/components/SlateEditor/plugins/linkBlockList/index.tsx
+++ b/src/components/SlateEditor/plugins/linkBlockList/index.tsx
@@ -64,10 +64,10 @@ export const linkBlockListPlugin = (editor: Editor) => {
   };
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_LINK_BLOCK_LIST) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/pitch/index.tsx
+++ b/src/components/SlateEditor/plugins/pitch/index.tsx
@@ -53,9 +53,9 @@ export const pitchPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_PITCH) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/related/index.tsx
+++ b/src/components/SlateEditor/plugins/related/index.tsx
@@ -87,10 +87,10 @@ export const relatedPlugin = (editor: Editor) => {
   };
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_RELATED) {
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/span/index.tsx
+++ b/src/components/SlateEditor/plugins/span/index.tsx
@@ -87,7 +87,7 @@ export const spanPlugin = (editor: Editor) => {
         return Transforms.removeNodes(editor, { at: path });
       }
 
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/plugins/table/index.tsx
+++ b/src/components/SlateEditor/plugins/table/index.tsx
@@ -261,7 +261,7 @@ export const tablePlugin = (editor: Editor) => {
         }
       }
       // v. Add surrounding paragraphs. Must be last since the table itself is not altered.
-      if (defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
 

--- a/src/components/SlateEditor/plugins/uuDisclaimer/index.ts
+++ b/src/components/SlateEditor/plugins/uuDisclaimer/index.ts
@@ -50,10 +50,10 @@ export const disclaimerPlugin = (editor: Editor) => {
   const { normalizeNode: nextNormalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
 
     if (Element.isElement(node) && node.type === TYPE_DISCLAIMER) {
-      if (!defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return nextNormalizeNode(entry);
       }
     } else {

--- a/src/components/SlateEditor/plugins/video/index.ts
+++ b/src/components/SlateEditor/plugins/video/index.ts
@@ -50,9 +50,9 @@ export const videoPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
   };
 
   editor.normalizeNode = (entry) => {
-    const [node] = entry;
+    const [node, path] = entry;
     if (Element.isElement(node) && node.type === TYPE_EMBED_BRIGHTCOVE) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, entry, normalizerConfig)) {
+      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
         return;
       }
     }

--- a/src/components/SlateEditor/utils/defaultNormalizer.ts
+++ b/src/components/SlateEditor/utils/defaultNormalizer.ts
@@ -39,6 +39,15 @@ const normalizeNodes = (
 ): boolean => {
   const children = element.children;
 
+  if (children.length === 0) {
+    const rule = config.firstNode || config.lastNode || config.nodes;
+    if (rule?.defaultType) {
+      logger?.log("Node has no children, inserting default type.");
+      editor.insertNodes(createNode(rule.defaultType), { at: path.concat(0) });
+      return true;
+    }
+  }
+
   for (const [index, child] of children.entries()) {
     // 1. If first node
     if (index === 0 && config.firstNode) {
@@ -126,15 +135,6 @@ const normalizeNodes = (
         editor.unwrapNodes({ at: path.concat(index) });
         return true;
       }
-    }
-  }
-
-  if (children.length === 0) {
-    const rule = config.firstNode || config.lastNode || config.nodes;
-    if (rule?.defaultType) {
-      logger?.log("Node has no children, inserting default type.");
-      editor.insertNodes(createNode(rule.defaultType), { at: path.concat(0) });
-      return true;
     }
   }
 

--- a/src/components/SlateEditor/utils/defaultNormalizer.ts
+++ b/src/components/SlateEditor/utils/defaultNormalizer.ts
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import { Editor, Element, NodeEntry, Path, Text, Transforms } from "slate";
+
+import { Editor, Element, Path, Text } from "slate";
 import { createNode } from "./normalizationHelpers";
 import { ElementType } from "../interfaces";
+import { isElementOfType, Logger } from "@ndla/editor";
 
 interface DefaultNodeRule {
   allowed: ElementType[];
@@ -28,110 +30,110 @@ export interface NormalizerConfig {
   nodes?: DefaultNodeRule;
 }
 
-const normalizeNodes = (editor: Editor, entry: NodeEntry, config: NormalizerConfig): boolean => {
-  const [node, path] = entry;
-
-  if (!Element.isElement(node)) return false;
-
-  const { firstNode, lastNode, nodes } = config;
-
-  const children = node.children;
+const normalizeNodes = (
+  editor: Editor,
+  element: Element,
+  path: Path,
+  config: NormalizerConfig,
+  logger?: Logger,
+): boolean => {
+  const children = element.children;
 
   for (const [index, child] of children.entries()) {
     // 1. If first node
-    if (index === 0 && firstNode) {
+    if (index === 0 && config.firstNode) {
       // a. Wrap text as default firstNode type
       if (Text.isText(child)) {
-        Transforms.wrapNodes(editor, createNode(firstNode.defaultType), {
-          at: [...path, 0],
-        });
+        logger?.log("First child is text, wrapping in default firstNode type.");
+        editor.wrapNodes(createNode(config.firstNode.defaultType), { at: path.concat(0) });
         return true;
         // first node is wrong and must be changed
-      } else if (!firstNode.allowed.includes(child.type)) {
+      } else if (!config.firstNode.allowed.includes(child.type)) {
         // b. If child is also an allowed lastNode. Insert default firstNode type before
-        if (children.length === 1 && lastNode && lastNode.allowed.includes(child.type)) {
-          Transforms.insertNodes(editor, createNode(firstNode.defaultType), {
-            at: [...path, 0],
-          });
+        if (children.length === 1 && config.lastNode?.allowed.includes(child.type)) {
+          logger?.log(
+            "Node only has one child, and it is allowed as a lastNode. Inserting default firstNode type as first child.",
+          );
+          editor.insertNodes(createNode(config.firstNode.defaultType), { at: path.concat(0) });
           return true;
         }
         // c. If child is allowed nodes type. Insert default firstNode type before.
-        else if (nodes && nodes.allowed.includes(child.type)) {
-          Transforms.insertNodes(editor, createNode(firstNode.defaultType), {
-            at: [...path, 0],
-          });
+        else if (config.nodes?.allowed.includes(child.type)) {
+          logger?.log(
+            "First node is allowed as a child, but not as the first child. Inserting default firstNode type as first child.",
+          );
+          editor.insertNodes(createNode(config.firstNode.defaultType), { at: path.concat(0) });
           return true;
           // d. Else: Unwrap child
         } else {
-          Transforms.unwrapNodes(editor, { at: [...path, 0] });
+          logger?.log("First node is incorrect, unwrapping.");
+          editor.unwrapNodes({ at: path.concat(0) });
           return true;
         }
       }
     }
     // 2. If last node
-    if (index === children.length - 1 && lastNode) {
+    if (index === children.length - 1 && config.lastNode) {
       // a. Wrap text as default firstNode type
       if (Text.isText(child)) {
-        Transforms.wrapNodes(editor, createNode(lastNode.defaultType), {
-          at: [...path, children.length - 1],
-        });
+        logger?.log("Last child is text, wrapping in default lastNode type.");
+        editor.wrapNodes(createNode(config.lastNode.defaultType), { at: path.concat(children.length - 1) });
         return true;
         // last node is wrong and must be changed
-      } else if (!lastNode.allowed.includes(child.type)) {
+      } else if (!config.lastNode.allowed.includes(child.type)) {
         // b. If child is allowed firstNode type. Insert default firstNode type after
-        if (children.length === 1 && firstNode && firstNode.allowed.includes(child.type)) {
-          Transforms.insertNodes(editor, createNode(lastNode.defaultType), {
-            at: [...path, children.length],
-          });
+        if (children.length === 1 && config.firstNode?.allowed.includes(child.type)) {
+          logger?.log(
+            "Node only has one child, and it is allowed as a firstNode. Inserting default lastNode type as last child.",
+          );
+          editor.insertNode(createNode(config.lastNode.defaultType), { at: path.concat(children.length) });
           return true;
         }
         // c. If child is allowed nodes type. Insert default lastNode type after.
-        else if (nodes && nodes.allowed.includes(child.type)) {
-          Transforms.insertNodes(editor, createNode(lastNode.defaultType), {
-            at: [...path, children.length],
-          });
+        else if (config.nodes?.allowed.includes(child.type)) {
+          logger?.log("Last node is allowed as a child, but not as the last child. Inserting default lastNode type.");
+          editor.insertNodes(createNode(config.lastNode.defaultType), { at: path.concat(children.length) });
           return true;
           // c. Else: Unwrap child
         } else {
-          Transforms.unwrapNodes(editor, {
-            at: [...path, children.length - 1],
-          });
+          logger?.log("Last node is incorrect, unwrapping.");
+          editor.unwrapNodes({ at: path.concat(children.length - 1) });
           return true;
         }
       }
     }
 
+    // TODO: Make this prettier
     // 3. If node is valid first or last node, skip next step
     if (
       Element.isElement(child) &&
-      ((index === 0 && firstNode && firstNode.allowed.includes(child.type)) ||
-        (index === children.length - 1 && lastNode && lastNode.allowed.includes(child.type)))
+      ((index === 0 && config.firstNode?.allowed.includes(child.type)) ||
+        (index === children.length - 1 && config.lastNode?.allowed.includes(child.type)))
     ) {
       continue;
     }
 
     // 4. Other nodes
-    if (nodes) {
+    if (config.nodes) {
       // a. Wrap if text
       if (Text.isText(child)) {
-        Transforms.wrapNodes(editor, createNode(nodes.defaultType), {
-          at: [...path, index],
-        });
+        logger?.log("Child is text, wrapping in default nodes type.");
+        editor.wrapNodes(createNode(config.nodes.defaultType), { at: path.concat(index) });
         return true;
         // b. Unwrap if incorrect
-      } else if (!nodes.allowed.includes(child.type)) {
-        Transforms.unwrapNodes(editor, { at: [...path, index] });
+      } else if (!config.nodes.allowed.includes(child.type)) {
+        logger?.log("Child is incorrect, unwrapping.");
+        editor.unwrapNodes({ at: path.concat(index) });
         return true;
       }
     }
   }
 
   if (children.length === 0) {
-    const rule = firstNode || lastNode || nodes;
+    const rule = config.firstNode || config.lastNode || config.nodes;
     if (rule?.defaultType) {
-      Transforms.insertNodes(editor, createNode(rule.defaultType), {
-        at: [...path, 0],
-      });
+      logger?.log("Node has no children, inserting default type.");
+      editor.insertNodes(createNode(rule.defaultType), { at: path.concat(0) });
       return true;
     }
   }
@@ -139,64 +141,59 @@ const normalizeNodes = (editor: Editor, entry: NodeEntry, config: NormalizerConf
   return false;
 };
 
-const normalizePrevious = (editor: Editor, entry: NodeEntry, settings: DefaultNodeRule): boolean => {
-  const [, path] = entry;
-  const { defaultType, allowed } = settings;
-
+const normalizePrevious = (editor: Editor, path: Path, config: DefaultNodeRule, logger?: Logger): boolean => {
   if (Path.hasPrevious(path)) {
-    const previousPath = Path.previous(path);
-
-    const [previousNode] = Editor.node(editor, previousPath);
+    const [previousNode] = editor.node(Path.previous(path));
 
     // 1. If previous element is incorrect, insert default element
-    if (!Element.isElement(previousNode) || !allowed.includes(previousNode.type)) {
-      Transforms.insertNodes(editor, createNode(defaultType), { at: path });
+    if (!isElementOfType(previousNode, config.allowed)) {
+      logger?.log("Previous sibling is incorrect, inserting default type.");
+      editor.insertNodes(createNode(config.defaultType), { at: path });
       return true;
     }
     // 2. If previous element does not exist, insert default element
   } else {
-    Transforms.insertNodes(editor, createNode(defaultType), { at: path });
+    logger?.log("Previous sibling does not exist, inserting default type.");
+    editor.insertNodes(createNode(config.defaultType), { at: path });
     return true;
   }
 
   return false;
 };
 
-const normalizeNext = (editor: Editor, entry: NodeEntry, settings: DefaultNodeRule): boolean => {
-  const [, path] = entry;
+const normalizeNext = (editor: Editor, path: Path, config: DefaultNodeRule, logger?: Logger): boolean => {
   const nextPath = Path.next(path);
-  const { defaultType, allowed } = settings;
 
   // 1. If next element is incorrect, insert default element
-  if (Editor.hasPath(editor, nextPath)) {
-    const [nextNode] = Editor.node(editor, nextPath);
-    if (!Element.isElement(nextNode) || !allowed.includes(nextNode.type)) {
-      Transforms.insertNodes(editor, createNode(defaultType), { at: nextPath });
+  if (editor.hasPath(nextPath)) {
+    const [nextNode] = editor.node(nextPath);
+
+    if (!isElementOfType(nextNode, config.allowed)) {
+      logger?.log("Next sibling is incorrect, inserting default type.");
+      editor.insertNodes(createNode(config.defaultType), { at: nextPath });
       return true;
     }
     // 2. If next element does not exist, insert default element
   } else {
-    Transforms.insertNodes(editor, createNode(defaultType), { at: nextPath });
+    logger?.log("Next sibling does not exist, inserting default type.");
+    editor.insertNodes(createNode(config.defaultType), { at: nextPath });
     return true;
   }
 
   return false;
 };
 
-const normalizeParent = (editor: Editor, entry: NodeEntry, settings: ParentNodeRule): boolean => {
-  const [, path] = entry;
-  const { defaultType, allowed } = settings;
-
-  const [parent] = Editor.node(editor, Path.parent(path));
+const normalizeParent = (editor: Editor, path: Path, config: ParentNodeRule, logger?: Logger): boolean => {
+  const [parent] = editor.node(Path.parent(path));
 
   // 1. If parent element is incorrect, change current node to default element
-  if (!Element.isElement(parent) || !allowed.includes(parent.type)) {
-    if (defaultType) {
-      Transforms.setNodes<Element>(editor, createNode(defaultType), {
-        at: path,
-      });
+  if (!isElementOfType(parent, config.allowed)) {
+    if (config.defaultType) {
+      logger?.log("Parent element is incorrect, changing to default type");
+      editor.setNodes<Element>(createNode(config.defaultType), { at: path });
     } else {
-      Transforms.unwrapNodes(editor, { at: path });
+      logger?.log("Parent element is incorrect, but no default type is set. Unwrapping");
+      editor.unwrapNodes({ at: path });
     }
     return true;
   }
@@ -204,25 +201,25 @@ const normalizeParent = (editor: Editor, entry: NodeEntry, settings: ParentNodeR
   return false;
 };
 
-export const defaultBlockNormalizer = (editor: Editor, entry: NodeEntry, config: NormalizerConfig): boolean => {
-  const [node] = entry;
-
-  if (!Element.isElement(node)) return false;
-
-  const { previous, next, firstNode, lastNode, nodes, parent } = config;
-
-  if (firstNode || nodes || lastNode) {
-    if (normalizeNodes(editor, entry, config)) {
+export const defaultBlockNormalizer = (
+  editor: Editor,
+  node: Element,
+  path: Path,
+  config: NormalizerConfig,
+  logger?: Logger,
+): boolean => {
+  if (config.firstNode || config.nodes || config.lastNode) {
+    if (normalizeNodes(editor, node, path, config, logger)) {
       return true;
     }
   }
-  if (parent && normalizeParent(editor, entry, parent)) {
+  if (config.parent && normalizeParent(editor, path, config.parent, logger)) {
     return true;
   }
-  if (previous && normalizePrevious(editor, entry, previous)) {
+  if (config.previous && normalizePrevious(editor, path, config.previous, logger)) {
     return true;
   }
-  if (next && normalizeNext(editor, entry, next)) {
+  if (config.next && normalizeNext(editor, path, config.next, logger)) {
     return true;
   }
 


### PR DESCRIPTION
Tilgi meg for alle filene, dette legger også til rette for at vi kan ta i bruk `defaultBlockNormalizer` med nye slate-plugins. 

Har egentlig ikke endret på logikken i `defaultBlockNormalizer`, jeg har bare forkortet koden litt. Når vi begynner å skrive våre gamle plugins om til `createPlugin` vil `defaultBlockNormalizer` logge mer og mer!