### PR TITLE
perf: debounce RichTextEditor onChange call

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@
 import config from "./config";
 import { WhitelistProvider } from "./interfaces";
 
+export const SAVE_DEBOUNCE_MS = 200;
+
 export const SAVE_BUTTON_ID = "editor-save-button";
 export const BLOCK_PICKER_TRIGGER_ID = "block-picker-trigger";
 

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
@@ -140,10 +140,7 @@ const InternalFormFooter = ({
     [articleChanged, dirty, initialValues, values],
   );
 
-  const onSave = useCallback(
-    (saveAsNew?: boolean) => handleSubmit(values, formik, saveAsNew),
-    [handleSubmit, values, formik],
-  );
+  const onSave = useCallback(() => handleSubmit(values, formik), [handleSubmit, values, formik]);
 
   usePreventWindowUnload(formIsDirty);
 

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useFormikContext } from "formik";
+import { useField, useFormikContext } from "formik";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LinkMedium } from "@ndla/icons";
@@ -45,9 +45,10 @@ import {
 import { TYPE_DISCLAIMER } from "../../../../components/SlateEditor/plugins/uuDisclaimer/types";
 import { TYPE_EMBED_BRIGHTCOVE } from "../../../../components/SlateEditor/plugins/video/types";
 import RichTextEditor from "../../../../components/SlateEditor/RichTextEditor";
-import { DRAFT_HTML_SCOPE } from "../../../../constants";
+import { DRAFT_HTML_SCOPE, SAVE_DEBOUNCE_MS } from "../../../../constants";
 import { isFormikFormDirty } from "../../../../util/formHelper";
 import { toCreateFrontPageArticle, toEditMarkup } from "../../../../util/routeHelpers";
+import { useDebouncedCallback } from "../../../../util/useDebouncedCallback";
 import { IngressField, TitleField, SlugField } from "../../../FormikForm";
 import { FrontpageArticleFormType } from "../../../FormikForm/articleFormHooks";
 import { useSession } from "../../../Session/SessionProvider";
@@ -93,6 +94,7 @@ const editorPlugins = frontpagePlugins.concat(frontpageRenderers);
 const FrontpageArticleFormContent = ({ articleLanguage }: Props) => {
   const { userPermissions } = useSession();
   const { t } = useTranslation();
+  const [field, meta, helpers] = useField("content");
 
   const { dirty, initialValues, values, isSubmitting } = useFormikContext<FrontpageArticleFormType>();
   const { slug, id, creators, language } = values;
@@ -110,6 +112,8 @@ const FrontpageArticleFormContent = ({ articleLanguage }: Props) => {
   const [isNormalizedOnLoad, setIsNormalizedOnLoad] = useState(isFormikDirty);
   const [isTouched, setIsTouched] = useState(false);
   const isCreatePage = toCreateFrontPageArticle() === window.location.pathname;
+
+  const debouncedOnChange = useDebouncedCallback(helpers.setValue, SAVE_DEBOUNCE_MS);
 
   useEffect(() => {
     setTimeout(() => {
@@ -164,37 +168,33 @@ const FrontpageArticleFormContent = ({ articleLanguage }: Props) => {
           </Button>
         </FormActionsContainer>
       </AlertDialog>
-      <FormField name="content">
-        {({ field, meta, helpers }) => (
-          <FieldRoot invalid={!!meta.error}>
-            <ContentTypeProvider value="subject-material">
-              <SegmentHeader>
-                <ContentEditableFieldLabel>{t("form.content.label")}</ContentEditableFieldLabel>
-                {!!id && !!userPermissions?.includes(DRAFT_HTML_SCOPE) && (
-                  <EditMarkupLink to={toEditMarkup(id, language ?? "")} title={t("editMarkup.linkTitle")} />
-                )}
-              </SegmentHeader>
-              <RichTextEditor
-                language={articleLanguage}
-                actions={frontpageActions}
-                toolbarOptions={toolbarOptions}
-                toolbarAreaFilters={toolbarAreaFilters}
-                blockpickerOptions={{
-                  actionsToShowInAreas,
-                }}
-                placeholder={t("form.content.placeholder")}
-                value={field.value}
-                submitted={isSubmitting}
-                plugins={editorPlugins}
-                data-testid="frontpage-article-content"
-                onChange={(value) => helpers.setValue(value)}
-              />
-            </ContentTypeProvider>
-            <FieldErrorMessage>{meta.error}</FieldErrorMessage>
-            <FieldWarning name={field.name} />
-          </FieldRoot>
-        )}
-      </FormField>
+      <FieldRoot invalid={!!meta.error}>
+        <ContentTypeProvider value="subject-material">
+          <SegmentHeader>
+            <ContentEditableFieldLabel>{t("form.content.label")}</ContentEditableFieldLabel>
+            {!!id && !!userPermissions?.includes(DRAFT_HTML_SCOPE) && (
+              <EditMarkupLink to={toEditMarkup(id, language ?? "")} title={t("editMarkup.linkTitle")} />
+            )}
+          </SegmentHeader>
+          <RichTextEditor
+            language={articleLanguage}
+            actions={frontpageActions}
+            toolbarOptions={toolbarOptions}
+            toolbarAreaFilters={toolbarAreaFilters}
+            blockpickerOptions={{
+              actionsToShowInAreas,
+            }}
+            placeholder={t("form.content.placeholder")}
+            value={field.value}
+            submitted={isSubmitting}
+            plugins={editorPlugins}
+            data-testid="frontpage-article-content"
+            onChange={debouncedOnChange}
+          />
+        </ContentTypeProvider>
+        <FieldErrorMessage>{meta.error}</FieldErrorMessage>
+        <FieldWarning name={field.name} />
+      </FieldRoot>
     </FormContent>
   );
 };

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -169,7 +169,7 @@ const FrontpageArticleFormContent = ({ articleLanguage }: Props) => {
         </FormActionsContainer>
       </AlertDialog>
       <FieldRoot invalid={!!meta.error}>
-        <ContentTypeProvider value="subject-material">
+        <ContentTypeProvider value="frontpage-article">
           <SegmentHeader>
             <ContentEditableFieldLabel>{t("form.content.label")}</ContentEditableFieldLabel>
             {!!id && !!userPermissions?.includes(DRAFT_HTML_SCOPE) && (

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -91,12 +91,12 @@ const LearningResourceForm = ({
   );
 
   const handleSubmit: HandleSubmitFunc<LearningResourceFormType> = useCallback(
-    async (values, helpers, saveAsNew) => {
+    async (values, helpers) => {
       if (!contexts?.length && values.status?.current !== ARCHIVED && values.status?.current !== UNPUBLISHED) {
         setShowTaxWarning(true);
         return;
       }
-      return await _handleSubmit(values, helpers, saveAsNew);
+      return await _handleSubmit(values, helpers);
     },
     [_handleSubmit, contexts?.length],
   );
@@ -212,12 +212,9 @@ const InternalFormFooter = ({
     [articleChanged, dirty, initialValues, values],
   );
 
-  const onSave = useCallback(
-    (saveAsNew?: boolean) => {
-      return handleSubmit(values, formik, saveAsNew);
-    },
-    [handleSubmit, values, formik],
-  );
+  const onSave = useCallback(() => {
+    return handleSubmit(values, formik);
+  }, [handleSubmit, values, formik]);
 
   usePreventWindowUnload(formIsDirty);
 

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleContent.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { useField } from "formik";
 import { useTranslation } from "react-i18next";
 import { FieldErrorMessage, FieldRoot } from "@ndla/primitives";
 import LastUpdatedLine from "./../../../../components/LastUpdatedLine/LastUpdatedLine";
@@ -23,8 +24,9 @@ import {
   createToolbarDefaultValues,
 } from "../../../../components/SlateEditor/plugins/toolbar/toolbarState";
 import RichTextEditor from "../../../../components/SlateEditor/RichTextEditor";
-import { DRAFT_HTML_SCOPE } from "../../../../constants";
+import { DRAFT_HTML_SCOPE, SAVE_DEBOUNCE_MS } from "../../../../constants";
 import { toEditMarkup } from "../../../../util/routeHelpers";
+import { useDebouncedCallback } from "../../../../util/useDebouncedCallback";
 import { IngressField, TitleField } from "../../../FormikForm";
 import { TopicArticleFormType } from "../../../FormikForm/articleFormHooks";
 import VisualElementField from "../../../FormikForm/components/VisualElementField";
@@ -41,8 +43,11 @@ interface Props {
 }
 
 const TopicArticleContent = ({ values, isSubmitting }: Props) => {
+  const [field, meta, helpers] = useField("content");
   const { t } = useTranslation();
   const { userPermissions } = useSession();
+
+  const debouncedOnChange = useDebouncedCallback(helpers.setValue, SAVE_DEBOUNCE_MS);
 
   return (
     <ContentTypeProvider value="topic">
@@ -62,31 +67,27 @@ const TopicArticleContent = ({ values, isSubmitting }: Props) => {
         </div>
         <IngressField />
         <VisualElementField types={["image"]} />
-        <FormField name="content">
-          {({ field, meta, helpers }) => (
-            <FieldRoot invalid={!!meta.error}>
-              <SegmentHeader>
-                <ContentEditableFieldLabel>{t("form.content.label")}</ContentEditableFieldLabel>
-                {!!values.id && !!userPermissions?.includes(DRAFT_HTML_SCOPE) && !!values.language && (
-                  <EditMarkupLink to={toEditMarkup(values.id, values.language)} title={t("editMarkup.linkTitle")} />
-                )}
-              </SegmentHeader>
-              <RichTextEditor
-                language={values.language}
-                placeholder={t("form.content.placeholder")}
-                value={field.value}
-                submitted={isSubmitting}
-                plugins={plugins}
-                hideBlockPicker
-                toolbarOptions={toolbarOptions}
-                toolbarAreaFilters={toolbarAreaFilters}
-                onChange={(value) => helpers.setValue(value)}
-              />
-              <FieldErrorMessage>{meta.error}</FieldErrorMessage>
-              <FieldWarning name={field.name} />
-            </FieldRoot>
-          )}
-        </FormField>
+        <FieldRoot invalid={!!meta.error}>
+          <SegmentHeader>
+            <ContentEditableFieldLabel>{t("form.content.label")}</ContentEditableFieldLabel>
+            {!!values.id && !!userPermissions?.includes(DRAFT_HTML_SCOPE) && !!values.language && (
+              <EditMarkupLink to={toEditMarkup(values.id, values.language)} title={t("editMarkup.linkTitle")} />
+            )}
+          </SegmentHeader>
+          <RichTextEditor
+            language={values.language}
+            placeholder={t("form.content.placeholder")}
+            value={field.value}
+            submitted={isSubmitting}
+            plugins={plugins}
+            hideBlockPicker
+            toolbarOptions={toolbarOptions}
+            toolbarAreaFilters={toolbarAreaFilters}
+            onChange={debouncedOnChange}
+          />
+          <FieldErrorMessage>{meta.error}</FieldErrorMessage>
+          <FieldWarning name={field.name} />
+        </FieldRoot>
       </FormContent>
     </ContentTypeProvider>
   );

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -91,12 +91,12 @@ const TopicArticleForm = ({
   const initialErrors = useMemo(() => validateFormik(initialValues, topicArticleRules, t), [initialValues, t]);
 
   const handleSubmit: HandleSubmitFunc<TopicArticleFormType> = useCallback(
-    async (values, helpers, saveAsNew) => {
+    async (values, helpers) => {
       if (!articleTaxonomy?.length && values.status?.current !== ARCHIVED && values.status?.current !== UNPUBLISHED) {
         setShowTaxWarning(true);
         return;
       }
-      return await _handleSubmit(values, helpers, saveAsNew);
+      return await _handleSubmit(values, helpers);
     },
     [_handleSubmit, articleTaxonomy?.length],
   );
@@ -169,11 +169,7 @@ interface FormFooterProps {
   article?: IArticleDTO;
   isNewlyCreated: boolean;
   savedToServer: boolean;
-  handleSubmit: (
-    values: TopicArticleFormType,
-    formikHelpers: FormikHelpers<TopicArticleFormType>,
-    saveAsNew?: boolean,
-  ) => Promise<void>;
+  handleSubmit: (values: TopicArticleFormType, formikHelpers: FormikHelpers<TopicArticleFormType>) => Promise<void>;
 }
 
 const InternalFormFooter = ({
@@ -201,10 +197,7 @@ const InternalFormFooter = ({
     [articleChanged, dirty, initialValues, values],
   );
 
-  const onSave = useCallback(
-    (saveAsNew?: boolean) => handleSubmit(values, formik, saveAsNew),
-    [handleSubmit, values, formik],
-  );
+  const onSave = useCallback(() => handleSubmit(values, formik), [handleSubmit, values, formik]);
 
   usePreventWindowUnload(formIsDirty);
 

--- a/src/containers/ArticlePage/articleTransformers.ts
+++ b/src/containers/ArticlePage/articleTransformers.ts
@@ -104,6 +104,7 @@ const draftApiTypeToArticleFormType = (
     comments: getCommentsDraftApiToArticleFormType(article, articleType),
     priority: article?.priority ?? "unspecified",
     disclaimer: inlineContentToEditorValue(article?.disclaimer?.disclaimer ?? "", true),
+    saveAsNew: false,
   };
 };
 

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -85,6 +85,7 @@ export interface ArticleFormType {
   processed: boolean;
   origin?: string;
   disclaimer?: Descendant[];
+  saveAsNew: boolean;
 }
 
 export interface LearningResourceFormType extends ArticleFormType {}
@@ -109,7 +110,7 @@ type HooksInputObject<T extends ArticleFormType> = {
   articleHistory: UseQueryResult<IArticleDTO[]> | undefined;
 };
 
-export type HandleSubmitFunc<T> = (values: T, formikHelpers: FormikHelpers<T>, saveAsNew?: boolean) => Promise<void>;
+export type HandleSubmitFunc<T> = (values: T, formikHelpers: FormikHelpers<T>) => Promise<void>;
 
 export function useArticleFormHooks<T extends ArticleFormType>({
   getInitialValues,
@@ -143,14 +144,14 @@ export function useArticleFormHooks<T extends ArticleFormType>({
   }, [articleLanguage, id]);
 
   const handleSubmit: HandleSubmitFunc<T> = useCallback(
-    async (values, formikHelpers, saveAsNew = false) => {
+    async (values, formikHelpers) => {
       formikHelpers.setSubmitting(true);
       const initialStatus = articleStatus?.current;
       const newStatus = values.status?.current;
       const statusChange = initialStatus !== newStatus;
       const slateArticle = getArticleFromSlate(values, initialValues, licenses!, false);
 
-      const newArticle = saveAsNew ? { ...slateArticle, createNewVersion: true } : slateArticle;
+      const newArticle = values.saveAsNew ? { ...slateArticle, createNewVersion: true } : slateArticle;
 
       let savedArticle: IArticleDTO;
       try {

--- a/src/util/useDebouncedCallback.ts
+++ b/src/util/useDebouncedCallback.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { debounce } from "lodash-es";
+import { useCallback, useEffect, useRef } from "react";
+import { SAVE_DEBOUNCE_MS } from "../constants";
+
+// Hook to debounce a function while ensuring cleanup on unmount
+export const useDebouncedCallback = (callback: (...args: any) => any, delay = SAVE_DEBOUNCE_MS) => {
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback; // Ensure latest callback is used
+  }, [callback]);
+
+  const debouncedFn = useRef(debounce((...args) => callbackRef.current(...args), delay)).current;
+
+  useEffect(() => {
+    return () => debouncedFn.cancel(); // Flush pending updates on unmount
+  }, [debouncedFn]);
+
+  return useCallback((...args: any) => debouncedFn(...args), [debouncedFn]);
+};


### PR DESCRIPTION
Dette er nok den største ytelsesforbedringen vi kan få i editoren. Debouncer `onChange`-kallet i 200ms, som tar en del arbeid av både valideringslogikken og formik. Ulempen med dette er at man i teorien kan lagre før verdien er flushet til formik. Vi kunne alternativt lagret et promise, og deretter ventet på at det resolvet før vi lagret? Hva tenker dere? Det er en ganske merkbar ytelsesforskjell på store artikler, f.eks http://localhost:3000/subject-matter/learning-resource/34220/edit/nb