### PR TITLE
fix: allow for dialog in dialog

### DIFF
--- a/src/components/SlateEditor/plugins/link/Link.tsx
+++ b/src/components/SlateEditor/plugins/link/Link.tsx
@@ -65,12 +65,16 @@ export interface Model {
 
 const Link = ({ attributes, editor, element, children }: Props) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
   const [editMode, setEditMode] = useState(false);
   const language = useArticleLanguage();
   const { t } = useTranslation();
 
   useEffect(() => {
     setEditMode(!!element.isFirstEdit);
+    if (!linkRef.current) return;
+    // We need to portal the popover into the closest slate editor instead of the body to account for editors in portalled dialogs.
+    setContainer(linkRef.current.closest("[data-slate-wrapper]") as HTMLElement | null);
   }, [element]);
 
   const linkData: LinkData = useMemo(() => {
@@ -161,7 +165,7 @@ const Link = ({ attributes, editor, element, children }: Props) => {
             <InlineBugfix />
           </a>
         </PopoverTrigger>
-        <Portal>
+        <Portal container={{ current: container }}>
           <StyledPopoverContent>
             <DialogTrigger asChild>
               <Button variant="link">{t("form.content.link.change")}</Button>

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -140,8 +140,6 @@ const SlateToolbar = ({ options: toolbarOptions, areaOptions, hideToolbar: hideT
     const nonCollapsed = selection && !Range.isCollapsed(selection);
     if (nonCollapsed && hasSelectionWithin && !hasMouseDown) {
       setOpen(true);
-    } else if (!document.activeElement?.closest('[role="dialog"]')) {
-      setOpen(false);
     }
   }, [editor, editor.selection, editorFocused, hasMouseDown, hasSelectionWithin, selection]);
 

--- a/src/containers/FormikForm/InlineField.tsx
+++ b/src/containers/FormikForm/InlineField.tsx
@@ -12,7 +12,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { SlatePlugin } from "../../components/SlateEditor/interfaces";
 import { breakPlugin } from "../../components/SlateEditor/plugins/break";
 import { breakRenderer } from "../../components/SlateEditor/plugins/break/render";
-import { linkPlugin } from "../../components/SlateEditor/plugins/link";
+import { contentLinkPlugin, linkPlugin } from "../../components/SlateEditor/plugins/link";
 import { linkRenderer } from "../../components/SlateEditor/plugins/link/render";
 import { markPlugin } from "../../components/SlateEditor/plugins/mark";
 import { markRenderer } from "../../components/SlateEditor/plugins/mark/render";
@@ -95,6 +95,7 @@ export const InlineField = ({ toolbarOptionsOverride, toolbarAreaFiltersOverride
       markPlugin,
       noopPlugin,
       linkPlugin,
+      contentLinkPlugin,
     ];
 
     return { toolbarOptions, toolbarAreaFilters, plugins: inlinePlugins.concat(renderers) };


### PR DESCRIPTION
Prøver å fikse dialog og popover for link-plugin når man skal sette inn en lenke i bildecaption. Dette er mer plaster på såret enn en solid løsning, men det _funker_. På sikt burde vi nok gå for en mer generell løsning, uten at jeg helt vet hva det skal være.