### PR TITLE
fix: remove redundant taxonomy note update

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -220,7 +220,6 @@ const LearningResourcePanels = ({
             >
               <LearningResourceTaxonomy
                 article={article}
-                updateNotes={updateNotes}
                 articleLanguage={articleLanguage}
                 hasTaxEntries={!!contexts?.length}
               />

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceTaxonomy.tsx
@@ -10,7 +10,7 @@ import { sortBy } from "lodash-es";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@ndla/primitives";
-import { IUpdatedArticleDTO, IArticleDTO } from "@ndla/types-backend/draft-api";
+import { IArticleDTO } from "@ndla/types-backend/draft-api";
 import { Metadata, NodeChild } from "@ndla/types-taxonomy";
 import TaxonomyBlock from "./taxonomy/TaxonomyBlock";
 import { useNodes } from "../../../../modules/nodes/nodeQueries";
@@ -20,7 +20,6 @@ import { useTaxonomyVersion } from "../../../StructureVersion/TaxonomyVersionPro
 
 interface Props {
   article: IArticleDTO;
-  updateNotes: (art: IUpdatedArticleDTO) => Promise<IArticleDTO>;
   articleLanguage: string;
   hasTaxEntries: boolean;
 }
@@ -33,7 +32,7 @@ export interface MinimalNodeChild
   metadata: Pick<Metadata, "visible">;
 }
 
-const LearningResourceTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEntries }: Props) => {
+const LearningResourceTaxonomy = ({ article, articleLanguage, hasTaxEntries }: Props) => {
   const { i18n } = useTranslation();
   const { taxonomyVersion } = useTaxonomyVersion();
 
@@ -73,7 +72,6 @@ const LearningResourceTaxonomy = ({ article, updateNotes, articleLanguage, hasTa
       subjects={subjectsQuery.data ?? []}
       hasTaxEntries={hasTaxEntries}
       resourceTypes={allResourceTypesQuery.data ?? []}
-      updateNotes={updateNotes}
       article={article}
       articleLanguage={articleLanguage}
       versions={versionsQuery.data ?? []}

--- a/src/containers/ArticlePage/LearningResourcePage/components/taxonomy/TaxonomyBlock.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/taxonomy/TaxonomyBlock.tsx
@@ -11,7 +11,7 @@ import { useCallback, useMemo, useState, MouseEvent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button, SelectLabel, Text } from "@ndla/primitives";
-import { IArticleDTO, IUpdatedArticleDTO } from "@ndla/types-backend/draft-api";
+import { IArticleDTO } from "@ndla/types-backend/draft-api";
 import {
   Node,
   NodeChild,
@@ -46,7 +46,6 @@ interface Props {
   resourceTypes: ResourceType[];
   article: IArticleDTO;
   versions: Version[];
-  updateNotes: (art: IUpdatedArticleDTO) => Promise<IArticleDTO>;
   articleLanguage: string;
 }
 
@@ -104,7 +103,6 @@ const TaxonomyBlock = ({
   resourceTypes,
   versions,
   article,
-  updateNotes,
   articleLanguage,
 }: Props) => {
   const { t, i18n } = useTranslation();
@@ -264,12 +262,6 @@ const TaxonomyBlock = ({
         originalNode: initialResource,
         taxonomyVersion,
       });
-      await updateNotes({
-        revision: article.revision,
-        notes: ["Oppdatert taksonomi."],
-        metaImage: undefined,
-        responsibleId: undefined,
-      });
       await qc.invalidateQueries({
         queryKey: nodeQueryKeys.nodes({
           contentURI: `urn:article:${article.id}`,
@@ -282,13 +274,11 @@ const TaxonomyBlock = ({
     },
     [
       article.id,
-      article.revision,
       article.title?.title,
       articleLanguage,
       initialResource,
       qc,
       taxonomyVersion,
-      updateNotes,
       updateTaxMutation,
       workingResource,
     ],

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleAccordionPanels.tsx
@@ -11,7 +11,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { PageContent, SwitchControl, SwitchHiddenInput, SwitchLabel, SwitchRoot, SwitchThumb } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { IUpdatedArticleDTO, IArticleDTO } from "@ndla/types-backend/draft-api";
+import { IArticleDTO } from "@ndla/types-backend/draft-api";
 import TopicArticleContent from "./TopicArticleContent";
 import TopicArticleTaxonomy from "./TopicArticleTaxonomy";
 import FormAccordion from "../../../../components/Accordion/FormAccordion";
@@ -57,18 +57,11 @@ const StyledControls = styled("div", {
 interface Props {
   article?: IArticleDTO;
   articleHistory: IArticleDTO[] | undefined;
-  updateNotes: (art: IUpdatedArticleDTO) => Promise<IArticleDTO>;
   articleLanguage: string;
   hasTaxonomyEntries: boolean;
 }
 
-const TopicArticleAccordionPanels = ({
-  article,
-  articleHistory,
-  updateNotes,
-  articleLanguage,
-  hasTaxonomyEntries,
-}: Props) => {
+const TopicArticleAccordionPanels = ({ article, articleHistory, articleLanguage, hasTaxonomyEntries }: Props) => {
   const [hideComments, setHideComments] = useLocalStorageBooleanState(STORED_HIDE_COMMENTS);
   const { t } = useTranslation();
   const { userPermissions } = useSession();
@@ -117,7 +110,6 @@ const TopicArticleAccordionPanels = ({
             >
               <TopicArticleTaxonomy
                 article={article}
-                updateNotes={updateNotes}
                 articleLanguage={articleLanguage}
                 hasTaxEntries={hasTaxonomyEntries}
               />

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -135,7 +135,6 @@ const TopicArticleForm = ({
           <TopicArticleAccordionPanels
             articleLanguage={articleLanguage}
             articleHistory={articleHistory?.data}
-            updateNotes={updateArticle}
             article={article}
             hasTaxonomyEntries={!!articleTaxonomy?.length}
           />

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleTaxonomy.tsx
@@ -10,7 +10,7 @@ import { sortBy } from "lodash-es";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@ndla/primitives";
-import { IUpdatedArticleDTO, IArticleDTO } from "@ndla/types-backend/draft-api";
+import { IArticleDTO } from "@ndla/types-backend/draft-api";
 import { Node } from "@ndla/types-taxonomy";
 import { ErrorMessage } from "@ndla/ui";
 import TopicTaxonomyBlock from "./TopicTaxonomyBlock";
@@ -20,7 +20,6 @@ import { useTaxonomyVersion } from "../../../StructureVersion/TaxonomyVersionPro
 
 type Props = {
   article: IArticleDTO;
-  updateNotes: (art: IUpdatedArticleDTO) => Promise<IArticleDTO>;
   articleLanguage: string;
   hasTaxEntries: boolean;
 };
@@ -41,7 +40,7 @@ const partitionByValidity = (nodes: Node[]) => {
   return [validPlacements, invalidPlacements];
 };
 
-const TopicArticleTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEntries }: Props) => {
+const TopicArticleTaxonomy = ({ article, articleLanguage, hasTaxEntries }: Props) => {
   const { t } = useTranslation();
   const { taxonomyVersion, changeVersion } = useTaxonomyVersion();
   const versionsQuery = useVersions();
@@ -99,7 +98,6 @@ const TopicArticleTaxonomy = ({ article, updateNotes, articleLanguage, hasTaxEnt
       versions={versionsQuery.data ?? []}
       hasTaxEntries={hasTaxEntries}
       articleLanguage={articleLanguage}
-      updateNotes={updateNotes}
     />
   );
 };

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicTaxonomyBlock.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicTaxonomyBlock.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button, ExpandableBox, ExpandableBoxSummary, SelectLabel, Text, UnOrderedList } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { IArticleDTO, IUpdatedArticleDTO } from "@ndla/types-backend/draft-api";
+import { IArticleDTO } from "@ndla/types-backend/draft-api";
 import { Node, Version } from "@ndla/types-taxonomy";
 import TopicArticleConnections from "./TopicArticleConnections";
 import { FormActionsContainer, FormContent } from "../../../../components/FormikForm";
@@ -38,7 +38,6 @@ interface Props {
   validPlacements: Node[];
   invalidPlacements: Node[];
   articleLanguage: string;
-  updateNotes: (art: IUpdatedArticleDTO) => Promise<IArticleDTO>;
 }
 
 const StyledLi = styled("li", {
@@ -56,7 +55,6 @@ const TopicTaxonomyBlock = ({
   nodes,
   subjects: propSubjects,
   articleLanguage,
-  updateNotes,
 }: Props) => {
   const { userPermissions } = useSession();
   const { taxonomyVersion, changeVersion } = useTaxonomyVersion();
@@ -103,13 +101,6 @@ const TopicTaxonomyBlock = ({
         name: article.title?.title ?? "",
         articleId: article.id,
         taxonomyVersion,
-      });
-      await updateNotes({
-        revision: article.revision,
-        language: article.title?.language,
-        notes: ["Oppdatert taksonomi."],
-        metaImage: undefined,
-        responsibleId: undefined,
       });
       await qc.invalidateQueries({
         queryKey: nodeQueryKeys.nodes({


### PR DESCRIPTION
Bør deployes sammen med [denne](https://github.com/NDLANO/taxonomy-api/pull/285)

Fjerner notater som oppdateres pga endringer i struktur siden disse nå oppdateres direkte fra taxonomy-api.