### PR TITLE
Support for HTML in AI rephrasing

### DIFF
--- a/src/components/SlateEditor/plugins/div/queries.ts
+++ b/src/components/SlateEditor/plugins/div/queries.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import { Descendant } from "slate";
+import { Node } from "slate";
 import { isElementOfType } from "@ndla/editor";
 import { DIV_ELEMENT_TYPE } from "./types";
 
-export const isDivElement = (node: Descendant | undefined) => isElementOfType(node, DIV_ELEMENT_TYPE);
+export const isDivElement = (node: Node | undefined) => isElementOfType(node, DIV_ELEMENT_TYPE);

--- a/src/components/SlateEditor/plugins/rephrase/Rephrase.tsx
+++ b/src/components/SlateEditor/plugins/rephrase/Rephrase.tsx
@@ -7,14 +7,16 @@
  */
 
 import { useCallback, useMemo } from "react";
-import { Editor, Path, Node, Transforms } from "slate";
+import { Editor, Element, Path, Transforms } from "slate";
 import { ReactEditor, RenderElementProps } from "slate-react";
-import { PARAGRAPH_ELEMENT_TYPE } from "@ndla/editor";
 import { useArticleLanguage } from "../../ArticleLanguageProvider";
 import { isRephraseElement } from "./queries/rephraseQueries";
 import { RephraseElement } from "./rephraseTypes";
+import { blockContentToEditorValue, blockContentToHTML } from "../../../../util/articleContentConverter";
 import { AiPromptDialog } from "../../../AiPromptDialog";
 import mergeLastUndos from "../../utils/mergeLastUndos";
+import { isDivElement } from "../div/queries";
+import { DIV_ELEMENT_TYPE } from "../div/types";
 
 interface Props extends RenderElementProps {
   element: RephraseElement;
@@ -24,51 +26,46 @@ interface Props extends RenderElementProps {
 export const Rephrase = ({ attributes, editor, element, children }: Props) => {
   const language = useArticleLanguage();
 
-  // TODO Handle marks and inlines in query.
-  const currentText = useMemo(() => Node.string(element), [element]);
+  const html = useMemo(() => blockContentToHTML(element.children), [element.children]);
 
-  const onClose = useCallback(() => {
-    const path = ReactEditor.findPath(editor, element);
-    const startOfNextPath = editor.start(Path.next(path));
-    Transforms.select(editor, startOfNextPath);
-    Transforms.unwrapNodes(editor, {
-      match: isRephraseElement,
-      at: path,
-      voids: true,
-    });
-    setTimeout(() => ReactEditor.focus(editor), 0);
-  }, [editor, element]);
+  const onClose = useCallback(
+    (generatedHtml?: string, shouldReplace?: boolean) => {
+      const path = ReactEditor.findPath(editor, element);
+      const nextPath = Path.next(path);
 
-  const onReplace = (generatedText: string) => {
-    if (generatedText) {
-      editor.insertText(generatedText);
-      mergeLastUndos(editor);
-    }
-    onClose();
-  };
+      if (generatedHtml) {
+        const [node] = blockContentToEditorValue(`<div>${generatedHtml}</div>`) as Element[];
+        Transforms.insertNodes(editor, { type: DIV_ELEMENT_TYPE, children: node.children }, { at: nextPath });
+        Transforms.unwrapNodes(editor, { match: isDivElement, at: nextPath });
+        mergeLastUndos(editor);
+      }
 
-  const onAppend = (generatedText: string) => {
-    if (generatedText) {
-      const [entry] = editor.nodes({ match: isRephraseElement });
-      const [_node, path] = entry;
-      editor.insertNode({ type: PARAGRAPH_ELEMENT_TYPE, children: [{ text: generatedText }] }, { at: Path.next(path) });
-      mergeLastUndos(editor);
-    }
-    onClose();
-  };
+      Transforms.select(editor, nextPath);
+      if (shouldReplace) {
+        Transforms.removeNodes(editor, { match: isRephraseElement, at: path });
+      } else {
+        Transforms.unwrapNodes(editor, {
+          match: isRephraseElement,
+          at: path,
+        });
+      }
+
+      setTimeout(() => ReactEditor.focus(editor), 0);
+    },
+    [editor, element],
+  );
 
   return (
     <AiPromptDialog
       defaultOpen
       promptVariables={{
         type: "alternativePhrasing",
-        text: currentText,
-        excerpt: currentText,
+        html,
       }}
       language={language}
       onExitComplete={onClose}
-      onReplace={onReplace}
-      onAppend={onAppend}
+      onReplace={(html) => onClose(html, true)}
+      onAppend={(html) => onClose(html, false)}
     >
       <span {...attributes}>{children}</span>
     </AiPromptDialog>

--- a/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/SlateToolbar.tsx
@@ -27,12 +27,12 @@ import { ToolbarInlineOptions } from "./ToolbarInlineOptions";
 import { ToolbarLanguageOptions } from "./ToolbarLanguageOptions";
 import { ToolbarMarkOptions } from "./ToolbarMarkOptions";
 import {
-  getSelectionElements,
   toolbarState,
   CategoryFilters,
   AreaFilters,
   ToolbarValue,
   ToolbarValues,
+  getSelectionElementTypes,
 } from "./toolbarState";
 import { ToolbarTableOptions } from "./ToolbarTableOptions";
 import { ToolbarTextOptions } from "./ToolbarTextOptions";
@@ -94,7 +94,6 @@ const checkHasSelectionWithin = (el?: Element | null) => {
 };
 
 const SlateToolbar = ({ options: toolbarOptions, areaOptions, hideToolbar: hideToolbarProp }: Props) => {
-  const selection = useSlateSelection();
   const editor = useSlate();
   const toolbarRef = useRef<HTMLDivElement>(null);
   const editorWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -154,15 +153,17 @@ const SlateToolbar = ({ options: toolbarOptions, areaOptions, hideToolbar: hideT
 
   const options = useMemo(() => {
     if (hideToolbar) return;
+    const { types, multipleBlocks } = getSelectionElementTypes(editor);
     return toolbarState({
-      editorAncestors: getSelectionElements(editor, selection),
+      selectionElementTypes: types,
+      multipleBlocksSelected: multipleBlocks,
       // TODO: This is not really scalable if we're going to introduce more constraints later-on.
       options: userPermissions?.includes(AI_ACCESS_SCOPE)
         ? toolbarOptions
         : merge({ inline: { rephrase: { hidden: true, disabled: true } } } as CategoryFilters, toolbarOptions),
       areaOptions,
     });
-  }, [hideToolbar, editor, selection, userPermissions, toolbarOptions, areaOptions]);
+  }, [hideToolbar, editor, userPermissions, toolbarOptions, areaOptions]);
 
   const positioningOptions = useMemo(() => {
     return {

--- a/src/components/SlateEditor/plugins/toolbar/__tests__/toolbarState-test.ts
+++ b/src/components/SlateEditor/plugins/toolbar/__tests__/toolbarState-test.ts
@@ -147,30 +147,27 @@ const arrayifyToolbar = (toolbar: OptionsType) => {
 };
 
 describe("toolbarState", () => {
-  test("returns all options if no area options, editorAncestors and default values are provided", () => {
+  test("returns all options if no area options, selection element types and default values are provided", () => {
     const res = toolbarState({ options: {}, areaOptions: {} });
     const expected = arrayifyToolbar(allOptions);
     expect(res).toEqual(expected);
   });
 
-  test("is not affected by only providing editorAncestors", () => {
+  test("is not affected by only providing paragraph selection element", () => {
     const res = toolbarState({
       options: {},
       areaOptions: {},
-      editorAncestors: [{ type: "paragraph", children: [{ text: "test" }] }],
+      selectionElementTypes: ["paragraph"],
     });
     const expected = arrayifyToolbar(allOptions);
     expect(res).toEqual(expected);
   });
 
-  test("filters out options that are disabled or hidden due to editorAncestors", () => {
+  test("filters out options that are disabled or hidden due to selection element types", () => {
     const res = toolbarState({
       options: {},
       areaOptions: createToolbarAreaOptions(),
-      editorAncestors: [
-        { type: "heading", children: [], level: 1 },
-        { type: "paragraph", children: [{ text: "test" }] },
-      ],
+      selectionElementTypes: ["heading", "paragraph"],
     });
 
     const opts: OptionsType = {
@@ -207,10 +204,7 @@ describe("toolbarState", () => {
           },
         },
       }),
-      editorAncestors: [
-        { type: "heading", children: [], level: 1 },
-        { type: "paragraph", children: [{ text: "test" }] },
-      ],
+      selectionElementTypes: ["heading", "paragraph"],
     });
 
     const opts: OptionsType = {

--- a/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
+++ b/src/components/SlateEditor/plugins/toolbar/handleMenuClicks.ts
@@ -10,7 +10,7 @@ import { KeyboardEvent, SyntheticEvent } from "react";
 import { Editor, Transforms, Element, Range, Node, BaseRange } from "slate";
 import { jsx as slatejsx } from "slate-hyperscript";
 import { HeadingElement, LIST_TYPES, ParagraphElement, toggleHeading, toggleList } from "@ndla/editor";
-import { BlockType, InlineType, TextType, getEditorAncestors } from "./toolbarState";
+import { BlockType, InlineType, TextType, getSelectionElementTypes } from "./toolbarState";
 import toggleBlock from "../../utils/toggleBlock";
 import { insertComment } from "../comment/inline/utils";
 import { insertInlineConcept } from "../concept/inline/utils";
@@ -38,9 +38,9 @@ const textOptions = (range: BaseRange) => ({
 });
 
 export const handleTextChange = (editor: Editor, type: string) => {
-  const ancestors = getEditorAncestors(editor, true);
-  const defaultValue = defaultValueState?.[ancestors[1]?.type] ??
-    defaultValueState?.[ancestors[0]?.type] ?? { type: TYPE_PARAGRAPH };
+  const { types: selectionTypes } = getSelectionElementTypes(editor, true);
+  const defaultValue = defaultValueState?.[selectionTypes[1]] ??
+    defaultValueState?.[selectionTypes[0]] ?? { type: TYPE_PARAGRAPH };
 
   const props: Partial<TextElements> =
     type === "normal-text" ? defaultValue : { type: TYPE_HEADING, level: parseHeadingLevel(type) };

--- a/src/components/SlateEditor/plugins/toolbar/index.ts
+++ b/src/components/SlateEditor/plugins/toolbar/index.ts
@@ -17,7 +17,7 @@ import {
   ToolbarAction,
   createToolbarAreaOptions,
   createToolbarDefaultValues,
-  getEditorAncestors,
+  getSelectionElementTypes,
   toolbarState,
 } from "./toolbarState";
 
@@ -106,8 +106,10 @@ const toolbarPlugin =
         return;
       }
 
+      const { types, multipleBlocks } = getSelectionElementTypes(editor);
       const state = toolbarState({
-        editorAncestors: getEditorAncestors(editor),
+        selectionElementTypes: types,
+        multipleBlocksSelected: multipleBlocks,
         options,
         areaOptions,
       });

--- a/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
+++ b/src/components/SlateEditor/plugins/toolbar/toolbarState.ts
@@ -7,11 +7,8 @@
  */
 
 import { merge } from "lodash-es";
-import { Editor, Element, Node, BaseSelection, Text } from "slate";
-import { NOOP_ELEMENT_TYPE } from "@ndla/editor";
+import { Editor, Element } from "slate";
 import { ElementType } from "../../interfaces";
-import { TYPE_PARAGRAPH } from "../paragraph/types";
-import { TYPE_SECTION } from "../section/types";
 import { SYMBOL_ELEMENT_TYPE } from "../symbol/types";
 
 export const languages = [
@@ -160,7 +157,7 @@ export const defaultAreaOptions: AreaFilters = {
     table: { hidden: false },
   },
   "concept-inline": {
-    inline: { disabled: true, "concept-inline": { disabled: false } },
+    inline: { disabled: true, "concept-inline": { disabled: false }, rephrase: { disabled: false } },
   },
   "content-link": {
     inline: { disabled: true, "content-link": { disabled: false } },
@@ -169,10 +166,14 @@ export const defaultAreaOptions: AreaFilters = {
     inline: { disabled: true },
   },
   mathml: {
-    inline: { disabled: true, mathml: { disabled: false } },
+    inline: { disabled: true, mathml: { disabled: false }, rephrase: { disabled: false } },
   },
-  "comment-inline": { inline: { disabled: true, "comment-inline": { disabled: false } } },
-  [SYMBOL_ELEMENT_TYPE]: { inline: { disabled: true, [SYMBOL_ELEMENT_TYPE]: { disabled: false } } },
+  "comment-inline": {
+    inline: { disabled: true, "comment-inline": { disabled: false }, rephrase: { disabled: false } },
+  },
+  [SYMBOL_ELEMENT_TYPE]: {
+    inline: { disabled: true, [SYMBOL_ELEMENT_TYPE]: { disabled: false }, rephrase: { disabled: false } },
+  },
   list: { inline: { disabled: true } },
   "definition-term": {
     block: { quote: { disabled: true } },
@@ -234,95 +235,47 @@ export const createToolbarDefaultValues = (userValues: CategoryFilters = {}): Ca
   }, {});
 };
 
-interface ToolbarStateProps {
+export const getSelectionElementTypes = (editor: Editor, reverse?: boolean) => {
+  // Finds the current lowest node in the editor and creates an array of its ancestors.
+  const elementGen = Editor.nodes(editor, {
+    match: (node) => Element.isElement(node) && node.type !== "section",
+    at: editor.selection ? Editor.unhangRange(editor, editor.selection) : undefined,
+    reverse,
+  });
+  const types = new Set<ElementType>();
+  let numBlocks = 0;
+  // ancestorGen is a generator, so we need to iterate over it to get the values.
+  for (const [element] of elementGen) {
+    types.add(element.type);
+    if (Editor.isBlock(editor, element)) numBlocks++;
+  }
+  return {
+    types: Array.from(types),
+    multipleBlocks: numBlocks > 1,
+  };
+};
+
+type ToolbarStateProps = {
+  selectionElementTypes?: ElementType[];
+  multipleBlocksSelected?: boolean;
   options?: CategoryFilters;
   areaOptions?: AreaFilters;
-  editorAncestors?: Element[];
-  selection?: BaseSelection;
-}
-
-export const getSelectionElements = (editor: Editor, selection: BaseSelection): Element[] => {
-  // Get elements in the selection only
-  if (selection) {
-    const fragments = editor.getFragment();
-    const elementFragments = fragments.filter(Element.isElement);
-
-    // When a fragment selects multiple blocks it seems to return the blocks in a section,
-    // if it is a section we have to flatten it and find the inline children.
-    // TODO: This logic works for the current nodes we have, further nested might provide a problem and must be solved in a different way.
-    if (elementFragments?.[0]?.type === TYPE_SECTION) {
-      return elementFragments
-        .flatMap((node) => node?.children as Element[])
-        .flatMap((node) => node?.children as Element[]);
-    } else if (elementFragments?.[0]?.type === TYPE_PARAGRAPH) {
-      return elementFragments.flatMap((node) => node?.children as Element[]);
-    }
-
-    return elementFragments;
-  }
-  return [];
-};
-
-export const getEditorAncestors = (editor: Editor, reverse?: boolean): Element[] => {
-  // Finds the current lowest node in the editor and creates an array of its ancestors.
-  const [lowest] = Editor.nodes(editor, { mode: "lowest" });
-  const ancestorGen = Node.ancestors(editor, lowest[1], { reverse });
-  const elementAncestors: Element[] = [];
-  // ancestorGen is a generator, so we need to iterate over it to get the values.
-  for (const ancestor of ancestorGen) {
-    if (Element.isElement(ancestor[0]) && ancestor[0].type !== "section") {
-      elementAncestors.push(ancestor[0]);
-    }
-  }
-  return elementAncestors;
-};
-
-/**
- * Sets all inline types as disabled if multiple element blocks are selected.
- */
-const disableInlineOnMultipleBlocksSelected = (
-  options: OptionsType,
-  editorAncestors?: Element[],
-): OptionsType & CategoryFilters => {
-  const ancestors =
-    editorAncestors?.[0]?.type === NOOP_ELEMENT_TYPE ? (editorAncestors[0].children as Element[]) : editorAncestors;
-
-  // Filter ancestors that contain inline elements or text blocks
-  // We need to handle both flattened text element and paragraph blocks
-  const filteredAncestors =
-    ancestors?.filter(
-      (fragment) =>
-        fragment.children?.length > 1 ||
-        (Text.isText(fragment) && fragment.text !== "") ||
-        (fragment.children?.length === 1 && Text.isText(fragment.children[0]) && fragment.children[0].text !== ""),
-    ) ?? [];
-
-  if (filteredAncestors?.length < 2) return options;
-
-  const disabledInlines = Object.entries(options.inline).reduce(
-    (acc, [key, value]) => {
-      const k = key as InlineType;
-      acc[k] = { ...value, disabled: true };
-      return acc;
-    },
-    {} as OptionsType["inline"],
-  );
-  return { ...options, inline: disabledInlines };
 };
 
 /**
  * Generates the toolbar based on the current selection of the editor.
  **/
 export const toolbarState = ({
+  selectionElementTypes,
+  multipleBlocksSelected,
   options: optionsProp = {},
   areaOptions = {},
-  editorAncestors,
 }: ToolbarStateProps): ToolbarType => {
   // Deep clone options to not mutate the original object.
   const options = deepClone(optionsProp);
 
-  editorAncestors?.forEach((node) => {
-    const filters = areaOptions[node.type];
+  selectionElementTypes?.forEach((type) => {
+    const filters = areaOptions[type];
     if (filters) {
       Object.entries(filters).forEach(([k, v]) => {
         const key = k as ToolbarCategories;
@@ -333,9 +286,13 @@ export const toolbarState = ({
   });
 
   const merged = merge({}, allOptions, options);
-  const maybeDisabledInline = disableInlineOnMultipleBlocksSelected(merged, editorAncestors);
+  if (multipleBlocksSelected) {
+    Object.keys(merged.inline).forEach((key) => {
+      merged.inline[key as InlineType].disabled = true;
+    });
+  }
 
-  const toolbar = Object.entries(maybeDisabledInline).reduce<ToolbarType>(
+  const toolbar = Object.entries(merged).reduce<ToolbarType>(
     (acc, curr) => {
       acc[curr[0] as ToolbarCategories] = Object.values(curr[1]);
       return acc;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -245,8 +245,7 @@ export interface AltTextVariables {
 
 export interface AlternativePhrasingVariables {
   type: "alternativePhrasing";
-  text: string;
-  excerpt: string;
+  html: string;
 }
 
 export interface MetaDescriptionVariables {
@@ -268,7 +267,7 @@ const promptTypes: PromptType[] = [
   "reflection",
 ] as const;
 
-export const isPromptType = (type: string): type is PromptType => promptTypes.includes(type as PromptType);
+export const isPromptType = (type: any): type is PromptType => promptTypes.includes(type as PromptType);
 
 export type PromptPayload<T extends PromptVariables> = T & {
   language: string;
@@ -280,4 +279,9 @@ export type PromptPayload<T extends PromptVariables> = T & {
 export interface DefaultPrompts {
   role: string;
   instructions: string;
+}
+
+export interface LlmReponse {
+  fullResponse: string;
+  answer: string;
 }

--- a/src/modules/llm/llmApi.ts
+++ b/src/modules/llm/llmApi.ts
@@ -6,20 +6,20 @@
  *
  */
 
-import { PromptVariables, PromptPayload, PromptType, DefaultPrompts } from "../../interfaces";
+import { PromptVariables, PromptPayload, PromptType, DefaultPrompts, LlmReponse } from "../../interfaces";
 import { fetchAuthorized } from "../../util/apiHelpers";
-import { resolveJsonOrRejectWithError, resolveTextOrRejectWithError } from "../../util/resolveJsonOrRejectWithError";
+import { resolveJsonOrRejectWithError } from "../../util/resolveJsonOrRejectWithError";
 
 export const fetchAIGeneratedAnswer = async <TVariables extends PromptVariables>(
   payload: PromptPayload<TVariables>,
-): Promise<string> =>
+): Promise<LlmReponse> =>
   fetchAuthorized("/generate-ai", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(payload),
-  }).then((res) => resolveTextOrRejectWithError(res));
+  }).then((res) => resolveJsonOrRejectWithError(res));
 
 export const fetchDefaultAiPrompts = async (type: PromptType, language: string): Promise<DefaultPrompts> =>
   fetchAuthorized(`/default-ai-prompts?type=${type}&language=${language}`).then((res) =>

--- a/src/modules/llm/llmMutations.ts
+++ b/src/modules/llm/llmMutations.ts
@@ -8,10 +8,10 @@
 
 import { DefaultError, UseMutationOptions, useMutation } from "@tanstack/react-query";
 import { fetchAIGeneratedAnswer } from "./llmApi";
-import { PromptVariables, PromptPayload } from "../../interfaces";
+import { PromptVariables, PromptPayload, LlmReponse } from "../../interfaces";
 
 export const useGenerateAIMutation = <TVariables extends PromptVariables>(
-  options?: UseMutationOptions<string, DefaultError, PromptPayload<TVariables>>,
+  options?: UseMutationOptions<LlmReponse, DefaultError, PromptPayload<TVariables>>,
 ) =>
   useMutation({
     mutationFn: fetchAIGeneratedAnswer,

--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -2313,6 +2313,7 @@ const phrases = {
     },
     failed: "Oops, something went wrong! Could not generate $t(textGeneration.types.{{type}}).\n{{error}}",
     failedTranscription: "Oops, something went wrong! Could not generate transcription.",
+    responseBox: "Full response from the AI model",
   },
 };
 

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -2311,6 +2311,7 @@ const phrases = {
     },
     failed: "Her gikk det galt! Klarte ikke å generere $t(textGeneration.types.{{type}}).\n{{error}}",
     failedTranscription: "Her gikk det galt! Klarte ikke å generere transkripsjon.",
+    responseBox: "Full respons fra KI-modellen",
   },
 };
 

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -2312,6 +2312,7 @@ const phrases = {
     },
     failed: "Her gjekk det gale! Klarte ikkje å generere $t(textGeneration.types.{{type}}).\n{{error}}",
     failedTranscription: "Her gjekk det gale! Klarte ikkje å generere transkribering.",
+    responseBox: "Full respons fra KI-modellen",
   },
 };
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -210,8 +210,8 @@ router.post("/generate-ai", jwtMiddleware, aiMiddleware, async (req, res) => {
     return;
   }
   try {
-    const text = await generateAnswer(req.body, req.body.language, req.body.max_tokens);
-    res.status(OK).send(text);
+    const llmResponse = await generateAnswer(req.body, req.body.language, req.body.max_tokens);
+    res.status(OK).send(llmResponse);
   } catch (err) {
     res
       .status(INTERNAL_SERVER_ERROR)

--- a/src/server/llm.ts
+++ b/src/server/llm.ts
@@ -17,7 +17,7 @@ import {
 } from "@aws-sdk/client-transcribe";
 import { llmQueryText } from "./llmQueries";
 import { PROMPTS } from "./llmPrompts";
-import { PromptType, DefaultPrompts, PromptPayload, PromptVariables } from "../interfaces";
+import { PromptType, DefaultPrompts, PromptPayload, PromptVariables, LlmReponse } from "../interfaces";
 import { LlmLanguageCode } from "./llmTypes";
 
 const aiModelId = getEnvironmentVariabel("NDLA_AI_MODEL_ID", "test");
@@ -41,7 +41,11 @@ export const getDefaultPrompts = (type: PromptType, language: LlmLanguageCode): 
   return { role, instructions };
 };
 
-export const generateAnswer = async (request: PromptPayload<PromptVariables>, language: string, max_tokens: number) => {
+export const generateAnswer = async (
+  request: PromptPayload<PromptVariables>,
+  language: string,
+  max_tokens: number | undefined,
+): Promise<LlmReponse> => {
   const { role, message } = llmQueryText(request, language);
 
   const prompt = {
@@ -76,6 +80,7 @@ export const generateAnswer = async (request: PromptPayload<PromptVariables>, la
     system: role,
   };
 
+  console.log("Invoking LLM with role:", role, "\nAnd prompt:", message);
   const command = new InvokeModelCommand({
     contentType: "application/json",
     body: JSON.stringify(payload),
@@ -85,15 +90,22 @@ export const generateAnswer = async (request: PromptPayload<PromptVariables>, la
   const decodedResponseBody = textDecoder.decode(response.body);
   const responseBody = JSON.parse(decodedResponseBody);
 
-  const containsError = responseBody.content[0].text.includes("<ERROR>");
+  const responseText = responseBody.content?.[0]?.text;
+  if (typeof responseText !== "string") throw new Error("Invalid response from Bedrock");
 
+  const containsError = responseText.includes("<ERROR>");
   if (containsError) {
-    const errorMsg = responseBody.content[0].text.match(LLM_ERROR_REGEX)[0].trim();
+    const errorMsg = responseText.match(LLM_ERROR_REGEX)?.[0].trim();
     throw new Error(errorMsg);
   }
 
-  const responseText = responseBody.content[0].text.match(LLM_ANSWER_REGEX)[0].trim();
-  return responseText;
+  const answer = responseText.match(LLM_ANSWER_REGEX)?.[0].trim();
+  if (!answer) throw new Error("LLM response did not include an answer tag");
+
+  return {
+    fullResponse: responseText,
+    answer,
+  };
 };
 
 interface StartTranscriptionJob {

--- a/src/server/llm.ts
+++ b/src/server/llm.ts
@@ -80,7 +80,6 @@ export const generateAnswer = async (
     system: role,
   };
 
-  console.log("Invoking LLM with role:", role, "\nAnd prompt:", message);
   const command = new InvokeModelCommand({
     contentType: "application/json",
     body: JSON.stringify(payload),

--- a/src/server/llmPrompts.ts
+++ b/src/server/llmPrompts.ts
@@ -63,7 +63,9 @@ export const PROMPTS: Prompts = {
         Du har fått som oppdrag å foreslå en bedre formulering av et tekstutdrag.`,
       formatInstructions: `
         Tekstutdraget er gitt i <excerpt>-taggen.
-        Innholdet i <draft>-taggen kan brukes som kontekst, men skal ikke gjenbrukes som del av den foreslåtte omformuleringen.
+        Innholdet i <excerpt>-taggen kan brukes som kontekst, men skal ikke gjenbrukes som del av den foreslåtte omformuleringen.
+        <excerpt>-taggen kan inneholde HTML-tagger. Disse bør i så fall gjenbrukes i omformuleringen, så lenge de fortsatt gir mening.
+        <excerpt>-taggen kan inneholde <ndlaembed> og <math>-tagger. Disse må ikke endres på, og må gjenbrukes med samme innhold og format i omformuleringen.
         Forslaget til en forbedret tekst skal være skrevet på NB.
         Forslaget til en forbedret tekst skal være skrevet i en <answer>-tag.`,
     },
@@ -125,7 +127,8 @@ export const PROMPTS: Prompts = {
         Du har fått i oppgåve å foreslå ei betre formulering av eit tekstutdrag.`,
       formatInstructions: `
         Tekstutdraget er gitt i <excerpt>-taggen.
-        Innhaldet i <draft>-taggen kan nyttast som kontekst, men skal ikkje gjenbrukast som del av den føreslåtte omformuleringa.
+        Innhaldet i <excerpt>-taggen kan nyttast som kontekst, men skal ikkje gjenbrukast som del av den føreslåtte omformuleringa.
+        <excerpt>-taggen inneheld HTML-taggar som kan gjenbrukast i svaret ditt.
         Forslaget til ein betre formulering skal vere skrive på NN.
         Forslaget til ein betre formulering skal vere skrive i ein <answer>-tag.`,
     },
@@ -187,7 +190,8 @@ export const PROMPTS: Prompts = {
         Your task is to suggest a better phrasing of the text in an excerpt.`,
       formatInstructions: `
         The excerpt is given in the <excerpt> tag.
-        The content in the <draft> tag can be used as context, but should not be reused as part of the suggested rephrasing.
+        The content in the <excerpt> tag can be used as context, but should not be reused as part of the suggested rephrasing.
+        The <excerpt> tag contains HTML tags that can be reused in your answer.
         The suggested rephrasing is to be written in EN.
         The suggested rephrasing is to be written inside an <answer> tag.`,
     },

--- a/src/server/llmPrompts.ts
+++ b/src/server/llmPrompts.ts
@@ -128,7 +128,8 @@ export const PROMPTS: Prompts = {
       formatInstructions: `
         Tekstutdraget er gitt i <excerpt>-taggen.
         Innhaldet i <excerpt>-taggen kan nyttast som kontekst, men skal ikkje gjenbrukast som del av den føreslåtte omformuleringa.
-        <excerpt>-taggen inneheld HTML-taggar som kan gjenbrukast i svaret ditt.
+        <excerpt>-taggen kan innehalde HTML-taggar. Disse bør i så måte gjenbrukast i omformuleringa, så lenge dei framleis gir meining.
+        <excerpt>-taggen kan innehalde <ndlaembed> og <math>-taggar. Disse må ikkje endras på, og må gjenbrukas med same innhald og format i omformuleringa.
         Forslaget til ein betre formulering skal vere skrive på NN.
         Forslaget til ein betre formulering skal vere skrive i ein <answer>-tag.`,
     },
@@ -191,7 +192,8 @@ export const PROMPTS: Prompts = {
       formatInstructions: `
         The excerpt is given in the <excerpt> tag.
         The content in the <excerpt> tag can be used as context, but should not be reused as part of the suggested rephrasing.
-        The <excerpt> tag contains HTML tags that can be reused in your answer.
+        The <excerpt> tag might contain HTML tags. If so, the tags should be reused in the suggested rephrasing, as long as they still make sense.
+        The <excerpt> tag might contain <ndlaembed> and <math> tags. These must not be changed, and must be reused with the same content and format in the suggested rephrasing.
         The suggested rephrasing is to be written in EN.
         The suggested rephrasing is to be written inside an <answer> tag.`,
     },

--- a/src/server/llmPrompts.ts
+++ b/src/server/llmPrompts.ts
@@ -63,7 +63,6 @@ export const PROMPTS: Prompts = {
         Du har fått som oppdrag å foreslå en bedre formulering av et tekstutdrag.`,
       formatInstructions: `
         Tekstutdraget er gitt i <excerpt>-taggen.
-        Innholdet i <excerpt>-taggen kan brukes som kontekst, men skal ikke gjenbrukes som del av den foreslåtte omformuleringen.
         <excerpt>-taggen kan inneholde HTML-tagger. Disse bør i så fall gjenbrukes i omformuleringen, så lenge de fortsatt gir mening.
         <excerpt>-taggen kan inneholde <ndlaembed> og <math>-tagger. Disse må ikke endres på, og må gjenbrukes med samme innhold og format i omformuleringen.
         Forslaget til en forbedret tekst skal være skrevet på NB.
@@ -127,7 +126,6 @@ export const PROMPTS: Prompts = {
         Du har fått i oppgåve å foreslå ei betre formulering av eit tekstutdrag.`,
       formatInstructions: `
         Tekstutdraget er gitt i <excerpt>-taggen.
-        Innhaldet i <excerpt>-taggen kan nyttast som kontekst, men skal ikkje gjenbrukast som del av den føreslåtte omformuleringa.
         <excerpt>-taggen kan innehalde HTML-taggar. Disse bør i så måte gjenbrukast i omformuleringa, så lenge dei framleis gir meining.
         <excerpt>-taggen kan innehalde <ndlaembed> og <math>-taggar. Disse må ikkje endras på, og må gjenbrukas med same innhald og format i omformuleringa.
         Forslaget til ein betre formulering skal vere skrive på NN.
@@ -191,7 +189,6 @@ export const PROMPTS: Prompts = {
         Your task is to suggest a better phrasing of the text in an excerpt.`,
       formatInstructions: `
         The excerpt is given in the <excerpt> tag.
-        The content in the <excerpt> tag can be used as context, but should not be reused as part of the suggested rephrasing.
         The <excerpt> tag might contain HTML tags. If so, the tags should be reused in the suggested rephrasing, as long as they still make sense.
         The <excerpt> tag might contain <ndlaembed> and <math> tags. These must not be changed, and must be reused with the same content and format in the suggested rephrasing.
         The suggested rephrasing is to be written in EN.

--- a/src/server/llmQueries.ts
+++ b/src/server/llmQueries.ts
@@ -45,8 +45,7 @@ const META_DESCRIPTION_QUERY = createQuery("metaDescription", {
 });
 
 const ALTERNATIVE_PRHASING_QUERY = createQuery("alternativePhrasing", {
-  excerpt: "excerpt",
-  draft: "text",
+  excerpt: "html",
 });
 
 const ALT_TEXT_QUERY = createQuery("altText");

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -6,20 +6,26 @@
  *
  */
 
-import { isPromptType } from "../interfaces";
+import { isPromptType, PromptPayload, PromptVariables } from "../interfaces";
+import { unreachable } from "../util/guards";
 
-export const isValidRequestBody = (body: any) => {
-  const type = body?.type;
-  if (!isPromptType(type)) {
-    return false;
-  } else if ((type === "summary" || type === "metaDescription") && !body.title && !body.text) {
-    return false;
-  } else if (type === "altText" && !body.image?.fileType && !body.image?.base64) {
-    return false;
-  } else if (type === "alternativePhrasing" && !body.text && !body.excerpt) {
-    return false;
-  } else if (type === "reflection" && !body.text) {
-    return false;
+export const isValidRequestBody = (
+  body: Partial<PromptPayload<PromptVariables>>,
+): body is PromptPayload<PromptVariables> => {
+  const type = body.type;
+  if (!isPromptType(type)) return false;
+
+  switch (type) {
+    case "summary":
+    case "metaDescription":
+      return !!body.title && !!body.text;
+    case "altText":
+      return !!body.image?.fileType && !!body.image?.base64;
+    case "alternativePhrasing":
+      return !!body.html;
+    case "reflection":
+      return !!body.text;
+    default:
+      return unreachable(type);
   }
-  return true;
 };


### PR DESCRIPTION
Fixes NDLANO/Issues#4376

Måtte endre på logikken i `toolbarState()` for å støtte markering av flere inline (men ikke block) elementer. Må testes for å sjekke at det blir riktig med hvilke inline elementer som er disabled i toolbar-en ift. hvor markør/selection er.