### PR TITLE
Responsible combobox: Fallback to empty list when responsible does not exist

### DIFF
--- a/src/containers/FormikForm/components/ResponsibleSelect.tsx
+++ b/src/containers/FormikForm/components/ResponsibleSelect.tsx
@@ -78,7 +78,7 @@ const ResponsibleSelect = ({ responsible, onSave }: Props) => {
     setQuery(details.inputValue);
   }, []);
 
-  const value = useMemo(() => (responsible ? [responsible] : undefined), [responsible]);
+  const value = useMemo(() => (responsible ? [responsible] : []), [responsible]);
 
   return (
     <StyledComboboxRoot


### PR DESCRIPTION
fikser opp i:

>  En liten greie jeg så er at når man endrer status til publisert så må man refreshe siden for at ansvarlig-combobox skal oppdatere seg riktig