### PR TITLE
Strip obsolete part of norgesfilm url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -190,6 +190,7 @@ export type ConfigType = {
   s3AudioRoot: string;
   enableMatomoData: boolean;
   enableUpdateGrepCodes: boolean;
+  norgesfilmNewUrl: boolean;
 };
 
 const getServerSideConfig = (): ConfigType => {
@@ -241,6 +242,7 @@ const getServerSideConfig = (): ConfigType => {
     s3AudioRoot: getAudioS3Root(ndlaEnvironment),
     enableMatomoData: getEnvironmentVariabel("ENABLE_MATOMO_DATA", "false") === "true",
     enableUpdateGrepCodes: getEnvironmentVariabel("ENABLE_UPDATE_GREP_CODES", "false") === "true",
+    norgesfilmNewUrl: getEnvironmentVariabel("NORGESFILM_NEW_URL", "false") === "true",
   };
 };
 
@@ -248,7 +250,6 @@ export function getUniversalConfig(): ConfigType {
   if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
     return getServerSideConfig();
   }
-
   return window.config;
 }
 

--- a/src/containers/VisualElement/urlTransformers.ts
+++ b/src/containers/VisualElement/urlTransformers.ts
@@ -7,6 +7,7 @@
  */
 
 import queryString from "query-string";
+import config from "../../config";
 import { fetchNrkMedia } from "../../modules/video/nrkApi";
 import { urlAsATag } from "../../util/htmlHelpers";
 
@@ -208,6 +209,29 @@ const gapminderTransformer: UrlTransformer = {
   },
 };
 
+const norgesfilmTransformer: UrlTransformer = {
+  domains: ["ndla.filmiundervisning.no"],
+  shouldTransform: (url, domains) => {
+    const aTag = urlAsATag(url);
+
+    if (!config.norgesfilmNewUrl) {
+      return false;
+    }
+
+    if (!domains.includes(aTag.hostname)) {
+      return false;
+    }
+    if (!aTag.href.includes("ndlafilm.aspx?filmId=")) {
+      return false;
+    }
+    return true;
+  },
+  transform: async (url) => {
+    const parts = url.split("ndlafilm.aspx?filmId=");
+    return parts.join("");
+  },
+};
+
 export const urlTransformers: UrlTransformer[] = [
   nrkTransformer,
   codepenTransformer,
@@ -217,4 +241,5 @@ export const urlTransformers: UrlTransformer[] = [
   sketcfabTransformer,
   jeopardyLabTransformer,
   gapminderTransformer,
+  norgesfilmTransformer,
 ];


### PR DESCRIPTION
La det bak et flagg for å kunne koordinere med deploy av migreringer.