### PR TITLE
feat: add copy image functionality

### DIFF
--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { Form, Formik, useFormikContext } from "formik";
+import { Formik, useFormikContext } from "formik";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -27,7 +27,7 @@ import { useCloneImageMutation } from "../../modules/image/imageMutations";
 import { NdlaErrorPayload } from "../../util/resolveJsonOrRejectWithError";
 import { toEditImage } from "../../util/routeHelpers";
 import { DialogCloseButton } from "../DialogCloseButton";
-import { FormActionsContainer } from "../FormikForm";
+import { Form, FormActionsContainer } from "../FormikForm";
 import validateFormik from "../formikValidationSchema";
 
 interface Props {

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -24,7 +24,7 @@ import {
 import { styled } from "@ndla/styled-system/jsx";
 import { ImageUploadFormElement } from "../../containers/ImageUploader/components/ImageUploadFormElement";
 import { useMessages } from "../../containers/Messages/MessagesProvider";
-import * as imageApi from "../../modules/image/imageApi";
+import { cloneImage } from "../../modules/image/imageApi";
 import { NdlaErrorPayload } from "../../util/resolveJsonOrRejectWithError";
 import { toEditImage } from "../../util/routeHelpers";
 import { DialogCloseButton } from "../DialogCloseButton";
@@ -76,7 +76,7 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
     async (values: FormikValuesType) => {
       try {
         setUpdating(true);
-        const newImage = await imageApi.cloneImage(imageId, values.imageFile);
+        const newImage = await cloneImage(imageId, values.imageFile);
         navigate(toEditImage(newImage.id, newImage.title.language));
       } catch (e) {
         const err = e as NdlaErrorPayload;

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { Formik, useFormikContext } from "formik";
+import { Form, Formik, useFormikContext } from "formik";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -21,27 +21,19 @@ import {
   DialogTrigger,
   Text,
 } from "@ndla/primitives";
-import { styled } from "@ndla/styled-system/jsx";
 import { ImageUploadFormElement } from "../../containers/ImageUploader/components/ImageUploadFormElement";
 import { useMessages } from "../../containers/Messages/MessagesProvider";
 import { cloneImage } from "../../modules/image/imageApi";
 import { NdlaErrorPayload } from "../../util/resolveJsonOrRejectWithError";
 import { toEditImage } from "../../util/routeHelpers";
 import { DialogCloseButton } from "../DialogCloseButton";
-import { FormActionsContainer, FormContent } from "../FormikForm";
+import { FormActionsContainer } from "../FormikForm";
 import validateFormik from "../formikValidationSchema";
 
 interface Props {
   loading: boolean;
   imageId: number;
 }
-
-const StyledFormContent = styled(FormContent, {
-  base: {
-    marginInlineEnd: "large",
-    gap: "small",
-  },
-});
 
 interface FormikValuesType {
   imageFile: Blob | string | undefined;
@@ -110,7 +102,7 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
           >
             {({ dirty, submitForm }) => {
               return (
-                <StyledFormContent>
+                <Form>
                   <Text>{t("imageForm.copyDescription")}</Text>
                   <ImageUploadFormElement language={i18n.language} />
                   <FormActionsContainer>
@@ -118,7 +110,7 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
                       {t("save")}
                     </Button>
                   </FormActionsContainer>
-                </StyledFormContent>
+                </Form>
               );
             }}
           </Formik>

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -48,6 +48,9 @@ interface FormikValuesType {
 }
 
 const formikRules = { imageFile: { required: true } };
+const initialValues: FormikValuesType = {
+  imageFile: undefined,
+};
 
 export const CloneImageDialog = ({ loading, imageId }: Props) => {
   const { t, i18n } = useTranslation();
@@ -86,10 +89,6 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
     },
     [imageId, navigate, applicationError],
   );
-
-  const initialValues: FormikValuesType = {
-    imageFile: undefined,
-  };
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Formik, useFormikContext } from "formik";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { DialogOpenChangeDetails } from "@ark-ui/react";
+import {
+  DialogContent,
+  Button,
+  DialogBody,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+  DialogTrigger,
+  Text,
+} from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
+import { ImageUploadFormElement } from "../../containers/ImageUploader/components/ImageUploadFormElement";
+import { useMessages } from "../../containers/Messages/MessagesProvider";
+import * as imageApi from "../../modules/image/imageApi";
+import { NdlaErrorPayload } from "../../util/resolveJsonOrRejectWithError";
+import { toEditImage } from "../../util/routeHelpers";
+import { DialogCloseButton } from "../DialogCloseButton";
+import { FormActionsContainer, FormContent } from "../FormikForm";
+import validateFormik from "../formikValidationSchema";
+
+interface Props {
+  loading: boolean;
+  imageId: number;
+}
+
+const StyledFormContent = styled(FormContent, {
+  base: {
+    marginInlineEnd: "large",
+    gap: "small",
+  },
+});
+
+interface FormikValuesType {
+  imageFile: Blob | string | undefined;
+}
+
+const formikRules = { imageFile: { required: true } };
+
+export const CloneImageDialog = ({ loading, imageId }: Props) => {
+  const { t, i18n } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const { createMessage, applicationError } = useMessages();
+  const [updating, setUpdating] = useState(false);
+  const navigate = useNavigate();
+  const parentFormikContext = useFormikContext<unknown>();
+  const parentFormIsDirty = parentFormikContext.dirty;
+
+  const onOpenChange = useCallback((details: DialogOpenChangeDetails) => setOpen(details.open), []);
+  const handleSubmit = useCallback(
+    async (values: FormikValuesType) => {
+      try {
+        if (parentFormIsDirty) {
+          createMessage({
+            translationKey: "form.mustSaveFirst",
+            severity: "danger",
+            timeToLive: 0,
+          });
+        } else {
+          setUpdating(true);
+          const newImage = await imageApi.cloneImage(imageId, values.imageFile);
+          navigate(toEditImage(newImage.id, newImage.title.language));
+        }
+      } catch (e) {
+        const err = e as NdlaErrorPayload;
+        applicationError(err);
+        setUpdating(false);
+      }
+    },
+    [parentFormIsDirty, createMessage, imageId, navigate, applicationError],
+  );
+
+  const initialValues: FormikValuesType = {
+    imageFile: undefined,
+  };
+
+  return (
+    <DialogRoot open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="small" variant="tertiary" loading={loading}>
+          {t("form.workflow.saveAsNew")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("imageForm.copyImageTitle")}</DialogTitle>
+          <DialogCloseButton />
+        </DialogHeader>
+        <DialogBody>
+          <Text textStyle="label.small">{t("imageForm.copyDescription")}</Text>
+          <Formik
+            initialValues={initialValues}
+            initialErrors={{}}
+            onSubmit={handleSubmit}
+            validate={(values) => validateFormik(values, formikRules, t)}
+          >
+            {({ dirty, submitForm }) => {
+              return (
+                <StyledFormContent>
+                  <ImageUploadFormElement language={i18n.language} />
+                  <FormActionsContainer>
+                    <Button disabled={!dirty} loading={loading || updating} onClick={submitForm}>
+                      {t("save")}
+                    </Button>
+                  </FormActionsContainer>
+                </StyledFormContent>
+              );
+            }}
+          </Formik>
+        </DialogBody>
+      </DialogContent>
+    </DialogRoot>
+  );
+};

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -100,13 +100,13 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
             onSubmit={handleSubmit}
             validate={(values) => validateFormik(values, formikRules, t)}
           >
-            {({ dirty, submitForm }) => {
+            {({ dirty, submitForm, isValid }) => {
               return (
                 <Form>
                   <Text>{t("imageForm.copyDescription")}</Text>
                   <ImageUploadFormElement language={i18n.language} />
                   <FormActionsContainer>
-                    <Button disabled={!dirty} loading={loading || updating} onClick={submitForm}>
+                    <Button disabled={!dirty || !isValid} loading={loading || updating} onClick={submitForm}>
                       {t("save")}
                     </Button>
                   </FormActionsContainer>

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -103,7 +103,6 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
           <DialogCloseButton />
         </DialogHeader>
         <DialogBody>
-          <Text textStyle="label.small">{t("imageForm.copyDescription")}</Text>
           <Formik
             initialValues={initialValues}
             onSubmit={handleSubmit}
@@ -112,6 +111,7 @@ export const CloneImageDialog = ({ loading, imageId }: Props) => {
             {({ dirty, submitForm }) => {
               return (
                 <StyledFormContent>
+                  <Text>{t("imageForm.copyDescription")}</Text>
                   <ImageUploadFormElement language={i18n.language} />
                   <FormActionsContainer>
                     <Button disabled={!dirty} loading={loading || updating} onClick={submitForm}>

--- a/src/components/HeaderWithLanguage/HeaderInformation.tsx
+++ b/src/components/HeaderWithLanguage/HeaderInformation.tsx
@@ -14,6 +14,7 @@ import { Button, Heading } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { TaxonomyContext } from "@ndla/types-taxonomy";
 import { ContentTypeBadge, constants } from "@ndla/ui";
+import { CloneImageDialog } from "./CloneImageDialog";
 import HeaderStatusInformation from "./HeaderStatusInformation";
 import { useMessages } from "../../containers/Messages/MessagesProvider";
 import { fetchAuth0Users } from "../../modules/auth0/auth0Api";
@@ -152,11 +153,12 @@ const HeaderInformation = ({
             {title ?? t("form.createNew", { type: t(`contentTypes.${type}`) })}
           </Heading>
         )}
-        {(type === "standard" || type === "topic-article") && (
+        {(type === "standard" || type === "topic-article") && id ? (
           <Button size="small" variant="tertiary" onClick={onSaveAsNew} data-testid="saveAsNew" loading={loading}>
             {t("form.workflow.saveAsNew")}
           </Button>
-        )}
+        ) : null}
+        {type === "image" && id ? <CloneImageDialog imageId={id} loading={loading} /> : null}
       </StyledTitleHeaderWrapper>
       <HeaderStatusInformation
         noStatus={noStatus}

--- a/src/containers/ImageUploader/components/ImageContent.tsx
+++ b/src/containers/ImageUploader/components/ImageContent.tsx
@@ -6,49 +6,12 @@
  *
  */
 
-import { useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
-import { DeleteBinLine, UploadCloudLine } from "@ndla/icons";
-import { ImageMeta } from "@ndla/image-search";
-import {
-  Button,
-  FieldLabel,
-  FieldRoot,
-  FileUploadDropzone,
-  FileUploadHiddenInput,
-  FileUploadLabel,
-  FileUploadRoot,
-  FileUploadTrigger,
-  IconButton,
-  FieldErrorMessage,
-  FieldTextArea,
-} from "@ndla/primitives";
-import { SafeLink } from "@ndla/safelink";
-import { styled } from "@ndla/styled-system/jsx";
+import { FieldLabel, FieldRoot, FieldErrorMessage, FieldTextArea } from "@ndla/primitives";
+import { ImageUploadFormElement } from "./ImageUploadFormElement";
 import { FormField } from "../../../components/FormField";
 import { FormContent } from "../../../components/FormikForm";
-import { MAX_IMAGE_UPLOAD_SIZE } from "../../../constants";
 import { TitleField } from "../../FormikForm";
-import { ImageFormikType } from "../imageTransformers";
-
-const StyledImg = styled("img", {
-  base: {
-    borderRadius: "xsmall",
-  },
-});
-
-const StyledIconButton = styled(IconButton, {
-  base: {
-    position: "absolute",
-    right: "-large",
-  },
-});
-
-const ImageContentWrapper = styled("div", {
-  base: {
-    position: "relative",
-  },
-});
 
 interface Props {
   language: string;
@@ -56,106 +19,11 @@ interface Props {
 
 const ImageContent = ({ language }: Props) => {
   const { t } = useTranslation();
-  const formikContext = useFormikContext<ImageFormikType>();
-  const { values, setFieldValue } = formikContext;
-
-  // We use the timestamp to avoid caching of the `imageFile` url in the browser
-  const timestamp = new Date().getTime();
-  const imgSrc = values.filepath || `${values.imageFile}?width=800&ts=${timestamp}`;
 
   return (
     <FormContent>
       <TitleField hideToolbar />
-      <ImageContentWrapper>
-        {!values.imageFile && (
-          <FormField name="imageFile">
-            {({ helpers, meta }) => (
-              <FieldRoot required invalid={!!meta.error}>
-                <FileUploadRoot
-                  accept={["image/gif", "image/png", "image/jpeg", "image/jpg", "image/svg+xml"]}
-                  onFileAccept={(details) => {
-                    const file = details.files?.[0];
-                    if (!file) return;
-                    setFieldValue("filepath", URL.createObjectURL(file));
-                    Promise.resolve(
-                      createImageBitmap(file as Blob).then((image) => {
-                        setFieldValue("imageDimensions", image);
-                      }),
-                    );
-                    setFieldValue("imageFile", file);
-                    setFieldValue("contentType", file.type);
-                    setFieldValue("fileSize", file.size);
-                  }}
-                  maxFileSize={MAX_IMAGE_UPLOAD_SIZE}
-                  onFileReject={(details) => {
-                    // Bug in formik's setError function requiring setTimeout to make it work,
-                    // as discussed here: https://github.com/jaredpalmer/formik/discussions/3870
-                    const fileErrors = details.files?.[0]?.errors;
-                    if (!fileErrors) return;
-                    if (fileErrors.includes("FILE_TOO_LARGE")) {
-                      const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t("form.image.fileUpload.tooLargeError")}`;
-                      setTimeout(() => {
-                        helpers.setError(errorMessage);
-                      }, 0);
-                      return;
-                    }
-                    if (fileErrors.includes("FILE_INVALID_TYPE")) {
-                      const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t("form.image.fileUpload.fileTypeInvalidError")}`;
-                      setTimeout(() => {
-                        helpers.setError(errorMessage);
-                      }, 0);
-                      return;
-                    }
-                    setTimeout(() => {
-                      helpers.setError(t("form.image.fileUpload.genericError"));
-                    }, 0);
-                  }}
-                >
-                  <FileUploadDropzone>
-                    <FileUploadLabel>{t("form.image.fileUpload.description")}</FileUploadLabel>
-                    <FileUploadTrigger asChild>
-                      <Button>
-                        <UploadCloudLine />
-                        {t("form.image.fileUpload.button")}
-                      </Button>
-                    </FileUploadTrigger>
-                  </FileUploadDropzone>
-                  <FileUploadHiddenInput />
-                </FileUploadRoot>
-                <FieldErrorMessage>{meta.error}</FieldErrorMessage>
-              </FieldRoot>
-            )}
-          </FormField>
-        )}
-        {!!values.imageFile && (
-          <StyledIconButton
-            aria-label={t("form.image.removeImage")}
-            title={t("form.image.removeImage")}
-            variant="danger"
-            onClick={() => setFieldValue("imageFile", undefined)}
-            size="small"
-          >
-            <DeleteBinLine />
-          </StyledIconButton>
-        )}
-        {!!values.imageFile && (
-          <>
-            {typeof values.imageFile === "string" ? (
-              <SafeLink target="_blank" to={values.imageFile}>
-                <StyledImg src={imgSrc} alt="" srcSet="" />
-              </SafeLink>
-            ) : (
-              <StyledImg src={imgSrc} alt="" srcSet="" />
-            )}
-            <ImageMeta
-              contentType={values.contentType ?? ""}
-              fileSize={values.fileSize ?? 0}
-              imageDimensions={values.imageDimensions}
-              locale={language}
-            />
-          </>
-        )}
-      </ImageContentWrapper>
+      <ImageUploadFormElement language={language} />
       <FormField name="caption">
         {({ field, meta }) => (
           <FieldRoot invalid={!!meta.error}>

--- a/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
+++ b/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
@@ -35,7 +35,8 @@ const StyledImg = styled("img", {
 const StyledIconButton = styled(IconButton, {
   base: {
     position: "absolute",
-    right: "-large",
+    top: "xsmall",
+    right: "xsmall",
   },
 });
 

--- a/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
+++ b/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import { useFormikContext } from "formik";
+import { useTranslation } from "react-i18next";
+import { DeleteBinLine, UploadCloudLine } from "@ndla/icons";
+import { ImageMeta } from "@ndla/image-search";
+import {
+  Button,
+  FieldRoot,
+  FileUploadDropzone,
+  FileUploadHiddenInput,
+  FileUploadLabel,
+  FileUploadRoot,
+  FileUploadTrigger,
+  FieldErrorMessage,
+  IconButton,
+} from "@ndla/primitives";
+import { SafeLink } from "@ndla/safelink";
+import { styled } from "@ndla/styled-system/jsx";
+import { FormField } from "../../../components/FormField";
+import { MAX_IMAGE_UPLOAD_SIZE } from "../../../constants";
+import { ImageFormikType } from "../imageTransformers";
+
+const StyledImg = styled("img", {
+  base: {
+    borderRadius: "xsmall",
+  },
+});
+
+const StyledIconButton = styled(IconButton, {
+  base: {
+    position: "absolute",
+    right: "-large",
+  },
+});
+
+const ImageContentWrapper = styled("div", {
+  base: {
+    position: "relative",
+  },
+});
+
+interface Props {
+  language: string;
+}
+
+export const ImageUploadFormElement = ({ language }: Props) => {
+  const { t } = useTranslation();
+  const formikContext = useFormikContext<ImageFormikType>();
+  const { values, setFieldValue } = formikContext;
+
+  // We use the timestamp to avoid caching of the `imageFile` url in the browser
+  const timestamp = new Date().getTime();
+  const imgSrc = values.filepath || `${values.imageFile}?width=800&ts=${timestamp}`;
+
+  return (
+    <ImageContentWrapper>
+      {!values.imageFile && (
+        <FormField name="imageFile">
+          {({ helpers, meta }) => (
+            <FieldRoot required invalid={!!meta.error}>
+              <FileUploadRoot
+                accept={["image/gif", "image/png", "image/jpeg", "image/jpg", "image/svg+xml"]}
+                onFileAccept={(details) => {
+                  const file = details.files?.[0];
+                  if (!file) return;
+                  setFieldValue("filepath", URL.createObjectURL(file));
+                  Promise.resolve(
+                    createImageBitmap(file as Blob).then((image) => {
+                      setFieldValue("imageDimensions", image);
+                    }),
+                  );
+                  setFieldValue("imageFile", file);
+                  setFieldValue("contentType", file.type);
+                  setFieldValue("fileSize", file.size);
+                }}
+                maxFileSize={MAX_IMAGE_UPLOAD_SIZE}
+                onFileReject={(details) => {
+                  // Bug in formik's setError function requiring setTimeout to make it work,
+                  // as discussed here: https://github.com/jaredpalmer/formik/discussions/3870
+                  const fileErrors = details.files?.[0]?.errors;
+                  if (!fileErrors) return;
+                  if (fileErrors.includes("FILE_TOO_LARGE")) {
+                    const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t("form.image.fileUpload.tooLargeError")}`;
+                    setTimeout(() => {
+                      helpers.setError(errorMessage);
+                    }, 0);
+                    return;
+                  }
+                  if (fileErrors.includes("FILE_INVALID_TYPE")) {
+                    const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t("form.image.fileUpload.fileTypeInvalidError")}`;
+                    setTimeout(() => {
+                      helpers.setError(errorMessage);
+                    }, 0);
+                    return;
+                  }
+                  setTimeout(() => {
+                    helpers.setError(t("form.image.fileUpload.genericError"));
+                  }, 0);
+                }}
+              >
+                <FileUploadDropzone>
+                  <FileUploadLabel>{t("form.image.fileUpload.description")}</FileUploadLabel>
+                  <FileUploadTrigger asChild>
+                    <Button>
+                      <UploadCloudLine />
+                      {t("form.image.fileUpload.button")}
+                    </Button>
+                  </FileUploadTrigger>
+                </FileUploadDropzone>
+                <FileUploadHiddenInput />
+              </FileUploadRoot>
+              <FieldErrorMessage>{meta.error}</FieldErrorMessage>
+            </FieldRoot>
+          )}
+        </FormField>
+      )}
+      {!!values.imageFile && (
+        <StyledIconButton
+          aria-label={t("form.image.removeImage")}
+          title={t("form.image.removeImage")}
+          variant="danger"
+          onClick={() => setFieldValue("imageFile", undefined)}
+          size="small"
+        >
+          <DeleteBinLine />
+        </StyledIconButton>
+      )}
+      {!!values.imageFile && (
+        <>
+          {typeof values.imageFile === "string" ? (
+            <SafeLink target="_blank" to={values.imageFile}>
+              <StyledImg src={imgSrc} alt="" srcSet="" />
+            </SafeLink>
+          ) : (
+            <StyledImg src={imgSrc} alt="" srcSet="" />
+          )}
+          <ImageMeta
+            contentType={values.contentType ?? ""}
+            fileSize={values.fileSize ?? 0}
+            imageDimensions={values.imageDimensions}
+            locale={language}
+          />
+        </>
+      )}
+    </ImageContentWrapper>
+  );
+};

--- a/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
+++ b/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
@@ -70,6 +70,8 @@ export const ImageUploadFormElement = ({ language }: Props) => {
                 onFileAccept={(details) => {
                   const file = details.files?.[0];
                   if (!file) return;
+                  // TODO: Make consumers handle field values themselves
+                  //       https://github.com/NDLANO/editorial-frontend/pull/2891#discussion_r1991020617
                   setFieldValue("filepath", URL.createObjectURL(file));
                   Promise.resolve(
                     createImageBitmap(file as Blob).then((image) => {

--- a/src/modules/image/imageApi.ts
+++ b/src/modules/image/imageApi.ts
@@ -21,6 +21,7 @@ import {
   throwErrorPayload,
 } from "../../util/apiHelpers";
 import { resolveJsonOrVoidOrRejectWithError } from "../../util/resolveJsonOrRejectWithError";
+import { createFormData } from "../../util/formDataHelper";
 
 const baseUrl = apiResourceUrl("/image-api/v3/images");
 
@@ -67,4 +68,18 @@ export const deleteLanguageVersionImage = (
 export const fetchSearchTags = async (input: string, language: string): Promise<ITagsSearchResultDTO> => {
   const response = await fetchAuthorized(`${baseUrl}/tag-search/?language=${language}&query=${input}`);
   return resolveJsonOrRejectWithError(response);
+};
+
+export const cloneImage = async (
+  imageId: number,
+  file: Blob | string | undefined,
+): Promise<IImageMetaInformationV3DTO> => {
+  const formData = await createFormData(file);
+  const result = await fetchAuthorized(`${baseUrl}/${imageId}/copy`, {
+    method: "POST",
+    headers: { "Content-Type": undefined }, // Without this we're missing a boundary: https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post
+    body: formData,
+  });
+
+  return resolveJsonOrRejectWithError<IImageMetaInformationV3DTO>(result);
 };

--- a/src/modules/image/imageMutations.ts
+++ b/src/modules/image/imageMutations.ts
@@ -10,12 +10,15 @@ import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { IImageMetaInformationV3DTO } from "@ndla/types-backend/image-api";
 import { cloneImage } from "./imageApi";
 
+interface CloneImageInput {
+  imageId: number;
+  imageFile: Blob | string | undefined;
+}
+
 export const useCloneImageMutation = (
-  options?: Partial<
-    UseMutationOptions<IImageMetaInformationV3DTO, unknown, { imageId: number; imageFile: Blob | string | undefined }>
-  >,
+  options?: Partial<UseMutationOptions<IImageMetaInformationV3DTO, unknown, CloneImageInput>>,
 ) => {
-  return useMutation<IImageMetaInformationV3DTO, unknown, { imageId: number; imageFile: Blob | string | undefined }>({
+  return useMutation<IImageMetaInformationV3DTO, unknown, CloneImageInput>({
     mutationFn: (vars) => cloneImage(vars.imageId, vars.imageFile),
     ...options,
   });

--- a/src/modules/image/imageMutations.ts
+++ b/src/modules/image/imageMutations.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useMutation, UseMutationOptions } from "@tanstack/react-query";
+import { IImageMetaInformationV3DTO } from "@ndla/types-backend/image-api";
+import { cloneImage } from "./imageApi";
+
+export const useCloneImageMutation = (
+  options?: Partial<
+    UseMutationOptions<IImageMetaInformationV3DTO, unknown, { imageId: number; imageFile: Blob | string | undefined }>
+  >,
+) => {
+  return useMutation<IImageMetaInformationV3DTO, unknown, { imageId: number; imageFile: Blob | string | undefined }>({
+    mutationFn: (vars) => cloneImage(vars.imageId, vars.imageFile),
+    ...options,
+  });
+};

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -618,7 +618,7 @@ const phrases = {
   imageForm: {
     title: "Image",
     copyImageTitle: "Upload image as copy",
-    copyDescription: "Upload a image with the same information as the current image",
+    copyDescription: "Upload an image with the same information as the current image",
   },
   contactBlockForm: {
     title: "Contact block",

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -617,6 +617,8 @@ const phrases = {
   },
   imageForm: {
     title: "Image",
+    copyImageTitle: "Upload image as copy",
+    copyDescription: "Upload a image with the same information as the current image",
   },
   contactBlockForm: {
     title: "Contact block",

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -617,7 +617,7 @@ const phrases = {
   imageForm: {
     title: "Bilde",
     copyImageTitle: "Last opp bilde som kopi",
-    copyDescription: "Last opp et bilde med samme informasjonen som dette bildet",
+    copyDescription: "Last opp et bilde med samme informasjon som dette bildet",
   },
   contactBlockForm: {
     title: "Kontaktblokk",

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -616,6 +616,8 @@ const phrases = {
   },
   imageForm: {
     title: "Bilde",
+    copyImageTitle: "Last opp bilde som kopi",
+    copyDescription: "Last opp et bilde med samme informasjonen som dette bildet",
   },
   contactBlockForm: {
     title: "Kontaktblokk",

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -617,7 +617,7 @@ const phrases = {
   imageForm: {
     title: "Bilete ",
     copyImageTitle: "Last opp bilete som kopi",
-    copyDescription: "Last opp eit bilete med same informasjonen som dette biletet",
+    copyDescription: "Last opp eit bilete med same informasjon som dette biletet",
   },
   contactBlockForm: {
     title: "Kontaktblokk",

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -616,6 +616,8 @@ const phrases = {
   },
   imageForm: {
     title: "Bilete ",
+    copyImageTitle: "Last opp bilete som kopi",
+    copyDescription: "Last opp eit bilete med same informasjonen som dette biletet",
   },
   contactBlockForm: {
     title: "Kontaktblokk",


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4290
Depends on https://github.com/NDLANO/backend/pull/619

Legger til en liten knapp i toppen av header for bilder på samme måte som for artikler.
Denne knappen åpner en ~~modal~~ dialog som lar deg laste opp et bilde med samme informasjon som bildet du står i.