### PR TITLE
Shadows bundled punycode with explicit imports

### DIFF
--- a/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
+++ b/src/components/SlateEditor/plugins/related/RelatedArticleBox.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { toUnicode } from "punycode";
+import { toUnicode } from "punycode/";
 import { useEffect, useRef, useState, ReactNode, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Editor, Transforms } from "slate";

--- a/src/components/SlateEditor/plugins/related/index.tsx
+++ b/src/components/SlateEditor/plugins/related/index.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { toUnicode } from "punycode";
+import { toUnicode } from "punycode/";
 import { jsx as slatejsx } from "slate-hyperscript";
 import {
   createDataAttributes,


### PR DESCRIPTION
Forsøker å få vekk melding `DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.`