### PR TITLE
Fix delete language navigation and language picker

### DIFF
--- a/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
+++ b/src/components/HeaderWithLanguage/DeleteLanguageVersion.tsx
@@ -118,7 +118,7 @@ const DeleteLanguageVersion = ({ id, language, supportedLanguages, type, disable
             break;
           case "subjectpage":
             await deleteSubectPageLanguageVersion(id, language);
-            if (newAfterLanguageDeletion && elementId && otherSupportedLanguage) {
+            if (!newAfterLanguageDeletion && elementId && otherSupportedLanguage) {
               navigate(toEditSubjectpage(elementId, otherSupportedLanguage, id));
             } else if (elementId) {
               navigate(toCreateSubjectpage(elementId, "nb"));

--- a/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
+++ b/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
@@ -36,6 +36,7 @@ interface Props {
   language: string;
   supportedLanguages: string[];
   title: string;
+  availableLanguages?: string[];
 }
 
 const SimpleLanguageHeader = ({
@@ -46,24 +47,15 @@ const SimpleLanguageHeader = ({
   language,
   supportedLanguages,
   title,
+  availableLanguages,
 }: Props) => {
   const { t } = useTranslation();
   const isNewLanguage = !!id && !supportedLanguages.includes(language);
 
-  const languages = [
-    { key: "nn", title: t("languages.nn"), include: true },
-    { key: "en", title: t("languages.en"), include: true },
-    { key: "nb", title: t("languages.nb"), include: true },
-    { key: "sma", title: t("languages.sma"), include: true },
-    { key: "se", title: t("languages.se"), include: true },
-    { key: "und", title: t("languages.und"), include: false },
-    { key: "de", title: t("languages.de"), include: true },
-    { key: "es", title: t("languages.es"), include: true },
-    { key: "ukr", title: t("languages.ukr"), include: false },
-  ];
-  const emptyLanguages = languages.filter(
-    (lang) => lang.key !== language && !supportedLanguages.includes(lang.key) && lang.include,
-  );
+  const languages = availableLanguages ?? ["nn", "en", "nb", "sma", "se", "de", "es"];
+  const emptyLanguages = languages
+    .filter((lang) => lang !== language && !supportedLanguages.includes(lang))
+    .map((lang) => ({ key: lang, title: t(`languages.${lang}`) }));
 
   return (
     <div>
@@ -89,8 +81,12 @@ const SimpleLanguageHeader = ({
               {t(`languages.${language}`)}
             </HeaderCurrentLanguagePill>
           )}
-          <StyledSplitter />
-          <HeaderLanguagePicker id={id} emptyLanguages={emptyLanguages} editUrl={editUrl} />
+          {emptyLanguages.length > 0 && (
+            <>
+              <StyledSplitter />
+              <HeaderLanguagePicker id={id} emptyLanguages={emptyLanguages} editUrl={editUrl} />
+            </>
+          )}
           <DeleteLanguageVersionWrapper>
             <DeleteLanguageVersion
               language={language}

--- a/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
+++ b/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
@@ -129,6 +129,7 @@ const NdlaFilmForm = ({ filmFrontpage, selectedLanguage }: Props) => {
               language={selectedLanguage}
               supportedLanguages={values.supportedLanguages}
               title={values.name}
+              availableLanguages={["nb", "nn", "en"]}
             />
 
             <FormAccordions defaultOpen={["slideshow", "themes"]}>


### PR DESCRIPTION
Fixes the navigation after deleting a language from a subject page, when there are other supported languages. Also fixes the language picker for the NDLA film frontpage, such that only Bokmål, Nynorsk and English is available.