### PR TITLE
fix: ensure buttons are placed above floated image

### DIFF
--- a/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
+++ b/src/components/SlateEditor/plugins/audio/SlateAudio.tsx
@@ -45,6 +45,7 @@ const ButtonContainer = styled("div", {
     display: "flex",
     gap: "3xsmall",
     justifyContent: "flex-end",
+    zIndex: "docked",
   },
 });
 

--- a/src/components/SlateEditor/plugins/details/Details.tsx
+++ b/src/components/SlateEditor/plugins/details/Details.tsx
@@ -25,6 +25,7 @@ const ButtonContainer = styled("div", {
     top: "-xlarge",
     display: "flex",
     gap: "3xsmall",
+    zIndex: "docked",
     justifyContent: "flex-end",
   },
 });

--- a/src/components/SlateEditor/plugins/framedContent/SlateFramedContent.tsx
+++ b/src/components/SlateEditor/plugins/framedContent/SlateFramedContent.tsx
@@ -137,7 +137,7 @@ const SlateFramedContent = (props: Props) => {
         ) : undefined}
         {!hasSlateCopyright && (
           <IconButton
-            variant="tertiary"
+            variant="secondary"
             size="small"
             aria-label={t("form.copyright.add")}
             title={t("form.copyright.add")}


### PR DESCRIPTION
Fixes https://trello.com/c/fENK4KvC/1349-ed-h%C3%B8yrestilt-bilde-kommer-over-knappene-til-ekspanderende-boks