### PR TITLE
Small fixes masthead search

### DIFF
--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -236,7 +236,7 @@ export const MastheadSearch = () => {
     return createListCollection({
       items: filteredSavedSearches,
       itemToString: (item) => item.searchPhrase,
-      itemToValue: (item) => item.searchPhrase,
+      itemToValue: (item) => `${item.searchPhrase}_${filteredSavedSearches.indexOf(item)}`,
     });
   }, [filteredSavedSearches]);
 

--- a/src/containers/Masthead/components/MastheadSearch.tsx
+++ b/src/containers/Masthead/components/MastheadSearch.tsx
@@ -80,7 +80,13 @@ export const MastheadSearch = () => {
   }, [location.pathname]);
 
   const filteredSavedSearches = useMemo(() => {
-    return userDataQuery.data?.savedSearches?.filter((item) => item.searchPhrase.includes(query)) ?? [];
+    return (
+      userDataQuery.data?.savedSearches?.filter((item) => {
+        const searchPhraseToLowerCase = item.searchPhrase.toLowerCase();
+        const queryToLowerCase = query.toLowerCase();
+        return searchPhraseToLowerCase.includes(queryToLowerCase);
+      }) ?? []
+    );
   }, [query, userDataQuery.data?.savedSearches]);
 
   const handleNodeId = async (nodeId: number) => {


### PR DESCRIPTION
Fikser opp i to greier:
- Sørger for unike values i masthead search, så slipper vi feks:
![Skjermbilde 2025-04-03 kl  12 02 50](https://github.com/user-attachments/assets/9c36d232-7567-423e-8d00-abc2615f6ea2)
- Filtrerer ikke søkeresultater basert på casing