### PR TITLE
Adds pasting gapminder url and get embeddable version

### DIFF
--- a/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.ts
+++ b/src/containers/VisualElement/__tests__/transformUrlIfNeeded-test.ts
@@ -94,3 +94,12 @@ test("transformUrlIfNeeded creates embed-url for sketchup model if needed", asyn
   );
   expect(url2).toMatch("https://3dwarehouse.sketchup.com/embed/eb498ef3-3de5-42ca-a621-34ea29cc08c4");
 });
+
+test("transformUrlIfNeeded adds ?embeddable=true for gapminder", async () => {
+  const url1 = await transformUrlIfNeeded(
+    "https://www.gapminder.org/tools/#$model$markers$line$data$filter$dimensions$geo$",
+  ); // abbreviated
+  expect(url1).toMatch(
+    "https://www.gapminder.org/tools/?embedded=true#$model$markers$line$data$filter$dimensions$geo$",
+  );
+});

--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -188,6 +188,25 @@ const jeopardyLabTransformer: UrlTransformer = {
   },
 };
 
+const gapminderTransformer: UrlTransformer = {
+  domains: ["www.gapminder.org"],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    if (aTag.href.includes("?embedded=true")) {
+      return false;
+    }
+    return true;
+  },
+  transform: async (url) => {
+    const parts = url.split("/tools/");
+    return parts.join("/tools/?embedded=true");
+  },
+};
+
 export const urlTransformers: UrlTransformer[] = [
   nrkTransformer,
   codepenTransformer,
@@ -196,4 +215,5 @@ export const urlTransformers: UrlTransformer[] = [
   sketchupTransformer,
   sketcfabTransformer,
   jeopardyLabTransformer,
+  gapminderTransformer,
 ];


### PR DESCRIPTION
Test ved å sette inn https://www.gapminder.org/tools/#$model$markers$line$data$filter$dimensions$geo$/$or@$geo$/$in@=nga&=ind&=jpn&=nor;;;;;;;;&encoding$selected$data$filter$markers@=nga;;;;&y$data$concept=pop&space@=geo&=time;;&scale$type:null&domain:null&zoomed:null;;&frame$value=1827;;;;;&chart-type=linechart&url=v2 i ressurs fra lenke