### PR TITLE
fix: add missing div plugin to commentToolbarUtils

### DIFF
--- a/src/containers/ArticlePage/components/commentToolbarUtils.ts
+++ b/src/containers/ArticlePage/components/commentToolbarUtils.ts
@@ -31,12 +31,14 @@ import { markPlugin } from "../../../components/SlateEditor/plugins/mark";
 import { listPlugin } from "../../../components/SlateEditor/plugins/list";
 import { inlineNavigationPlugin } from "@ndla/editor";
 import { divRenderer } from "../../../components/SlateEditor/plugins/div/render";
+import { divPlugin } from "../../../components/SlateEditor/plugins/div";
 
 export const plugins: SlatePlugin[] = [
   inlineNavigationPlugin,
   sectionPlugin,
   spanPlugin,
   paragraphPlugin,
+  divPlugin,
   toolbarPlugin(),
   textTransformPlugin,
   breakPlugin,


### PR DESCRIPTION
Vi rendrer div, så vi burde inkludere pluginen også!