### PR TITLE
fix: hide rephrase button if user doesn't have AI access

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+import { merge } from "lodash-es";
 import {
   Children,
   ComponentPropsWithRef,
@@ -35,6 +36,8 @@ import {
 } from "./toolbarState";
 import { ToolbarTableOptions } from "./ToolbarTableOptions";
 import { ToolbarTextOptions } from "./ToolbarTextOptions";
+import { AI_ACCESS_SCOPE } from "../../../../constants";
+import { useSession } from "../../../../containers/Session/SessionProvider";
 
 const ToolbarContainer = styled(PopoverContent, {
   base: {
@@ -98,6 +101,7 @@ const SlateToolbar = ({ options: toolbarOptions, areaOptions, hideToolbar: hideT
   const [open, setOpen] = useState(false);
   const [hasSelectionWithin, setHasSelectionWithin] = useState(false);
   const [hasMouseDown, setHasMouseDown] = useState(false);
+  const { userPermissions } = useSession();
 
   const shouldShowToolbar = useSlateSelector((editor) => {
     if (!editor.selection || Range.isCollapsed(editor.selection)) return false;
@@ -152,10 +156,13 @@ const SlateToolbar = ({ options: toolbarOptions, areaOptions, hideToolbar: hideT
     if (hideToolbar) return;
     return toolbarState({
       editorAncestors: getSelectionElements(editor, selection),
-      options: toolbarOptions,
+      // TODO: This is not really scalable if we're going to introduce more constraints later-on.
+      options: userPermissions?.includes(AI_ACCESS_SCOPE)
+        ? toolbarOptions
+        : merge({ inline: { rephrase: { hidden: true, disabled: true } } } as CategoryFilters, toolbarOptions),
       areaOptions,
     });
-  }, [hideToolbar, editor, selection, toolbarOptions, areaOptions]);
+  }, [hideToolbar, editor, selection, userPermissions, toolbarOptions, areaOptions]);
 
   const positioningOptions = useMemo(() => {
     return {


### PR DESCRIPTION
Kun visuelt, backenden sjekker allerede etter dette. Liker ikke løsningen, men det er den beste jeg kommer på.