### PR TITLE
refactor: split external plugin into externalPlugin and iframePlugin.

### DIFF
--- a/src/components/SlateEditor/helpers.ts
+++ b/src/components/SlateEditor/helpers.ts
@@ -15,7 +15,7 @@ import { COMMENT_INLINE_ELEMENT_TYPE } from "./plugins/comment/inline/types";
 import { CONCEPT_INLINE_ELEMENT_TYPE } from "./plugins/concept/inline/types";
 import { DETAILS_ELEMENT_TYPE } from "./plugins/details/detailsTypes";
 import { TYPE_EMBED_ERROR } from "./plugins/embed/types";
-import { TYPE_EXTERNAL } from "./plugins/external/types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "./plugins/external/types";
 import { FILE_ELEMENT_TYPE } from "./plugins/file/types";
 import { FOOTNOTE_ELEMENT_TYPE } from "./plugins/footnote/types";
 import { FRAMED_CONTENT_ELEMENT_TYPE } from "./plugins/framedContent/framedContentTypes";
@@ -51,7 +51,8 @@ export const blocks: ElementType[] = [
   AUDIO_ELEMENT_TYPE,
   BRIGHTCOVE_ELEMENT_TYPE,
   TYPE_EMBED_ERROR,
-  TYPE_EXTERNAL,
+  EXTERNAL_ELEMENT_TYPE,
+  IFRAME_ELEMENT_TYPE,
   H5P_ELEMENT_TYPE,
   IMAGE_ELEMENT_TYPE,
   FILE_ELEMENT_TYPE,

--- a/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateBlockPicker.tsx
@@ -35,7 +35,7 @@ import { defaultContactBlock } from "../contactBlock/utils";
 import { DETAILS_ELEMENT_TYPE } from "../details/detailsTypes";
 import { defaultDetailsBlock } from "../details/utils";
 import { TYPE_EMBED_ERROR } from "../embed/types";
-import { TYPE_EXTERNAL } from "../external/types";
+import { EXTERNAL_ELEMENT_TYPE } from "../external/types";
 import { defaultExternalBlock } from "../external/utils";
 import { FILE_ELEMENT_TYPE } from "../file/types";
 import { FRAMED_CONTENT_ELEMENT_TYPE } from "../framedContent/framedContentTypes";
@@ -292,7 +292,7 @@ const SlateBlockPicker = ({
         onInsertBlock(defaultH5pBlock());
         break;
       }
-      case TYPE_EXTERNAL: {
+      case EXTERNAL_ELEMENT_TYPE: {
         onInsertBlock(defaultExternalBlock());
         break;
       }

--- a/src/components/SlateEditor/plugins/blockPicker/actions.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/actions.tsx
@@ -41,7 +41,7 @@ import { COMMENT_BLOCK_ELEMENT_TYPE } from "../comment/block/types";
 import { GLOSS_BLOCK_ELEMENT_TYPE } from "../concept/block/types";
 import { CONTACT_BLOCK_ELEMENT_TYPE } from "../contactBlock/types";
 import { DETAILS_ELEMENT_TYPE } from "../details/detailsTypes";
-import { TYPE_EXTERNAL } from "../external/types";
+import { EXTERNAL_ELEMENT_TYPE } from "../external/types";
 import { FILE_ELEMENT_TYPE } from "../file/types";
 import { FRAMED_CONTENT_ELEMENT_TYPE } from "../framedContent/framedContentTypes";
 import { TYPE_GRID } from "../grid/types";
@@ -116,7 +116,7 @@ export const commonActions: Action[] = [
     helpIcon: renderArticleInDialog("H5P"),
   },
   {
-    data: { type: TYPE_EXTERNAL, object: "url" },
+    data: { type: EXTERNAL_ELEMENT_TYPE, object: "url" },
     icon: <LinkMedium />,
     helpIcon: renderArticleInDialog("ResourceFromLink"),
   },

--- a/src/components/SlateEditor/plugins/external/SlateExternal.tsx
+++ b/src/components/SlateEditor/plugins/external/SlateExternal.tsx
@@ -8,9 +8,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Editor, Element, Path, Transforms } from "slate";
+import { Editor, Path, Transforms } from "slate";
 import { ReactEditor, RenderElementProps, useSelected } from "slate-react";
 import { Portal } from "@ark-ui/react";
+import { isElementOfType } from "@ndla/editor";
 import { PencilFill, DeleteBinLine, ErrorWarningLine, ExpandUpDownLine } from "@ndla/icons";
 import {
   DialogBody,
@@ -28,7 +29,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { IframeEmbedData, IframeMetaData, OembedEmbedData, OembedMetaData } from "@ndla/types-embed";
 import { EmbedWrapper, ExternalEmbed, IframeEmbed } from "@ndla/ui";
 import { ExternalEmbedForm } from "./ExternalEmbedForm";
-import { ExternalElement, IframeElement, TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
+import { EXTERNAL_ELEMENT_TYPE, ExternalElement, IFRAME_ELEMENT_TYPE, IframeElement } from "./types";
 import { EXTERNAL_WHITELIST_PROVIDERS } from "../../../../constants";
 import { WhitelistProvider } from "../../../../interfaces";
 import { useExternalEmbed } from "../../../../modules/embed/queries";
@@ -145,7 +146,7 @@ export const SlateExternal = ({ element, editor, attributes, children }: Props) 
     const path = ReactEditor.findPath(editor, element);
     Transforms.removeNodes(editor, {
       at: path,
-      match: (node) => Element.isElement(node) && (node.type === TYPE_EXTERNAL || node.type === TYPE_IFRAME),
+      match: (node) => isElementOfType(node, [EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE]),
       voids: true,
     });
     setTimeout(() => {

--- a/src/components/SlateEditor/plugins/external/__tests__/serializer-test.ts
+++ b/src/components/SlateEditor/plugins/external/__tests__/serializer-test.ts
@@ -10,7 +10,7 @@ import { Descendant } from "slate";
 import { blockContentToEditorValue, blockContentToHTML } from "../../../../../util/articleContentConverter";
 import { TYPE_PARAGRAPH } from "../../paragraph/types";
 import { TYPE_SECTION } from "../../section/types";
-import { TYPE_EXTERNAL } from "../types";
+import { EXTERNAL_ELEMENT_TYPE } from "../types";
 
 describe("external serializer", () => {
   const editorWithYoutube: Descendant[] = [
@@ -19,7 +19,7 @@ describe("external serializer", () => {
       children: [
         { type: TYPE_PARAGRAPH, children: [{ text: "" }] },
         {
-          type: TYPE_EXTERNAL,
+          type: EXTERNAL_ELEMENT_TYPE,
           children: [
             {
               text: "",

--- a/src/components/SlateEditor/plugins/external/index.ts
+++ b/src/components/SlateEditor/plugins/external/index.ts
@@ -6,14 +6,27 @@
  *
  */
 
-import { Editor, Element } from "slate";
 import { jsx as slatejsx } from "slate-hyperscript";
-import { createDataAttributes, createHtmlTag, createSerializer, parseElementAttributes } from "@ndla/editor";
-import { TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
+import {
+  createDataAttributes,
+  createHtmlTag,
+  createPlugin,
+  createSerializer,
+  parseElementAttributes,
+} from "@ndla/editor";
+import {
+  EXTERNAL_ELEMENT_TYPE,
+  EXTERNAL_PLUGIN,
+  ExternalPluginOptions,
+  IFRAME_ELEMENT_TYPE,
+  IFRAME_PLUGIN,
+  IframePluginOptions,
+} from "./types";
 import { NormalizerConfig, defaultBlockNormalizer } from "../../utils/defaultNormalizer";
 import { afterOrBeforeTextBlockElement } from "../../utils/normalizationHelpers";
 import { TYPE_NDLA_EMBED } from "../embed/types";
 import { TYPE_PARAGRAPH } from "../paragraph/types";
+import { isExternalElement, isIframeElement } from "./queries";
 
 const normalizerConfig: NormalizerConfig = {
   previous: {
@@ -30,34 +43,50 @@ export const externalSerializer = createSerializer({
   deserialize(el) {
     if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
     const embed = el as HTMLEmbedElement;
-    const embedAttributes = parseElementAttributes(Array.from(embed.attributes));
-    if (embedAttributes.resource === TYPE_EXTERNAL || embedAttributes.resource === TYPE_IFRAME) {
-      return slatejsx("element", { type: embedAttributes.resource, data: embedAttributes }, { text: "" });
-    }
+    const attributes = parseElementAttributes(Array.from(embed.attributes));
+    if (attributes.resource !== EXTERNAL_ELEMENT_TYPE) return;
+    return slatejsx("element", { type: attributes.resource, data: attributes }, { text: "" });
   },
   serialize(node) {
-    if (Element.isElement(node) && (node.type === TYPE_EXTERNAL || node.type === TYPE_IFRAME) && node.data) {
-      const data = createDataAttributes(node.data);
-      return createHtmlTag({ tag: TYPE_NDLA_EMBED, data, bailOnEmpty: true });
-    }
+    if (!isExternalElement(node)) return;
+    const data = createDataAttributes(node.data);
+    return createHtmlTag({ tag: TYPE_NDLA_EMBED, data, bailOnEmpty: true });
   },
 });
 
-export const externalPlugin = (disableNormalize?: boolean) => (editor: Editor) => {
-  const { normalizeNode: nextNormalizeNode, isVoid: nextIsVoid } = editor;
+export const iframeSerializer = createSerializer({
+  deserialize(el) {
+    if (el.tagName.toLowerCase() !== TYPE_NDLA_EMBED) return;
+    const embed = el as HTMLEmbedElement;
+    const attributes = parseElementAttributes(Array.from(embed.attributes));
+    if (attributes.resource !== IFRAME_ELEMENT_TYPE) return;
+    return slatejsx("element", { type: attributes.resource, data: attributes }, { text: "" });
+  },
+  serialize(node) {
+    if (!isIframeElement(node)) return;
+    const data = createDataAttributes(node.data);
+    return createHtmlTag({ tag: TYPE_NDLA_EMBED, data, bailOnEmpty: true });
+  },
+});
 
-  editor.normalizeNode = (entry) => {
-    const [node, path] = entry;
-    if (Element.isElement(node) && (node.type === TYPE_EXTERNAL || node.type === TYPE_IFRAME)) {
-      if (!disableNormalize && defaultBlockNormalizer(editor, node, path, normalizerConfig)) {
-        return;
-      }
-    }
-    nextNormalizeNode(entry);
-  };
+export const iframePlugin = createPlugin<typeof IFRAME_ELEMENT_TYPE, IframePluginOptions>({
+  name: IFRAME_PLUGIN,
+  type: IFRAME_ELEMENT_TYPE,
+  isVoid: true,
+  options: { disableNormalize: false },
+  normalize: (editor, node, path, logger, opts) => {
+    if (!isIframeElement(node) || opts.disableNormalize) return false;
+    return defaultBlockNormalizer(editor, node, path, normalizerConfig, logger);
+  },
+});
 
-  editor.isVoid = (element) => {
-    return element.type === TYPE_EXTERNAL || element.type === TYPE_IFRAME ? true : nextIsVoid(element);
-  };
-  return editor;
-};
+export const externalPlugin = createPlugin<typeof EXTERNAL_ELEMENT_TYPE, ExternalPluginOptions>({
+  name: EXTERNAL_PLUGIN,
+  type: EXTERNAL_ELEMENT_TYPE,
+  isVoid: true,
+  options: { disableNormalize: false },
+  normalize: (editor, node, path, logger, opts) => {
+    if (!isExternalElement(node) || opts.disableNormalize) return false;
+    return defaultBlockNormalizer(editor, node, path, normalizerConfig, logger);
+  },
+});

--- a/src/components/SlateEditor/plugins/external/queries.ts
+++ b/src/components/SlateEditor/plugins/external/queries.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Node } from "slate";
+import { isElementOfType } from "@ndla/editor";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "./types";
+
+export const isIframeElement = (node: Node | undefined) => isElementOfType(node, IFRAME_ELEMENT_TYPE);
+
+export const isExternalElement = (node: Node | undefined) => isElementOfType(node, EXTERNAL_ELEMENT_TYPE);

--- a/src/components/SlateEditor/plugins/external/render.tsx
+++ b/src/components/SlateEditor/plugins/external/render.tsx
@@ -8,12 +8,12 @@
 
 import { Editor } from "slate";
 import { SlateExternal } from "./SlateExternal";
-import { TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "./types";
 
 export const externalRenderer = (editor: Editor) => {
   const { renderElement } = editor;
   editor.renderElement = ({ attributes, children, element }) => {
-    if (element.type === TYPE_EXTERNAL || element.type === TYPE_IFRAME) {
+    if (element.type === EXTERNAL_ELEMENT_TYPE || element.type === IFRAME_ELEMENT_TYPE) {
       return (
         <SlateExternal attributes={attributes} editor={editor} element={element}>
           {children}

--- a/src/components/SlateEditor/plugins/external/types.ts
+++ b/src/components/SlateEditor/plugins/external/types.ts
@@ -9,8 +9,19 @@
 import { Descendant } from "slate";
 import { IframeEmbedData, OembedEmbedData } from "@ndla/types-embed";
 
-export const TYPE_EXTERNAL = "external";
-export const TYPE_IFRAME = "iframe";
+export const IFRAME_ELEMENT_TYPE = "iframe";
+export const IFRAME_PLUGIN = "iframe-plugin";
+
+export const EXTERNAL_ELEMENT_TYPE = "external";
+export const EXTERNAL_PLUGIN = "external-plugin";
+
+export interface ExternalPluginOptions {
+  disableNormalize?: boolean;
+}
+
+export interface IframePluginOptions {
+  disableNormalize?: boolean;
+}
 
 export interface ExternalElement {
   type: "external";

--- a/src/components/SlateEditor/plugins/external/utils.ts
+++ b/src/components/SlateEditor/plugins/external/utils.ts
@@ -7,8 +7,10 @@
  */
 
 import { jsx as slatejsx } from "slate-hyperscript";
-import { TYPE_EXTERNAL, TYPE_IFRAME } from "./types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "./types";
 
-export const defaultExternalBlock = () => slatejsx("element", { type: TYPE_EXTERNAL, isFirstEdit: true }, { text: "" });
+export const defaultExternalBlock = () =>
+  slatejsx("element", { type: EXTERNAL_ELEMENT_TYPE, isFirstEdit: true }, { text: "" });
 
-export const defaultIframeBlock = () => slatejsx("element", { type: TYPE_IFRAME, isFirstEdit: true }, { text: "" });
+export const defaultIframeBlock = () =>
+  slatejsx("element", { type: IFRAME_ELEMENT_TYPE, isFirstEdit: true }, { text: "" });

--- a/src/components/SlateEditor/utils/normalizationHelpers.ts
+++ b/src/components/SlateEditor/utils/normalizationHelpers.ts
@@ -15,7 +15,7 @@ import { CODE_BLOCK_ELEMENT_TYPE } from "../plugins/codeBlock/types";
 import { COMMENT_BLOCK_ELEMENT_TYPE } from "../plugins/comment/block/types";
 import { DETAILS_ELEMENT_TYPE } from "../plugins/details/detailsTypes";
 import { TYPE_EMBED_ERROR } from "../plugins/embed/types";
-import { TYPE_EXTERNAL } from "../plugins/external/types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "../plugins/external/types";
 import { FILE_ELEMENT_TYPE } from "../plugins/file/types";
 import { TYPE_GRID } from "../plugins/grid/types";
 import { H5P_ELEMENT_TYPE } from "../plugins/h5p/types";
@@ -43,7 +43,8 @@ export const textBlockElements: Element["type"][] = [
   TYPE_TABLE,
   AUDIO_ELEMENT_TYPE,
   BRIGHTCOVE_ELEMENT_TYPE,
-  TYPE_EXTERNAL,
+  EXTERNAL_ELEMENT_TYPE,
+  IFRAME_ELEMENT_TYPE,
   TYPE_EMBED_ERROR,
   H5P_ELEMENT_TYPE,
   FILE_ELEMENT_TYPE,

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleFormContent.tsx
@@ -30,7 +30,7 @@ import { CAMPAIGN_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/
 import { CODE_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/codeBlock/types";
 import { COMMENT_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/comment/block/types";
 import { CONTACT_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/contactBlock/types";
-import { TYPE_EXTERNAL } from "../../../../components/SlateEditor/plugins/external/types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/external/types";
 import { FILE_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/file/types";
 import { TYPE_GRID } from "../../../../components/SlateEditor/plugins/grid/types";
 import { H5P_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/h5p/types";
@@ -66,7 +66,8 @@ const visualElements = [
   H5P_ELEMENT_TYPE,
   BRIGHTCOVE_ELEMENT_TYPE,
   AUDIO_ELEMENT_TYPE,
-  TYPE_EXTERNAL,
+  EXTERNAL_ELEMENT_TYPE,
+  IFRAME_ELEMENT_TYPE,
   IMAGE_ELEMENT_TYPE,
 ];
 

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
@@ -24,7 +24,7 @@ import { summaryPlugin } from "../../../../components/SlateEditor/plugins/detail
 import { divPlugin } from "../../../../components/SlateEditor/plugins/div";
 import { dndPlugin } from "../../../../components/SlateEditor/plugins/DND";
 import { embedPlugin } from "../../../../components/SlateEditor/plugins/embed";
-import { externalPlugin } from "../../../../components/SlateEditor/plugins/external";
+import { externalPlugin, iframePlugin } from "../../../../components/SlateEditor/plugins/external";
 import { filePlugin } from "../../../../components/SlateEditor/plugins/file";
 import { footnotePlugin } from "../../../../components/SlateEditor/plugins/footnote";
 import { framedContentPlugin } from "../../../../components/SlateEditor/plugins/framedContent/framedContentPlugin";
@@ -64,7 +64,8 @@ export const frontpagePlugins: SlatePlugin[] = [
   divPlugin,
   paragraphPlugin,
   footnotePlugin,
-  externalPlugin(),
+  externalPlugin,
+  iframePlugin,
   embedPlugin(),
   audioPlugin,
   imagePlugin,

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -27,7 +27,7 @@ import { AUDIO_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/a
 import { learningResourceActions } from "../../../../components/SlateEditor/plugins/blockPicker/actions";
 import { CODE_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/codeBlock/types";
 import { COMMENT_BLOCK_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/comment/block/types";
-import { TYPE_EXTERNAL } from "../../../../components/SlateEditor/plugins/external/types";
+import { EXTERNAL_ELEMENT_TYPE, IFRAME_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/external/types";
 import { FILE_ELEMENT_TYPE } from "../../../../components/SlateEditor/plugins/file/types";
 import { FOOTNOTE_ELEMENT_TYPE, FootnoteElement } from "../../../../components/SlateEditor/plugins/footnote/types";
 import { TYPE_GRID } from "../../../../components/SlateEditor/plugins/grid/types";
@@ -59,7 +59,8 @@ const visualElements = [
   H5P_ELEMENT_TYPE,
   BRIGHTCOVE_ELEMENT_TYPE,
   AUDIO_ELEMENT_TYPE,
-  TYPE_EXTERNAL,
+  EXTERNAL_ELEMENT_TYPE,
+  IFRAME_ELEMENT_TYPE,
   IMAGE_ELEMENT_TYPE,
 ];
 

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
@@ -23,7 +23,7 @@ import { summaryPlugin } from "../../../../components/SlateEditor/plugins/detail
 import { divPlugin } from "../../../../components/SlateEditor/plugins/div";
 import { dndPlugin } from "../../../../components/SlateEditor/plugins/DND";
 import { embedPlugin } from "../../../../components/SlateEditor/plugins/embed";
-import { externalPlugin } from "../../../../components/SlateEditor/plugins/external";
+import { externalPlugin, iframePlugin } from "../../../../components/SlateEditor/plugins/external";
 import { filePlugin } from "../../../../components/SlateEditor/plugins/file";
 import { footnotePlugin } from "../../../../components/SlateEditor/plugins/footnote";
 import { framedContentPlugin } from "../../../../components/SlateEditor/plugins/framedContent/framedContentPlugin";
@@ -63,7 +63,8 @@ export const learningResourcePlugins: SlatePlugin[] = [
   audioPlugin,
   imagePlugin,
   h5pPlugin,
-  externalPlugin(),
+  externalPlugin,
+  iframePlugin,
   videoPlugin,
   embedPlugin(),
   framedContentPlugin,

--- a/src/containers/VisualElement/VisualElement.tsx
+++ b/src/containers/VisualElement/VisualElement.tsx
@@ -12,7 +12,7 @@ import { audioPlugin } from "../../components/SlateEditor/plugins/audio/audioPlu
 import { audioRenderer } from "../../components/SlateEditor/plugins/audio/render";
 import { EmbedElements, embedPlugin } from "../../components/SlateEditor/plugins/embed";
 import { embedRenderer } from "../../components/SlateEditor/plugins/embed/render";
-import { externalPlugin } from "../../components/SlateEditor/plugins/external";
+import { externalPlugin, iframePlugin } from "../../components/SlateEditor/plugins/external";
 import { externalRenderer } from "../../components/SlateEditor/plugins/external/render";
 import { h5pPlugin } from "../../components/SlateEditor/plugins/h5p";
 import { h5pRenderer } from "../../components/SlateEditor/plugins/h5p/render";
@@ -54,7 +54,8 @@ const VisualElement = ({
       audioRenderer,
       h5pPlugin.configure({ options: { disableNormalize: true } }),
       h5pRenderer,
-      externalPlugin(true),
+      externalPlugin.configure({ options: { disableNormalize: true } }),
+      iframePlugin.configure({ options: { disableNormalize: true } }),
       videoPlugin.configure({ options: { disableNormalization: true } }),
       videoRenderer,
       imagePlugin.configure({ options: { disableNormalization: true } }),

--- a/src/util/articleContentConverter.tsx
+++ b/src/util/articleContentConverter.tsx
@@ -39,7 +39,7 @@ import { divSerializer } from "../components/SlateEditor/plugins/div";
 import { embedSerializer } from "../components/SlateEditor/plugins/embed";
 import { TYPE_NDLA_EMBED } from "../components/SlateEditor/plugins/embed/types";
 import { defaultEmbedBlock, isSlateEmbed } from "../components/SlateEditor/plugins/embed/utils";
-import { externalSerializer } from "../components/SlateEditor/plugins/external";
+import { externalSerializer, iframeSerializer } from "../components/SlateEditor/plugins/external";
 import { fileSerializer } from "../components/SlateEditor/plugins/file";
 import { footnoteSerializer } from "../components/SlateEditor/plugins/footnote";
 import { framedContentSerializer } from "../components/SlateEditor/plugins/framedContent/framedContentSerializer";
@@ -124,6 +124,7 @@ const extendedRules: SlateSerializer<any>[] = [
   brightcoveSerializer,
   h5pSerializer,
   externalSerializer,
+  iframeSerializer,
   copyrightSerializer,
   embedSerializer,
   framedContentSerializer,


### PR DESCRIPTION
Lagt `IFRAME_ELEMENT_TYPE` de fleste stedene vi kun hadde `EXTERNAL_ELEMENT_TYPE` før. De burde vel strengt tatt behandles ganske så likt?