### PR TITLE
feat: unique IDs for slate block nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jwt-decode": "^4.0.0",
     "lodash-es": "^4.17.21",
     "monaco-editor": "0.47.0",
+    "nanoid": "^5.1.2",
     "p-limit": "^6.2.0",
     "prettier": "^3.5.3",
     "prismjs": "^1.29.0",

--- a/src/__tests__/vitest.setup.ts
+++ b/src/__tests__/vitest.setup.ts
@@ -9,6 +9,8 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 
+export const anySlateElementId = expect.any(String);
+
 afterEach(() => {
   cleanup();
 });

--- a/src/components/SlateEditor/interfaces.ts
+++ b/src/components/SlateEditor/interfaces.ts
@@ -75,60 +75,62 @@ export interface CustomEditor extends _CustomEditor {
   shouldHideBlockPicker?: () => boolean | undefined;
 }
 
+type CustomElement =
+  | ParagraphElement
+  | SectionElement
+  | BreakElement
+  | LinkElement
+  | ContentLinkElement
+  | BlockQuoteElement
+  | HeadingElement
+  | ListElement
+  | ListItemElement
+  | FootnoteElement
+  | MathmlElement
+  | ConceptInlineElement
+  | ConceptBlockElement
+  | AsideElement
+  | FileElement
+  | DetailsElement
+  | SummaryElement
+  | CodeBlockElement
+  | TableElement
+  | TableCaptionElement
+  | TableRowElement
+  | TableCellElement
+  | TableHeadElement
+  | TableBodyElement
+  | RelatedElement
+  | BrightcoveEmbedElement
+  | AudioElement
+  | ImageElement
+  | ErrorEmbedElement
+  | H5pElement
+  | FramedContentElement
+  | DivElement
+  | SpanElement
+  | DefinitionListElement
+  | DefinitionDescriptionElement
+  | DefinitionTermElement
+  | PitchElement
+  | GridElement
+  | GridCellElement
+  | KeyFigureElement
+  | ContactBlockElement
+  | CampaignBlockElement
+  | LinkBlockListElement
+  | DisclaimerElement
+  | NoopElement
+  | ExternalElement
+  | IframeElement
+  | CopyrightElement
+  | CommentInlineElement
+  | CommentBlockElement;
+
 declare module "slate" {
   interface CustomTypes {
     Editor: BaseEditor & ReactEditor & HistoryEditor & CustomEditor;
-    Element:
-      | ParagraphElement
-      | SectionElement
-      | BreakElement
-      | LinkElement
-      | ContentLinkElement
-      | BlockQuoteElement
-      | HeadingElement
-      | ListElement
-      | ListItemElement
-      | FootnoteElement
-      | MathmlElement
-      | ConceptInlineElement
-      | ConceptBlockElement
-      | AsideElement
-      | FileElement
-      | DetailsElement
-      | SummaryElement
-      | CodeBlockElement
-      | TableElement
-      | TableCaptionElement
-      | TableRowElement
-      | TableCellElement
-      | TableHeadElement
-      | TableBodyElement
-      | RelatedElement
-      | BrightcoveEmbedElement
-      | AudioElement
-      | ImageElement
-      | ErrorEmbedElement
-      | H5pElement
-      | FramedContentElement
-      | DivElement
-      | SpanElement
-      | DefinitionListElement
-      | DefinitionDescriptionElement
-      | DefinitionTermElement
-      | PitchElement
-      | GridElement
-      | GridCellElement
-      | KeyFigureElement
-      | ContactBlockElement
-      | CampaignBlockElement
-      | LinkBlockListElement
-      | DisclaimerElement
-      | NoopElement
-      | ExternalElement
-      | IframeElement
-      | CopyrightElement
-      | CommentInlineElement
-      | CommentBlockElement;
+    Element: CustomElement & { id?: string };
     Text: CustomTextWithMarks;
   }
 }

--- a/src/components/SlateEditor/plugins/aside/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/aside/__tests__/normalizer-test.ts
@@ -14,6 +14,7 @@ import { TYPE_LINK } from "../../link/types";
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { ASIDE_ELEMENT_TYPE } from "../asideTypes";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -45,26 +46,30 @@ describe("aside normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -89,14 +94,16 @@ describe("aside normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "" }] }],
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -121,17 +128,19 @@ describe("aside normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
             children: [
-              { type: TYPE_HEADING, level: 1, children: [{ text: "content" }] },
-              { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+              { type: TYPE_HEADING, id: anySlateElementId, level: 1, children: [{ text: "content" }] },
+              { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
             ],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -164,14 +173,16 @@ describe("aside normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: ASIDE_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: { type: "factAside" },
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/codeBlock/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/codeBlock/__tests__/normalizer-test.ts
@@ -10,6 +10,7 @@ import { Descendant } from "slate";
 import { createSlate, PARAGRAPH_ELEMENT_TYPE, SECTION_ELEMENT_TYPE } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { CODE_BLOCK_ELEMENT_TYPE } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -59,10 +60,12 @@ describe("codeblock normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: CODE_BLOCK_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: {
               codeContent: "print(1)",
               codeFormat: "python",
@@ -72,9 +75,10 @@ describe("codeblock normalizer tests", () => {
             children: [{ text: "" }],
             isFirstEdit: false,
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: CODE_BLOCK_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: {
               codeContent: "print(1)",
               codeFormat: "python",
@@ -84,9 +88,10 @@ describe("codeblock normalizer tests", () => {
             children: [{ text: "" }],
             isFirstEdit: false,
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: CODE_BLOCK_ELEMENT_TYPE,
+            id: anySlateElementId,
             data: {
               codeContent: "print(1)",
               codeFormat: "python",
@@ -96,7 +101,7 @@ describe("codeblock normalizer tests", () => {
             children: [{ text: "" }],
             isFirstEdit: false,
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/definitionList/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/definitionList/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_DEFINITION_DESCRIPTION, TYPE_DEFINITION_LIST, TYPE_DEFINITION_TERM } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -35,14 +36,15 @@ describe("definition normalizing tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_DEFINITION_LIST,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -70,16 +72,17 @@ describe("definition normalizing tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_DEFINITION_LIST,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-          { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+          { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -121,22 +124,26 @@ describe("definition normalizing tests", () => {
     expect(editor.children).toEqual([
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_DEFINITION_LIST,
+            id: anySlateElementId,
             children: [
-              { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-              { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
-              { type: TYPE_DEFINITION_TERM, children: [{ text: "" }] },
-              { type: TYPE_DEFINITION_DESCRIPTION, children: [{ text: "" }] },
+              { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+              { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
+              { type: TYPE_DEFINITION_TERM, id: anySlateElementId, children: [{ text: "" }] },
+              { type: TYPE_DEFINITION_DESCRIPTION, id: anySlateElementId, children: [{ text: "" }] },
             ],
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/details/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/details/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { SPAN_ELEMENT_TYPE } from "../../span/types";
 import { DETAILS_ELEMENT_TYPE } from "../detailsTypes";
 import { SUMMARY_ELEMENT_TYPE } from "../summaryTypes";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -49,32 +50,36 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: SUMMARY_ELEMENT_TYPE, children: [{ text: "title" }] },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: SUMMARY_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: SUMMARY_ELEMENT_TYPE, children: [{ text: "title" }] },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: SUMMARY_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: SUMMARY_ELEMENT_TYPE, children: [{ text: "title" }] },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: SUMMARY_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -100,19 +105,29 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 type: SUMMARY_ELEMENT_TYPE,
-                children: [{ type: PARAGRAPH_ELEMENT_TYPE, serializeAsText: true, children: [{ text: "" }] }],
+                id: anySlateElementId,
+                children: [
+                  {
+                    type: PARAGRAPH_ELEMENT_TYPE,
+                    id: anySlateElementId,
+                    serializeAsText: true,
+                    children: [{ text: "" }],
+                  },
+                ],
               },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -138,16 +153,18 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: SUMMARY_ELEMENT_TYPE, children: [{ text: "title" }] },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+              { type: SUMMARY_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -176,16 +193,18 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: SUMMARY_ELEMENT_TYPE, children: [{ text: "title" }] },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "wrong" }] },
+              { type: SUMMARY_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "wrong" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -204,7 +223,8 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
-        children: [{ type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "title" }] }],
+        id: anySlateElementId,
+        children: [{ type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "title" }] }],
       },
     ];
     editor.reinitialize({ value: editorValue, shouldNormalize: true });
@@ -235,19 +255,24 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "upper" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "upper" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 type: SUMMARY_ELEMENT_TYPE,
-                children: [{ type: HEADING_ELEMENT_TYPE, level: 2, children: [{ text: "title" }] }],
+                id: anySlateElementId,
+                children: [
+                  { type: HEADING_ELEMENT_TYPE, id: anySlateElementId, level: 2, children: [{ text: "title" }] },
+                ],
               },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "lower" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "lower" }] },
         ],
       },
     ];
@@ -279,19 +304,29 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "upper" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "upper" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 type: SUMMARY_ELEMENT_TYPE,
-                children: [{ type: PARAGRAPH_ELEMENT_TYPE, serializeAsText: true, children: [{ text: "title" }] }],
+                id: anySlateElementId,
+                children: [
+                  {
+                    type: PARAGRAPH_ELEMENT_TYPE,
+                    id: anySlateElementId,
+                    serializeAsText: true,
+                    children: [{ text: "title" }],
+                  },
+                ],
               },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "lower" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "lower" }] },
         ],
       },
     ];
@@ -323,23 +358,26 @@ describe("details normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "upper" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "upper" }] },
           {
             type: DETAILS_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 type: SUMMARY_ELEMENT_TYPE,
+                id: anySlateElementId,
                 children: [
                   { text: "" },
                   { type: SPAN_ELEMENT_TYPE, data: {}, children: [{ text: "title" }] },
                   { text: "" },
                 ],
               },
-              { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "content" }] },
+              { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "content" }] },
             ],
           },
-          { type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: "lower" }] },
+          { type: PARAGRAPH_ELEMENT_TYPE, id: anySlateElementId, children: [{ text: "lower" }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/embed/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { AUDIO_ELEMENT_TYPE } from "../../audio/audioTypes";
 import { H5P_ELEMENT_TYPE } from "../../h5p/types";
 import { IMAGE_ELEMENT_TYPE } from "../../image/types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -72,13 +73,16 @@ describe("embed normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: IMAGE_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -96,10 +100,12 @@ describe("embed normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: H5P_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -113,10 +119,12 @@ describe("embed normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: AUDIO_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -131,6 +139,7 @@ describe("embed normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/file/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/file/__tests__/normalizer-test.ts
@@ -10,6 +10,7 @@ import { Descendant } from "slate";
 import { createSlate, PARAGRAPH_ELEMENT_TYPE, SECTION_ELEMENT_TYPE } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { FILE_ELEMENT_TYPE } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -53,13 +54,16 @@ describe("file normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: FILE_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -69,10 +73,12 @@ describe("file normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: FILE_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -82,10 +88,12 @@ describe("file normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: FILE_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -95,6 +103,7 @@ describe("file normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/framedContent/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/framedContent/__tests__/normalizer-test.ts
@@ -14,6 +14,7 @@ import { TYPE_LINK } from "../../link/types";
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { FRAMED_CONTENT_ELEMENT_TYPE } from "../framedContentTypes";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -42,23 +43,27 @@ describe("framedContent normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            id: anySlateElementId,
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            id: anySlateElementId,
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            id: anySlateElementId,
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -82,13 +87,15 @@ describe("framedContent normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "" }] }],
+            id: anySlateElementId,
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -112,16 +119,18 @@ describe("framedContent normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
-              { type: TYPE_HEADING, level: 1, children: [{ text: "content" }] },
-              { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+              { type: TYPE_HEADING, id: anySlateElementId, level: 1, children: [{ text: "content" }] },
+              { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
             ],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -153,13 +162,15 @@ describe("framedContent normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: FRAMED_CONTENT_ELEMENT_TYPE,
-            children: [{ type: TYPE_PARAGRAPH, children: [{ text: "content" }] }],
+            id: anySlateElementId,
+            children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "content" }] }],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/grid/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/grid/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { frontpagePlugins } from "../../../../../containers/ArticlePage/Frontpag
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_GRID, TYPE_GRID_CELL } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: frontpagePlugins });
 
@@ -59,10 +60,12 @@ describe("normalizing grid tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: TYPE_GRID,
+            id: anySlateElementId,
             data: {
               columns: "2",
               border: "none",
@@ -70,17 +73,19 @@ describe("normalizing grid tests", () => {
             children: [
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "a" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "a" }] }],
               },
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "a" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "a" }] }],
               },
             ],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];
@@ -122,10 +127,12 @@ describe("normalizing grid tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
           {
             type: TYPE_GRID,
+            id: anySlateElementId,
             data: {
               columns: "4",
               border: "none",
@@ -133,27 +140,31 @@ describe("normalizing grid tests", () => {
             children: [
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "a" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "a" }] }],
               },
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "a" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "a" }] }],
               },
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] }],
               },
               {
                 type: TYPE_GRID_CELL,
+                id: anySlateElementId,
                 data: { parallaxCell: "false" },
-                children: [{ type: TYPE_PARAGRAPH, children: [{ text: "" }] }],
+                children: [{ type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] }],
               },
             ],
           },
-          { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
+          { type: TYPE_PARAGRAPH, id: anySlateElementId, children: [{ text: "" }] },
         ],
       },
     ];

--- a/src/components/SlateEditor/plugins/heading/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/heading/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_HEADING } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -46,22 +47,27 @@ describe("heading normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_HEADING,
+            id: anySlateElementId,
             level: 3,
             children: [{ text: "not empty" }],
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -96,24 +102,29 @@ describe("heading normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_HEADING,
+            id: anySlateElementId,
             level: 2,
             children: [{ text: "" }],
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
       },
     ];
-    editor.children = editorValue;
+
+    editor.reinitialize({ value: editorValue });
     Transforms.select(editor, [0, 1, 0]);
     Editor.normalize(editor, { force: true });
     expect(editor.children).toEqual(expectedValue);
@@ -145,18 +156,22 @@ test("remove bold marker on header", () => {
   const expectedValue: Descendant[] = [
     {
       type: TYPE_SECTION,
+      id: anySlateElementId,
       children: [
         {
           type: TYPE_PARAGRAPH,
+          id: anySlateElementId,
           children: [{ text: "" }],
         },
         {
           type: TYPE_HEADING,
+          id: anySlateElementId,
           level: 2,
           children: [{ text: "Test" }],
         },
         {
           type: TYPE_PARAGRAPH,
+          id: anySlateElementId,
           children: [{ text: "" }],
         },
       ],

--- a/src/components/SlateEditor/plugins/id/__tests__/id-operations-test.ts
+++ b/src/components/SlateEditor/plugins/id/__tests__/id-operations-test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { createSlate, PARAGRAPH_ELEMENT_TYPE, SECTION_ELEMENT_TYPE } from "@ndla/editor";
+import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
+import { Descendant, Element, NodeEntry, Transforms } from "slate";
+
+const editor = createSlate({ plugins: learningResourcePlugins });
+
+describe("idPlugin", () => {
+  test("should assign unique ids to nodes", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "" }],
+          },
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "" }],
+          },
+        ],
+      },
+    ];
+
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+
+    const nodes: NodeEntry<Element>[] = Array.from(
+      editor.nodes({ match: (node) => Element.isElement(node) && !!node.id, at: [] }),
+    );
+
+    expect(nodes.length).toBe(3); // 2 paragraphs + 1 section
+    const idsSet = new Set<string>(nodes.filter(([n]) => n.id).map(([n]) => n.id!));
+    expect(idsSet.size).toBe(3); // all ids should be unique
+  });
+  test("splitting a node in the middle should ensure that the new nodes have unique ids", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "Denne splittes" }],
+          },
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "" }],
+          },
+        ],
+      },
+    ];
+
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+    Transforms.splitNodes(editor, { at: { path: [0, 0], offset: 6 } });
+
+    const nodes: NodeEntry<Element>[] = Array.from(
+      editor.nodes({ match: (node) => Element.isElement(node) && node.type === "paragraph", at: [] }),
+    );
+
+    expect(nodes.length).toBe(3);
+
+    const idsSet = new Set<string>(nodes.filter(([n]) => n.id).map(([n]) => n.id!));
+    expect(idsSet.size).toBe(3); // all ids should be unique
+  });
+  test("should assign unique ids when pasting nodes that have already gotten unique ids", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "Paragraf 1" }],
+          },
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "Paragraf 2" }],
+          },
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "" }],
+          },
+        ],
+      },
+    ];
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+
+    const paragraphNodes = Array.from(
+      editor.nodes({ at: [], match: (n) => Element.isElement(n) && n.type === "paragraph" }),
+    );
+
+    const [id1, id2] = paragraphNodes.map(([node]) => node.id);
+
+    Transforms.insertFragment(
+      editor,
+      [
+        { type: PARAGRAPH_ELEMENT_TYPE, id: id1, children: [{ text: "Paragraf 1" }] },
+        { type: PARAGRAPH_ELEMENT_TYPE, id: id2, children: [{ text: "Paragraf 2" }] },
+      ],
+      { at: [0, 2] },
+    );
+
+    const allParagraphNodes = Array.from(
+      editor.nodes({ at: [], match: (n) => Element.isElement(n) && n.type === "paragraph" }),
+    );
+
+    const paragraphIds = new Set(allParagraphNodes.filter(([node]) => node.id).map(([node]) => node.id!));
+
+    expect(allParagraphNodes.length).toBe(4);
+    expect(paragraphIds.size).toBe(4);
+  });
+});

--- a/src/components/SlateEditor/plugins/id/idPlugin.ts
+++ b/src/components/SlateEditor/plugins/id/idPlugin.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { createPlugin } from "@ndla/editor";
+import { ID_PLUGIN } from "./idTypes";
+import { Descendant, Editor, Element, Node, NodeEntry } from "slate";
+import { makeNodeId } from "../../utils/makeNodeId";
+
+const assignIdToInitialValue = (editor: Editor, idsSet: Set<string>, nodeEntry: NodeEntry) => {
+  const [node, path] = nodeEntry;
+  if (Element.isElement(node) && editor.isBlock(node)) {
+    if (!node.id && editor.hasPath(path)) {
+      let nodeId = makeNodeId();
+      while (idsSet.has(nodeId)) {
+        nodeId = makeNodeId();
+      }
+      node.id = nodeId;
+    }
+    node.children.forEach((node, idx) => assignIdToInitialValue(editor, idsSet, [node, path.concat(idx)]));
+  }
+};
+
+const getAllIds = (children: Descendant[], set = new Set<string>()): Set<string> => {
+  children.forEach((node) => {
+    if ("id" in node && node.id) {
+      set.add(node.id);
+      node.children?.forEach((child) => getAllIds([child], set));
+    }
+  });
+  return set;
+};
+
+const TRANSFORM_OPS = ["insert_node", "remove_node", "merge_node", "split_node"];
+
+export const idPlugin = createPlugin({
+  name: ID_PLUGIN,
+  normalizeInitialValue: (editor) => {
+    const idsSet = new Set<string>();
+    editor.children.forEach((node, idx) => assignIdToInitialValue(editor, idsSet, [node, [idx]]));
+  },
+  transform: (editor) => {
+    let idsSet = new Set<string>();
+    const { apply } = editor;
+
+    const assignIdRecursively = (node: Node) => {
+      if (Element.isElement(node) && editor.isBlock(node)) {
+        if (!node.id || idsSet.has(node.id)) {
+          let nodeId = makeNodeId();
+          while (idsSet.has(nodeId)) {
+            nodeId = makeNodeId();
+          }
+          idsSet.add(nodeId);
+          node.id = nodeId;
+        }
+        node.children.forEach(assignIdRecursively);
+      }
+    };
+
+    editor.apply = (operation) => {
+      // If there are no ids in the document and our history is empty, the editor is clean. We need to add the initial ids
+      if (
+        (!idsSet.size && (!editor.history.redos.length || !editor.history.undos.length)) ||
+        TRANSFORM_OPS.includes(operation.type)
+      ) {
+        idsSet = getAllIds(editor.children);
+      }
+      if (operation.type === "remove_node") {
+        if ("id" in operation.node && operation.node.id) {
+          idsSet.delete(operation.node.id);
+        }
+      } else if (operation.type === "merge_node") {
+        if ("id" in operation.properties && operation.properties.id) {
+          idsSet.delete(operation.properties.id);
+        }
+      } else if (operation.type === "insert_node") {
+        assignIdRecursively(operation.node);
+      } else if (operation.type === "split_node" && "type" in operation.properties) {
+        let nodeId = makeNodeId();
+        while (idsSet.has(nodeId)) {
+          nodeId = makeNodeId();
+        }
+        idsSet.add(nodeId);
+        operation.properties.id = nodeId;
+      }
+
+      return apply(operation);
+    };
+
+    return editor;
+  },
+});

--- a/src/components/SlateEditor/plugins/id/idTypes.ts
+++ b/src/components/SlateEditor/plugins/id/idTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const ID_PLUGIN = "id";

--- a/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/link/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_LINK, TYPE_CONTENT_LINK } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -47,9 +48,11 @@ describe("link normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               { text: "" },
               {
@@ -98,9 +101,11 @@ describe("link normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               { text: "" },
               {
@@ -168,9 +173,11 @@ describe("link normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/list/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/list/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_LIST, TYPE_LIST_ITEM } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -41,9 +42,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "abc" }],
           },
         ],
@@ -80,9 +83,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -91,14 +96,17 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_LIST,
+            id: anySlateElementId,
             listType: "letter-list",
             data: {},
             children: [
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "abc",
@@ -111,6 +119,7 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -168,9 +177,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -179,14 +190,17 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_LIST,
+            id: anySlateElementId,
             listType: "letter-list",
             data: {},
             children: [
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "",
@@ -195,14 +209,17 @@ describe("list normalizer tests", () => {
                   },
                   {
                     type: TYPE_LIST,
+                    id: anySlateElementId,
                     listType: "letter-list",
                     data: {},
                     children: [
                       {
                         type: TYPE_LIST_ITEM,
+                        id: anySlateElementId,
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "",
@@ -219,6 +236,7 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -290,9 +308,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -301,14 +321,17 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_LIST,
+            id: anySlateElementId,
             listType: "letter-list",
             data: {},
             children: [
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "",
@@ -317,14 +340,17 @@ describe("list normalizer tests", () => {
                   },
                   {
                     type: TYPE_LIST,
+                    id: anySlateElementId,
                     listType: "numbered-list",
                     data: {},
                     children: [
                       {
                         type: TYPE_LIST_ITEM,
+                        id: anySlateElementId,
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "abc",
@@ -337,14 +363,17 @@ describe("list normalizer tests", () => {
                   },
                   {
                     type: TYPE_LIST,
+                    id: anySlateElementId,
                     listType: "letter-list",
                     data: {},
                     children: [
                       {
                         type: TYPE_LIST_ITEM,
+                        id: anySlateElementId,
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "def",
@@ -361,6 +390,7 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -392,9 +422,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -422,9 +454,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -433,14 +467,17 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_LIST,
+            id: anySlateElementId,
             listType: "numbered-list",
             data: {},
             children: [
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "abc",
@@ -453,6 +490,7 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -534,9 +572,11 @@ describe("list normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -545,14 +585,17 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_LIST,
+            id: anySlateElementId,
             listType: "letter-list",
             data: {},
             children: [
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "abc",
@@ -563,9 +606,11 @@ describe("list normalizer tests", () => {
               },
               {
                 type: TYPE_LIST_ITEM,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_PARAGRAPH,
+                    id: anySlateElementId,
                     children: [
                       {
                         text: "def",
@@ -578,6 +623,7 @@ describe("list normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [
               {
                 text: "",

--- a/src/components/SlateEditor/plugins/mark/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/mark/__tests__/normalizer-test.ts
@@ -11,6 +11,7 @@ import { createSlate } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -31,9 +32,11 @@ describe("mark normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/paragraph/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/paragraph/__tests__/normalizer-test.ts
@@ -11,6 +11,7 @@ import { createSlate } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { TYPE_SECTION } from "../../section/types";
 import { TYPE_PARAGRAPH } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -32,9 +33,11 @@ describe("paragraph normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/related/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/related/__tests__/normalizer-test.ts
@@ -10,6 +10,7 @@ import { Descendant } from "slate";
 import { createSlate, PARAGRAPH_ELEMENT_TYPE, SECTION_ELEMENT_TYPE } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { RELATED_ELEMENT_TYPE } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -53,13 +54,16 @@ describe("related normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: RELATED_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -69,10 +73,12 @@ describe("related normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: RELATED_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -82,10 +88,12 @@ describe("related normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: RELATED_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               {
                 text: "",
@@ -95,6 +103,7 @@ describe("related normalizer tests", () => {
           },
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/section/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/section/__tests__/normalizer-test.ts
@@ -12,6 +12,7 @@ import { learningResourcePlugins } from "../../../../../containers/ArticlePage/L
 import { TYPE_HEADING } from "../../heading/types";
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -27,9 +28,11 @@ describe("section normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -50,9 +53,11 @@ describe("section normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "abc" }],
           },
         ],
@@ -79,14 +84,17 @@ describe("section normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_HEADING,
+            id: anySlateElementId,
             level: 1,
             children: [{ text: "heading" }],
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/span/__tests__/normalizer-test.ts
@@ -10,6 +10,7 @@ import { Descendant } from "slate";
 import { createSlate, PARAGRAPH_ELEMENT_TYPE, SECTION_ELEMENT_TYPE } from "@ndla/editor";
 import { learningResourcePlugins } from "../../../../../containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins";
 import { SPAN_ELEMENT_TYPE } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -38,9 +39,11 @@ describe("span normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: SECTION_ELEMENT_TYPE,
+        id: anySlateElementId,
         children: [
           {
             type: PARAGRAPH_ELEMENT_TYPE,
+            id: anySlateElementId,
             children: [
               { text: "" },
               {

--- a/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
+++ b/src/components/SlateEditor/plugins/table/__tests__/normalizer-test.ts
@@ -20,6 +20,7 @@ import {
   TYPE_TABLE_CELL,
   TYPE_TABLE_CELL_HEADER,
 } from "../types";
+import { anySlateElementId } from "../../../../../__tests__/vitest.setup";
 
 const editor = createSlate({ plugins: learningResourcePlugins });
 
@@ -116,18 +117,22 @@ describe("table normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_TABLE,
+            id: anySlateElementId,
             rowHeaders: false,
             colgroups: '<colgroup></colgroup><colgroup span="2"></colgroup>',
             children: [
               {
                 type: TYPE_TABLE_CAPTION,
+                id: anySlateElementId,
                 children: [
                   {
                     text: "",
@@ -136,12 +141,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_HEAD,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -151,6 +159,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "1",
@@ -161,6 +170,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -169,6 +179,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             serializeAsText: true,
                             children: [
                               {
@@ -184,12 +195,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_BODY,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -198,6 +212,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "3",
@@ -208,6 +223,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -216,6 +232,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "4",
@@ -232,6 +249,7 @@ describe("table normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -357,18 +375,22 @@ describe("table normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_TABLE,
+            id: anySlateElementId,
             rowHeaders: false,
             colgroups: '<colgroup></colgroup><colgroup span="2"></colgroup>',
             children: [
               {
                 type: TYPE_TABLE_CAPTION,
+                id: anySlateElementId,
                 children: [
                   {
                     text: "",
@@ -377,12 +399,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_HEAD,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -392,6 +417,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "1",
@@ -402,6 +428,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -411,6 +438,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "2",
@@ -425,12 +453,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_BODY,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -439,6 +470,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "3",
@@ -449,6 +481,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -457,6 +490,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "4",
@@ -473,6 +507,7 @@ describe("table normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -584,18 +619,22 @@ describe("table normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_TABLE,
+            id: anySlateElementId,
             rowHeaders: false,
             colgroups: '<colgroup></colgroup><colgroup span="2"></colgroup>',
             children: [
               {
                 type: TYPE_TABLE_CAPTION,
+                id: anySlateElementId,
                 children: [
                   {
                     text: "",
@@ -604,12 +643,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_HEAD,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -619,6 +661,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "1",
@@ -629,6 +672,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -638,6 +682,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "2",
@@ -652,12 +697,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_BODY,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -666,6 +714,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "3",
@@ -676,6 +725,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           rowspan: 1,
@@ -683,6 +733,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             serializeAsText: true,
                             children: [
                               {
@@ -700,6 +751,7 @@ describe("table normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],
@@ -862,18 +914,22 @@ describe("table normalizer tests", () => {
     const expectedValue: Descendant[] = [
       {
         type: TYPE_SECTION,
+        id: anySlateElementId,
         children: [
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
           {
             type: TYPE_TABLE,
+            id: anySlateElementId,
             rowHeaders: true,
             colgroups: '<colgroup></colgroup><colgroup span="2"></colgroup>',
             children: [
               {
                 type: TYPE_TABLE_CAPTION,
+                id: anySlateElementId,
                 children: [
                   {
                     text: "",
@@ -882,12 +938,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_HEAD,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           id: "00",
@@ -898,6 +957,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "1",
@@ -908,6 +968,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           colspan: 1,
                           id: "01",
@@ -918,6 +979,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "2",
@@ -932,12 +994,15 @@ describe("table normalizer tests", () => {
               },
               {
                 type: TYPE_TABLE_BODY,
+                id: anySlateElementId,
                 children: [
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL_HEADER,
+                        id: anySlateElementId,
                         data: {
                           id: "r1",
                           headers: "00",
@@ -949,6 +1014,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "3",
@@ -959,6 +1025,7 @@ describe("table normalizer tests", () => {
                       },
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           headers: "01 r1",
                           colspan: 1,
@@ -968,6 +1035,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "4",
@@ -980,9 +1048,11 @@ describe("table normalizer tests", () => {
                   },
                   {
                     type: TYPE_TABLE_ROW,
+                    id: anySlateElementId,
                     children: [
                       {
                         type: TYPE_TABLE_CELL,
+                        id: anySlateElementId,
                         data: {
                           headers: "01 r1",
                           colspan: 1,
@@ -992,6 +1062,7 @@ describe("table normalizer tests", () => {
                         children: [
                           {
                             type: TYPE_PARAGRAPH,
+                            id: anySlateElementId,
                             children: [
                               {
                                 text: "5",
@@ -1008,6 +1079,7 @@ describe("table normalizer tests", () => {
           },
           {
             type: TYPE_PARAGRAPH,
+            id: anySlateElementId,
             children: [{ text: "" }],
           },
         ],

--- a/src/components/SlateEditor/utils/makeNodeId.ts
+++ b/src/components/SlateEditor/utils/makeNodeId.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { nanoid } from "nanoid";
+
+export const makeNodeId = () => nanoid(16);

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
@@ -51,9 +51,11 @@ import { headingPlugin } from "../../../../components/SlateEditor/plugins/headin
 import { breakPlugin } from "../../../../components/SlateEditor/plugins/break";
 import { markPlugin } from "../../../../components/SlateEditor/plugins/mark";
 import { listPlugin } from "../../../../components/SlateEditor/plugins/list";
+import { idPlugin } from "../../../../components/SlateEditor/plugins/id/idPlugin";
 
 // Plugins are checked from last to first
 export const frontpagePlugins: SlatePlugin[] = [
+  idPlugin,
   sectionPlugin,
   spanPlugin,
   divPlugin,

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { inlineNavigationPlugin } from "@ndla/editor";
 import { SlatePlugin } from "../../../../components/SlateEditor/interfaces";
 import { asidePlugin } from "../../../../components/SlateEditor/plugins/aside/asidePlugin";
 import { audioPlugin } from "../../../../components/SlateEditor/plugins/audio/audioPlugin";
@@ -46,9 +47,10 @@ import { headingPlugin } from "../../../../components/SlateEditor/plugins/headin
 import { breakPlugin } from "../../../../components/SlateEditor/plugins/break";
 import { markPlugin } from "../../../../components/SlateEditor/plugins/mark";
 import { listPlugin } from "../../../../components/SlateEditor/plugins/list";
-import { inlineNavigationPlugin } from "@ndla/editor";
+import { idPlugin } from "../../../../components/SlateEditor/plugins/id/idPlugin";
 
 export const learningResourcePlugins: SlatePlugin[] = [
+  idPlugin,
   inlineNavigationPlugin,
   sectionPlugin,
   spanPlugin,

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
@@ -27,9 +27,11 @@ import { listPlugin } from "../../../../components/SlateEditor/plugins/list";
 import { markPlugin } from "../../../../components/SlateEditor/plugins/mark";
 import { breakPlugin } from "../../../../components/SlateEditor/plugins/break";
 import { inlineNavigationPlugin } from "@ndla/editor";
+import { idPlugin } from "../../../../components/SlateEditor/plugins/id/idPlugin";
 
 // Plugins are checked from last to first
 export const topicArticlePlugins: SlatePlugin[] = [
+  idPlugin,
   inlineNavigationPlugin,
   sectionPlugin,
   spanPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5571,6 +5571,7 @@ __metadata:
     jwt-decode: "npm:^4.0.0"
     lodash-es: "npm:^4.17.21"
     monaco-editor: "npm:0.47.0"
+    nanoid: "npm:^5.1.2"
     nock: "npm:^14.0.1"
     p-limit: "npm:^6.2.0"
     postcss: "npm:^8.5.3"
@@ -8817,6 +8818,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^5.1.2":
+  version: 5.1.3
+  resolution: "nanoid@npm:5.1.3"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 10c0/632ab0e758f8cdd3d14835b2c094e7320cdb92c2404e4bc6cd864765d8fab76647e73ee664a7d11b1a5b5c7e04b8c030d6719d2b61f8b1295a5fb64a9d779a8b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Denne gjør egentlig ingenting på egenhånd, så den er kanskje litt vanskelig å teste. Hovedmåten å teste på blir kanskje å se hvordan `editor.children` ser ut mens man gjør rare ting i editoren, men sliter litt med å brekke den. 

Brorparten av endringene har med testene våre å gjøre. Node-ID'er er generert dynamisk. Tanken var i utgangspunktet å mocke de, men det ble veldig fort veldig komplekst når man tok normalisering med i bildet. Vurderte også å modifisere`toEqual` til å ignorere ID'er når man sammenlignet to slate-noder, men såpass mye rekursjon kommer nok med en ytelsespris. CI trenger ikke å bli tregere :')

Endte opp med å asserte at ID eksisterer på alle noder, men sjekker aldri hvilken verdi det er. PDD sjekker vi bare at det er en string, og at den finnes på objektet. En fin konsekvens av dette er at vi indirekte tester ID-pluginen på tvers av hele applikasjonen!