### PR TITLE
Struktur: småfikser

### DIFF
--- a/src/containers/StructurePage/resourceComponents/Resource.tsx
+++ b/src/containers/StructurePage/resourceComponents/Resource.tsx
@@ -89,12 +89,12 @@ interface Props {
   currentNodeId: string;
   responsible?: string;
   resource: ResourceWithNodeConnectionAndMeta;
-  contentMetaLoading: boolean;
+  nodeResourcesIsPending: boolean;
   showQuality: boolean;
   onDelete: (connectionId: string) => void;
 }
 
-const Resource = ({ currentNodeId, resource, contentMetaLoading, responsible, showQuality, onDelete }: Props) => {
+const Resource = ({ currentNodeId, resource, nodeResourcesIsPending, responsible, showQuality, onDelete }: Props) => {
   const { t, i18n } = useTranslation();
   const location = useLocation();
   const { taxonomyVersion } = useTaxonomyVersion();
@@ -152,7 +152,7 @@ const Resource = ({ currentNodeId, resource, contentMetaLoading, responsible, sh
               />
             )}
             <StatusIcons
-              contentMetaLoading={contentMetaLoading}
+              nodeResourcesIsPending={nodeResourcesIsPending}
               resource={resource}
               multipleTaxonomy={resource.contexts?.length > 1}
             />

--- a/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourceItems.tsx
@@ -35,14 +35,21 @@ interface Props {
   resources: ResourceWithNodeConnectionAndMeta[];
   currentNodeId: string;
   contentMeta: Dictionary<NodeResourceMeta>;
-  contentMetaLoading: boolean;
+  nodeResourcesIsPending: boolean;
   users?: Dictionary<Auth0UserData>;
   showQuality: boolean;
 }
 
 const isError = (error: unknown): error is Error => (error as Error).message !== undefined;
 
-const ResourceItems = ({ resources, currentNodeId, contentMeta, contentMetaLoading, users, showQuality }: Props) => {
+const ResourceItems = ({
+  resources,
+  currentNodeId,
+  contentMeta,
+  nodeResourcesIsPending,
+  users,
+  showQuality,
+}: Props) => {
   const { t, i18n } = useTranslation();
   const [deleteId, setDeleteId] = useState<string>("");
   const { taxonomyVersion } = useTaxonomyVersion();
@@ -80,7 +87,6 @@ const ResourceItems = ({ resources, currentNodeId, contentMeta, contentMetaLoadi
   const { mutateAsync: updateNodeResource } = usePutResourceForNodeMutation({
     onMutate: ({ id, body }) => onUpdateRank(id, body.rank as number),
     onError: (e) => handleError(e),
-    onSuccess: () => qc.invalidateQueries({ queryKey: compKey }),
   });
 
   const onDelete = async (deleteId: string) => {
@@ -130,7 +136,7 @@ const ResourceItems = ({ resources, currentNodeId, contentMeta, contentMetaLoadi
               contentMeta: resource.contentUri ? contentMeta[resource.contentUri] : undefined,
             }}
             key={resource.id}
-            contentMetaLoading={contentMetaLoading}
+            nodeResourcesIsPending={nodeResourcesIsPending}
             showQuality={showQuality}
             onDelete={toggleDelete}
           />

--- a/src/containers/StructurePage/resourceComponents/ResourcesContainer.tsx
+++ b/src/containers/StructurePage/resourceComponents/ResourcesContainer.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Spinner } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { NodeChild, ResourceType } from "@ndla/types-taxonomy";
@@ -34,7 +35,7 @@ interface Props {
   contentMeta: Dictionary<NodeResourceMeta>;
   grouped: boolean;
   setCurrentNode: (changedNode: NodeChild) => void;
-  contentMetaLoading: boolean;
+  nodeResourcesIsPending: boolean;
   showQuality: boolean;
   users: Dictionary<Auth0UserData> | undefined;
 }
@@ -45,10 +46,11 @@ const ResourcesContainer = ({
   contentMeta,
   grouped,
   setCurrentNode,
-  contentMetaLoading,
+  nodeResourcesIsPending,
   showQuality,
   users,
 }: Props) => {
+  const { t } = useTranslation();
   const resourceTypesWithoutMissing = useMemo(
     () => resourceTypes.filter((rt) => rt.id !== "missing").map((rt) => ({ id: rt.id, name: rt.name })),
     [resourceTypes],
@@ -89,14 +91,14 @@ const ResourcesContainer = ({
           resourceTypes: [],
           relevanceId: currentNode.relevanceId,
         }}
-        contentMetaLoading={contentMetaLoading}
+        nodeResourcesIsPending={nodeResourcesIsPending}
         responsible={currentMeta?.responsible ? users?.[currentMeta.responsible.responsibleId]?.name : undefined}
         topicNodes={data}
         showQuality={showQuality}
       />
       <ResourceWrapper>
-        {contentMetaLoading ? (
-          <Spinner />
+        {nodeResourcesIsPending ? (
+          <Spinner aria-label={t("loading")} />
         ) : grouped ? (
           mapping?.map((resource) => (
             <ResourceItems
@@ -104,7 +106,7 @@ const ResourcesContainer = ({
               resources={resource.resources}
               currentNodeId={currentNodeId}
               contentMeta={contentMeta}
-              contentMetaLoading={contentMetaLoading}
+              nodeResourcesIsPending={nodeResourcesIsPending}
               users={users}
               showQuality={showQuality}
             />
@@ -114,7 +116,7 @@ const ResourcesContainer = ({
             resources={nodeResources}
             currentNodeId={currentNodeId}
             contentMeta={contentMeta}
-            contentMetaLoading={contentMetaLoading}
+            nodeResourcesIsPending={nodeResourcesIsPending}
             users={users}
             showQuality={showQuality}
           />

--- a/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
+++ b/src/containers/StructurePage/resourceComponents/StatusIcons.tsx
@@ -32,12 +32,12 @@ const StyledErrorWarningFill = styled(ErrorWarningFill, {
 });
 
 interface Props {
-  contentMetaLoading: boolean;
+  nodeResourcesIsPending: boolean;
   resource: ResourceWithNodeConnectionAndMeta;
   multipleTaxonomy: boolean;
 }
 
-const StatusIcons = ({ contentMetaLoading, resource, multipleTaxonomy }: Props) => {
+const StatusIcons = ({ nodeResourcesIsPending, resource, multipleTaxonomy }: Props) => {
   const { t } = useTranslation();
   const approachingRevision = useMemo(
     () => isApproachingRevision(resource.contentMeta?.revisions),
@@ -65,7 +65,9 @@ const StatusIcons = ({ contentMetaLoading, resource, multipleTaxonomy }: Props) 
       {!!approachingRevision && !!warnStatus && !!expirationDate && (
         <StatusTimeFill variant={warnStatus} aria-label={expirationText} title={expirationText} />
       )}
-      {!contentMetaLoading && <WrongTypeError resource={resource} articleType={resource.contentMeta?.articleType} />}
+      {!nodeResourcesIsPending && (
+        <WrongTypeError resource={resource} articleType={resource.contentMeta?.articleType} />
+      )}
       {!!multipleTaxonomy && (
         <StyledErrorWarningFill
           aria-label={t("form.workflow.multipleTaxonomy")}

--- a/src/containers/StructurePage/resourceComponents/StructureResources.tsx
+++ b/src/containers/StructurePage/resourceComponents/StructureResources.tsx
@@ -8,7 +8,7 @@
 
 import { TFunction } from "i18next";
 import { keyBy } from "lodash-es";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { NodeChild, ResourceType } from "@ndla/types-taxonomy";
 import ResourcesContainer from "./ResourcesContainer";
@@ -59,7 +59,7 @@ const StructureResources = ({ currentChildNode, setCurrentNode, showQuality, use
   const { taxonomyVersion } = useTaxonomyVersion();
   const grouped = currentChildNode?.metadata?.customFields["topic-resources"] ?? "grouped";
 
-  const { data: nodeResources } = useResourcesWithNodeConnection(
+  const { data: nodeResources, isPending: nodeResourcesIsPending } = useResourcesWithNodeConnection(
     {
       id: currentChildNode.id,
       language: i18n.language,
@@ -70,11 +70,10 @@ const StructureResources = ({ currentChildNode, setCurrentNode, showQuality, use
     },
     {
       select: (resources) => resources.map((r) => (r.resourceTypes.length > 0 ? r : withMissing(r))),
-      placeholderData: [],
     },
   );
 
-  const { data: nodeResourceMetas, isLoading: contentMetaLoading } = useNodeResourceMetas(
+  const { data: nodeResourceMetas, isPending: contentMetaIsPending } = useNodeResourceMetas(
     {
       nodeId: currentChildNode.id,
       ids:
@@ -84,10 +83,10 @@ const StructureResources = ({ currentChildNode, setCurrentNode, showQuality, use
           .filter<string>((uri): uri is string => !!uri) ?? [],
       language: i18n.language,
     },
-    { enabled: !!currentChildNode.contentUri || !!nodeResources?.length },
+    { enabled: !!currentChildNode.contentUri || (!!nodeResources && !!nodeResources?.length) },
   );
 
-  const keyedMetas = keyBy(nodeResourceMetas, (m) => m.contentUri);
+  const keyedMetas = useMemo(() => keyBy(nodeResourceMetas, (m) => m.contentUri), [nodeResourceMetas]);
 
   const { data: resourceTypes } = useAllResourceTypes(
     { language: i18n.language, taxonomyVersion },
@@ -105,7 +104,7 @@ const StructureResources = ({ currentChildNode, setCurrentNode, showQuality, use
       contentMeta={keyedMetas}
       grouped={grouped === "grouped"}
       setCurrentNode={setCurrentNode}
-      contentMetaLoading={contentMetaLoading}
+      nodeResourcesIsPending={contentMetaIsPending || nodeResourcesIsPending}
       showQuality={showQuality}
       users={users}
     />

--- a/src/containers/StructurePage/resourceComponents/TopicResourceBanner.tsx
+++ b/src/containers/StructurePage/resourceComponents/TopicResourceBanner.tsx
@@ -9,7 +9,7 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { MessageLine, CheckboxCircleLine } from "@ndla/icons";
-import { Text } from "@ndla/primitives";
+import { Skeleton, Text } from "@ndla/primitives";
 import { SafeLink, SafeLinkIconButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { Node, NodeChild, ResourceType } from "@ndla/types-taxonomy";
@@ -127,7 +127,7 @@ interface Props {
   resources: ResourceWithNodeConnectionAndMeta[];
   resourceTypes: Pick<ResourceType, "id" | "name">[];
   articleIds?: number[];
-  contentMetaLoading: boolean;
+  nodeResourcesIsPending: boolean;
   responsible: string | undefined;
   topicNodes: Node[] | undefined;
   showQuality: boolean;
@@ -139,7 +139,7 @@ const TopicResourceBanner = ({
   onCurrentNodeChanged,
   resourceTypes,
   resources,
-  contentMetaLoading,
+  nodeResourcesIsPending,
   responsible,
   topicNodes,
   showQuality,
@@ -147,7 +147,7 @@ const TopicResourceBanner = ({
   const { t, i18n } = useTranslation();
   const { taxonomyVersion } = useTaxonomyVersion();
 
-  const elementCount = Object.values(contentMeta).length;
+  const elementCount = useMemo(() => Object.values(contentMeta).length, [contentMeta]);
   const workflowCount = useMemo(() => getWorkflowCount(contentMeta), [contentMeta]);
 
   const numericId = parseInt(currentNode.contentUri?.split(":").pop() ?? "");
@@ -170,9 +170,17 @@ const TopicResourceBanner = ({
           </ContentWrapper>
         )}
         <ContentWrapper>
-          <Text color="text.subtle" textStyle="label.small">{`${workflowCount}/${elementCount} ${t(
-            "taxonomy.workflow",
-          ).toLowerCase()}`}</Text>
+          {nodeResourcesIsPending ? (
+            <Skeleton aria-label={t("loading")}>
+              <Text color="text.subtle" textStyle="label.small">
+                {`${0}/${0} ${t("taxonomy.workflow").toLowerCase()}`}
+              </Text>
+            </Skeleton>
+          ) : (
+            <Text color="text.subtle" textStyle="label.small">{`${workflowCount}/${elementCount} ${t(
+              "taxonomy.workflow",
+            ).toLowerCase()}`}</Text>
+          )}
           {!!lastCommentTopicArticle && (
             <MessageLine
               title={stripInlineContentHtmlTags(lastCommentTopicArticle)}
@@ -211,7 +219,7 @@ const TopicResourceBanner = ({
             {!!isSupplementary && <SupplementaryIndicator />}
           </TextWrapper>
           <StatusIcons
-            contentMetaLoading={contentMetaLoading}
+            nodeResourcesIsPending={nodeResourcesIsPending}
             resource={currentNode}
             multipleTaxonomy={contexts?.length ? contexts.length > 1 : false}
           />


### PR DESCRIPTION
Noen småfikser:
- Tar i bruk isPending istedenfor isLoading (anbefalt i react-query docsen)
- Invaliderer ikke query på drag end, så slipper vi at spinner vises i det man slipper en ressurs
- Venter med å kjøre nodeResourceMeta-query til nodeResources-query har kjørt, så slipper vi at feil data vises for antall ressurser i flyt et lite øyeblikk
- Legger på shimmer for å indikere loading for antall i flyt (tenker det er bedre enn å vise 0/0 mens data hentes)