### PR TITLE
refactor: replace date-fns with `@internationalized/date`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@tanstack/react-query": "5.79.0",
     "auth0-js": "^9.22.1",
     "compression": "^1.7.4",
-    "date-fns": "2.30.0",
     "diff-match-patch": "^1.0.5",
     "escape-html": "^1.0.3",
     "express": "^5.0.0",

--- a/src/components/LastUpdatedLine/LastUpdatedLine.tsx
+++ b/src/components/LastUpdatedLine/LastUpdatedLine.tsx
@@ -9,7 +9,7 @@
 import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { DatePickerValueChangeDetails } from "@ark-ui/react";
-import { getLocalTimeZone, parseAbsolute, ZonedDateTime } from "@internationalized/date";
+import { getLocalTimeZone, parseAbsoluteToLocal, ZonedDateTime } from "@internationalized/date";
 import { PencilFill } from "@ndla/icons";
 import { Button, DatePickerControl, DatePickerRoot, DatePickerTrigger, Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
@@ -49,7 +49,7 @@ const LastUpdatedLine = ({ creators, published, onChange, allowEdit = false, con
 
   const dateValue = useMemo(() => {
     if (!published) return [];
-    return (published ? [parseAbsolute(published, getLocalTimeZone())] : []) as ZonedDateTime[];
+    return (published ? [parseAbsoluteToLocal(published)] : []) as ZonedDateTime[];
   }, [published]);
 
   const onValueChange = useCallback(

--- a/src/containers/ArticlePage/components/InputComment.tsx
+++ b/src/containers/ArticlePage/components/InputComment.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { format } from "date-fns";
 import { FieldArrayRenderProps } from "formik";
 import { TFunction } from "i18next";
 import { useCallback, useState } from "react";
@@ -71,11 +70,16 @@ const StyledFieldRoot = styled(FieldRoot, {
   },
 });
 
+const timeFormatter = new Intl.DateTimeFormat("nb-NO", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
 export const getCommentInfoText = (userName: string | undefined, t: TFunction): string => {
   const currentDate = new Date();
   const dateTime = formatDateForBackend(currentDate);
   const formattedDate = formatDate(dateTime);
-  const formattedTime = format(currentDate, "HH:mm");
+  const formattedTime = timeFormatter.format(currentDate);
 
   return `${t("form.workflow.addComment.createdBy")} ${userName?.split(" ")[0]} (${formattedDate} - ${formattedTime})`;
 };

--- a/src/containers/ArticlePage/components/RevisionNotes.tsx
+++ b/src/containers/ArticlePage/components/RevisionNotes.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import { addYears } from "date-fns";
 import { FastField, FieldArray, FieldProps, useField } from "formik";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { getLocalTimeZone, today } from "@internationalized/date";
 import { DeleteBinLine } from "@ndla/icons";
 import {
   Button,
@@ -150,7 +150,9 @@ const RevisionNotes = () => {
             onClick={() =>
               arrayHelpers.push({
                 note: "",
-                revisionDate: formatDateForBackend(addYears(new Date(), 5)),
+                revisionDate: formatDateForBackend(
+                  today(getLocalTimeZone()).add({ years: 5 }).toDate(getLocalTimeZone()),
+                ),
                 status: "needs-revision",
                 new: true,
               })

--- a/src/containers/FormikForm/components/InlineDatePicker.tsx
+++ b/src/containers/FormikForm/components/InlineDatePicker.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useMemo } from "react";
 import { DatePickerValueChangeDetails } from "@ark-ui/react";
-import { getLocalTimeZone, parseAbsolute } from "@internationalized/date";
+import { getLocalTimeZone, parseAbsoluteToLocal } from "@internationalized/date";
 import { CalendarLine } from "@ndla/icons";
 import { Button, DatePickerControl, DatePickerRoot, DatePickerTrigger } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
@@ -57,7 +57,7 @@ interface Props {
 
 const InlineDatePicker = ({ onChange, value, name, placeholder, title }: Props) => {
   const translations = useDatePickerTranslations();
-  const dateValue = useMemo(() => (value ? parseAbsolute(value, getLocalTimeZone()) : undefined), [value]);
+  const dateValue = useMemo(() => (value ? parseAbsoluteToLocal(value) : undefined), [value]);
   const displayValue = useMemo(() => (dateValue ? dateFormatter.format(dateValue.toDate()) : undefined), [dateValue]);
   const onValueChange = useCallback(
     (details: DatePickerValueChangeDetails) => {

--- a/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
+++ b/src/containers/StructurePage/resourceComponents/ApproachingRevisionDate.tsx
@@ -6,10 +6,9 @@
  *
  */
 
-import addYears from "date-fns/addYears";
-import isBefore from "date-fns/isBefore";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { getLocalTimeZone, parseAbsoluteToLocal, today } from "@internationalized/date";
 import { Text } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { IRevisionMetaDTO } from "@ndla/types-backend/draft-api";
@@ -42,8 +41,8 @@ export const isApproachingRevision = (revisions?: IRevisionMetaDTO[]) => {
   if (!revisions?.length) return false;
   const expirationDate = getExpirationDate({ revisions: revisions });
   if (!expirationDate) return false;
-  const currentDateAddYear = addYears(new Date(), 1);
-  return isBefore(new Date(expirationDate), currentDateAddYear);
+  const currentDateAddYear = today(getLocalTimeZone()).add({ years: 1 });
+  return parseAbsoluteToLocal(expirationDate).compare(currentDateAddYear) <= 0;
 };
 
 const ApproachingRevisionDate = ({ resources, currentNode, contentMeta }: Props) => {

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import addYears from "date-fns/addYears";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { getLocalTimeZone, today } from "@internationalized/date";
 import { NotificationLine } from "@ndla/icons";
 import {
   SwitchControl,
@@ -108,7 +108,9 @@ const Revisions = ({ userData }: Props) => {
     { title: t("welcomePage.revisionDate"), sortableField: "revisionDate" },
   ];
 
-  const currentDateAddYear = formatDateForBackend(addYears(new Date(), 1));
+  const currentDateAddYear = formatDateForBackend(
+    today(getLocalTimeZone()).add({ years: 1 }).toDate(getLocalTimeZone()),
+  );
 
   const { data, isPending, isError } = useSearch(
     {

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -6,20 +6,23 @@
  *
  */
 
-import format from "date-fns/format";
-import parseISO from "date-fns/parseISO";
+import { parseAbsoluteToLocal } from "@internationalized/date";
 
-const NORWEGIAN_FORMAT = "dd.MM.yyyy";
+const dateFormatter = new Intl.DateTimeFormat("nb-NO", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
 
 export default function formatDate(date: string | number | undefined): string {
   if (!date) return "";
 
   if (typeof date === "string") {
-    const parsedDate = parseISO(date);
-    return format(parsedDate, NORWEGIAN_FORMAT);
+    const parsedDate = parseAbsoluteToLocal(date);
+    return dateFormatter.format(parsedDate.toDate());
   }
 
-  return format(date, NORWEGIAN_FORMAT);
+  return dateFormatter.format(date);
 }
 
 export function formatDateForBackend(date: Date): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.7.6":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.7.6":
   version: 7.26.9
   resolution: "@babel/runtime@npm:7.26.9"
   dependencies:
@@ -6373,15 +6373,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:2.30.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.21.0"
-  checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
-  languageName: node
-  linkType: hard
-
 "debug@npm:2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -6731,7 +6722,6 @@ __metadata:
     compression: "npm:^1.7.4"
     concurrently: "npm:^9.1.2"
     cross-env: "npm:^7.0.3"
-    date-fns: "npm:2.30.0"
     diff-match-patch: "npm:^1.0.5"
     esbuild: "npm:^0.25.4"
     escape-html: "npm:^1.0.3"


### PR DESCRIPTION
ark bruker det, så tenker det er like greit at vi gjør det samme. Virker som et godt nok bibliotek.