### PR TITLE
refactor: use a plugin to disable enter key in TitleField instead of extending editor

### DIFF
--- a/src/components/SlateEditor/RichTextEditor.tsx
+++ b/src/components/SlateEditor/RichTextEditor.tsx
@@ -8,7 +8,7 @@
 
 import { useFormikContext } from "formik";
 import { isEqual } from "lodash-es";
-import { FocusEvent, KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FocusEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Descendant, Editor, Range, Transforms } from "slate";
 import { Slate, Editable, RenderElementProps, RenderLeafProps, ReactEditor } from "slate-react";
 import { EditableProps } from "slate-react/dist/components/editable";
@@ -49,7 +49,6 @@ export interface RichTextEditorProps extends Omit<EditableProps, "value" | "onCh
   blockpickerOptions?: Partial<BlockPickerOptions>;
   toolbarOptions: CategoryFilters;
   toolbarAreaFilters: AreaFilters;
-  additionalOnKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => boolean;
   hideBlockPicker?: boolean;
   testId?: string;
   hideToolbar?: boolean;
@@ -72,7 +71,6 @@ const RichTextEditor = ({
   toolbarOptions,
   toolbarAreaFilters,
   hideBlockPicker,
-  additionalOnKeyDown,
   hideToolbar,
   receiveInitialFocus,
   onBlur: onBlurProp,
@@ -216,19 +214,6 @@ const RichTextEditor = ({
     [onBlurProp],
   );
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>) => {
-      let allowEditorKeyDown = true;
-      if (additionalOnKeyDown) {
-        allowEditorKeyDown = additionalOnKeyDown(e);
-      }
-      if (allowEditorKeyDown) {
-        editor.onKeyDown(e);
-      }
-    },
-    [additionalOnKeyDown, editor],
-  );
-
   return (
     <article className={noArticleStyling ? undefined : "ndla-article"}>
       <ArticleLanguageProvider language={language}>
@@ -247,7 +232,7 @@ const RichTextEditor = ({
               aria-labelledby={labelledBy}
               {...rest}
               onBlur={onBlur}
-              onKeyDown={handleKeyDown}
+              onKeyDown={editor.onKeyDown}
               placeholder={placeholder}
               renderElement={renderElement}
               renderLeaf={renderLeaf}

--- a/src/containers/FormikForm/TitleField.tsx
+++ b/src/containers/FormikForm/TitleField.tsx
@@ -6,8 +6,10 @@
  *
  */
 
-import { KeyboardEvent, memo, useCallback, useMemo } from "react";
+import { isKeyHotkey } from "is-hotkey";
+import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { createPlugin } from "@ndla/editor";
 import { FieldErrorMessage, FieldRoot } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { ContentEditableFieldLabel } from "../../components/Form/ContentEditableFieldLabel";
@@ -47,7 +49,22 @@ const StyledRichTextEditor = styled(RichTextEditor, {
   },
 });
 
+const noEnterPlugin = createPlugin({
+  name: "no-enter",
+  shortcuts: {
+    enter: {
+      keyCondition: isKeyHotkey("Enter"),
+      handler: (_, event, logger) => {
+        event.preventDefault();
+        logger.log("Enter key pressed in title field, preventing default behavior");
+        return true;
+      },
+    },
+  },
+});
+
 const titlePlugins: SlatePlugin[] = [
+  noEnterPlugin,
   spanPlugin,
   paragraphPlugin,
   textTransformPlugin,
@@ -85,13 +102,6 @@ const TitleField = ({ maxLength = 256, name = "title", hideToolbar }: Props) => 
     return basePlugins.concat(toolbarPlugin(toolbarOptions, toolbarAreaFilters));
   }, [hideToolbar]);
 
-  const onKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      return false;
-    } else return true;
-  }, []);
-
   return (
     <FormField name={name}>
       {({ field, meta, helpers }) => (
@@ -101,7 +111,6 @@ const TitleField = ({ maxLength = 256, name = "title", hideToolbar }: Props) => 
             {...field}
             id="title-editor"
             testId="title-editor"
-            additionalOnKeyDown={onKeyDown}
             hideBlockPicker
             submitted={false}
             placeholder={t("form.title.label")}


### PR DESCRIPTION
Synes dette er en ganske mye mer "lesbar" måte å håndtere dette tilfellet på. Hele greia er bare at man skal disable enter i tittel-feltet. 