### PR TITLE
Skill på søketrefftype ved ny ressurs i struktur

### DIFF
--- a/src/components/abstractions/Combobox.tsx
+++ b/src/components/abstractions/Combobox.tsx
@@ -29,6 +29,7 @@ import {
   Text,
 } from "@ndla/primitives";
 import { Flex, styled } from "@ndla/styled-system/jsx";
+import { ContentTypeBadge } from "@ndla/ui";
 
 interface GenericComboboxItemIndicatorProps extends ComboboxItemIndicatorProps {
   ref?: Ref<HTMLDivElement>;
@@ -109,6 +110,7 @@ interface GenericComboboxItemCustomProps {
   description?: string;
   fallbackImageElement?: ReactNode;
   useFallbackImage?: boolean;
+  contentType?: string;
   image?: {
     url?: string;
     alt?: string;
@@ -122,6 +124,7 @@ export const GenericComboboxItemContent = ({
   image,
   description,
   fallbackImageElement,
+  contentType,
   useFallbackImage,
   ...props
 }: GenericComboboxItemProps) => (
@@ -142,6 +145,7 @@ export const GenericComboboxItemContent = ({
           </StyledText>
         )}
       </Flex>
+      {contentType ? <ContentTypeBadge contentType={contentType} /> : undefined}
       <GenericComboboxItemIndicator />
     </ListItemContent>
   </StyledListItemRoot>

--- a/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
+++ b/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
@@ -27,6 +27,7 @@ import { IArticleV2DTO } from "@ndla/types-backend/article-api";
 import { ILearningPathSummaryV2DTO, ILearningPathV2DTO } from "@ndla/types-backend/learningpath-api";
 import { IApiTaxonomyContextDTO, IMultiSearchSummaryDTO } from "@ndla/types-backend/search-api";
 import { ResourceType } from "@ndla/types-taxonomy";
+import { ContentTypeBadge } from "@ndla/ui";
 import { GenericComboboxInput, GenericComboboxItemContent } from "../../../components/abstractions/Combobox";
 import { GenericSearchCombobox } from "../../../components/Form/GenericSearchCombobox";
 import { FormActionsContainer, FormContent } from "../../../components/FormikForm";
@@ -295,6 +296,7 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
               title={item.title.title}
               description={item.metaDescription.metaDescription}
               image={item.metaImage}
+              contentType={item.learningResourceType === "learningpath" ? item.learningResourceType : undefined}
               useFallbackImage
             />
           )}
@@ -316,6 +318,9 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
               <ListItemHeading>{preview.title.title}</ListItemHeading>
               <Text textStyle="body.small">{preview.metaDescription?.metaDescription}</Text>
             </StyledListItemContent>
+            {preview.learningResourceType === "learningpath" && (
+              <ContentTypeBadge contentType={preview.learningResourceType} />
+            )}
           </ListItemRoot>
         )
       )}

--- a/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
+++ b/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
@@ -280,11 +280,11 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
       )}
       {!pastedUrl && (
         <GenericSearchCombobox
-          value={preview ? [preview.id.toString()] : undefined}
+          value={preview ? [`${preview.learningResourceType}_${preview.id.toString()}`] : undefined}
           onValueChange={(details) => setPreview(toPreview(details.items[0]))}
           items={searchQuery.data?.results ?? []}
           itemToString={(item) => item.title.title}
-          itemToValue={(item) => item.id.toString()}
+          itemToValue={(item) => `${item.learningResourceType}_${item.id.toString()}`}
           inputValue={query}
           onInputValueChange={(details) => setQuery(details.inputValue)}
           isSuccess={searchQuery.isSuccess}


### PR DESCRIPTION
Det er vanskelig å søke etter nye læringsstier, og om du forsøker å søke på sti-id så vil du kunne få både sti og artikkel med samme id i lista. Disse lar seg ikkje skille i dag og kun den første lar seg velge. 
Denne koden gjør det _litt_ enklere å finne læringsstier i dette søket.

Test: søk etter 3305 i felt for å legge til ny ressurs i struktur. Sjå at du kan skille mellom disse to:
![image](https://github.com/user-attachments/assets/60e5c0f5-8e86-4242-bbeb-9c095b512ee1)
