### PR TITLE
feat: disallow invalid pastes

### DIFF
--- a/src/components/SlateEditor/plugins/paste/index.ts
+++ b/src/components/SlateEditor/plugins/paste/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { createPlugin } from "@ndla/editor";
+import { PASTE_PLUGIN } from "./types";
+import { Descendant, Element, Node, Transforms } from "slate";
+
+export const b64Decode = (data: string | undefined): Descendant[] => {
+  try {
+    return JSON.parse(decodeURIComponent(atob(data ?? "")));
+  } catch (e) {
+    return [];
+  }
+};
+
+export const pastePlugin = createPlugin({
+  name: PASTE_PLUGIN,
+  transform: (editor, logger) => {
+    const { insertData } = editor;
+
+    editor.insertData = (data) => {
+      const slate = b64Decode(data.getData("application/x-slate-fragment"));
+      if (!slate) return insertData(data);
+      const allElements = slate.filter((n) => Element.isElement(n)).flatMap((n) => Array.from(Node.elements(n)));
+      for (const [node] of allElements) {
+        if (!editor.supportsElement(node)) {
+          logger.log("Unsupported element found during paste");
+          const plainText = data.getData("text/plain");
+          return Transforms.insertText(editor, plainText);
+        }
+      }
+      return insertData(data);
+    };
+
+    return editor;
+  },
+});

--- a/src/components/SlateEditor/plugins/paste/types.ts
+++ b/src/components/SlateEditor/plugins/paste/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const PASTE_PLUGIN = "paste";

--- a/src/components/SlateEditor/plugins/uuDisclaimer/DisclaimerForm.tsx
+++ b/src/components/SlateEditor/plugins/uuDisclaimer/DisclaimerForm.tsx
@@ -26,6 +26,7 @@ import { noopPlugin } from "../noop";
 import { noopRenderer } from "../noop/render";
 import { paragraphPlugin } from "../paragraph";
 import { paragraphRenderer } from "../paragraph/render";
+import { pastePlugin } from "../paste";
 import saveHotkeyPlugin from "../saveHotkey";
 import { spanPlugin } from "../span";
 import { spanRenderer } from "../span/render";
@@ -60,6 +61,7 @@ export const disclaimerPlugins: SlatePlugin[] = [
   markPlugin,
   noopPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];
 
 const renderers: SlatePlugin[] = [

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/frontpagePlugins.ts
@@ -65,6 +65,7 @@ import { definitionDescriptionPlugin } from "../../../../components/SlateEditor/
 import { symbolPlugin } from "../../../../components/SlateEditor/plugins/symbol";
 import { tableHeadPlugin } from "../../../../components/SlateEditor/plugins/table/tableHeadPlugin";
 import { unsupportedPlugin } from "../../../../components/SlateEditor/plugins/unsupported/unsupportedPlugin";
+import { pastePlugin } from "../../../../components/SlateEditor/plugins/paste";
 
 // Plugins are checked from last to first
 export const frontpagePlugins: SlatePlugin[] = [
@@ -129,4 +130,5 @@ export const frontpagePlugins: SlatePlugin[] = [
   rephrasePlugin,
   symbolPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourcePanels.tsx
@@ -33,6 +33,7 @@ import { noopPlugin } from "../../../../components/SlateEditor/plugins/noop";
 import { noopRenderer } from "../../../../components/SlateEditor/plugins/noop/render";
 import { paragraphPlugin } from "../../../../components/SlateEditor/plugins/paragraph";
 import { paragraphRenderer } from "../../../../components/SlateEditor/plugins/paragraph/render";
+import { pastePlugin } from "../../../../components/SlateEditor/plugins/paste";
 import saveHotkeyPlugin from "../../../../components/SlateEditor/plugins/saveHotkey";
 import { spanPlugin } from "../../../../components/SlateEditor/plugins/span";
 import { spanRenderer } from "../../../../components/SlateEditor/plugins/span/render";
@@ -88,6 +89,7 @@ export const disclaimerPlugins: SlatePlugin[] = [
   linkPlugin,
   contentLinkPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];
 
 const renderers: SlatePlugin[] = [

--- a/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
+++ b/src/containers/ArticlePage/LearningResourcePage/components/learningResourcePlugins.ts
@@ -61,6 +61,7 @@ import { definitionListPlugin } from "../../../../components/SlateEditor/plugins
 import { definitionTermPlugin } from "../../../../components/SlateEditor/plugins/definitionList/definitionTermPlugin";
 import { definitionDescriptionPlugin } from "../../../../components/SlateEditor/plugins/definitionList/definitionDescriptionPlugin";
 import { unsupportedPlugin } from "../../../../components/SlateEditor/plugins/unsupported/unsupportedPlugin";
+import { pastePlugin } from "../../../../components/SlateEditor/plugins/paste";
 
 export const learningResourcePlugins: SlatePlugin[] = [
   idPlugin,
@@ -120,4 +121,5 @@ export const learningResourcePlugins: SlatePlugin[] = [
   rephrasePlugin,
   symbolPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];

--- a/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
+++ b/src/containers/ArticlePage/TopicArticlePage/components/topicArticlePlugins.ts
@@ -32,6 +32,7 @@ import { definitionTermPlugin } from "../../../../components/SlateEditor/plugins
 import { definitionDescriptionPlugin } from "../../../../components/SlateEditor/plugins/definitionList/definitionDescriptionPlugin";
 import { symbolPlugin } from "../../../../components/SlateEditor/plugins/symbol";
 import { unsupportedPlugin } from "../../../../components/SlateEditor/plugins/unsupported/unsupportedPlugin";
+import { pastePlugin } from "../../../../components/SlateEditor/plugins/paste";
 
 // Plugins are checked from last to first
 export const topicArticlePlugins: SlatePlugin[] = [
@@ -64,4 +65,5 @@ export const topicArticlePlugins: SlatePlugin[] = [
   rephrasePlugin,
   symbolPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];

--- a/src/containers/ArticlePage/components/commentToolbarUtils.ts
+++ b/src/containers/ArticlePage/components/commentToolbarUtils.ts
@@ -34,6 +34,7 @@ import { divRenderer } from "../../../components/SlateEditor/plugins/div/render"
 import { divPlugin } from "../../../components/SlateEditor/plugins/div";
 import { unsupportedPlugin } from "../../../components/SlateEditor/plugins/unsupported/unsupportedPlugin";
 import { unsupportedElementRenderer } from "../../../components/SlateEditor/plugins/unsupported/unsupportedElementRenderer";
+import { pastePlugin } from "../../../components/SlateEditor/plugins/paste";
 
 export const plugins: SlatePlugin[] = [
   inlineNavigationPlugin,
@@ -51,6 +52,7 @@ export const plugins: SlatePlugin[] = [
   linkPlugin,
   listPlugin,
   unsupportedPlugin,
+  pastePlugin,
   sectionRenderer,
   noopRenderer,
   paragraphRenderer,

--- a/src/containers/AudioUploader/components/AudioManuscript.tsx
+++ b/src/containers/AudioUploader/components/AudioManuscript.tsx
@@ -25,6 +25,7 @@ import { noopPlugin } from "../../../components/SlateEditor/plugins/noop";
 import { noopRenderer } from "../../../components/SlateEditor/plugins/noop/render";
 import { paragraphPlugin } from "../../../components/SlateEditor/plugins/paragraph";
 import { paragraphRenderer } from "../../../components/SlateEditor/plugins/paragraph/render";
+import { pastePlugin } from "../../../components/SlateEditor/plugins/paste";
 import saveHotkeyPlugin from "../../../components/SlateEditor/plugins/saveHotkey";
 import { spanPlugin } from "../../../components/SlateEditor/plugins/span";
 import { spanRenderer } from "../../../components/SlateEditor/plugins/span/render";
@@ -77,6 +78,7 @@ const manuscriptPlugins: SlatePlugin[] = [
   markPlugin,
   noopPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];
 
 const LANGUAGE_MAP: Record<string, string> = {

--- a/src/containers/FormikForm/IngressField.tsx
+++ b/src/containers/FormikForm/IngressField.tsx
@@ -27,6 +27,7 @@ import { noopPlugin } from "../../components/SlateEditor/plugins/noop";
 import { noopRenderer } from "../../components/SlateEditor/plugins/noop/render";
 import { paragraphPlugin } from "../../components/SlateEditor/plugins/paragraph";
 import { paragraphRenderer } from "../../components/SlateEditor/plugins/paragraph/render";
+import { pastePlugin } from "../../components/SlateEditor/plugins/paste";
 import saveHotkeyPlugin from "../../components/SlateEditor/plugins/saveHotkey";
 import { spanPlugin } from "../../components/SlateEditor/plugins/span";
 import { spanRenderer } from "../../components/SlateEditor/plugins/span/render";
@@ -100,6 +101,7 @@ const ingressPlugins: SlatePlugin[] = [
   noopPlugin,
   commentInlinePlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];
 
 const ingressRenderers: SlatePlugin[] = [

--- a/src/containers/FormikForm/InlineField.tsx
+++ b/src/containers/FormikForm/InlineField.tsx
@@ -21,6 +21,7 @@ import { inlineNoopPlugin } from "../../components/SlateEditor/plugins/noop";
 import { noopRenderer } from "../../components/SlateEditor/plugins/noop/render";
 import { paragraphPlugin } from "../../components/SlateEditor/plugins/paragraph";
 import { paragraphRenderer } from "../../components/SlateEditor/plugins/paragraph/render";
+import { pastePlugin } from "../../components/SlateEditor/plugins/paste";
 import saveHotkeyPlugin from "../../components/SlateEditor/plugins/saveHotkey";
 import { spanPlugin } from "../../components/SlateEditor/plugins/span";
 import { spanRenderer } from "../../components/SlateEditor/plugins/span/render";
@@ -106,6 +107,7 @@ export const InlineField = ({
       linkPlugin,
       contentLinkPlugin,
       unsupportedPlugin,
+      pastePlugin,
     ];
 
     return { toolbarOptions, toolbarAreaFilters, plugins: inlinePlugins.concat(renderers) };

--- a/src/containers/FormikForm/TitleField.tsx
+++ b/src/containers/FormikForm/TitleField.tsx
@@ -23,6 +23,7 @@ import { noopPlugin } from "../../components/SlateEditor/plugins/noop";
 import { noopRenderer } from "../../components/SlateEditor/plugins/noop/render";
 import { paragraphPlugin } from "../../components/SlateEditor/plugins/paragraph";
 import { paragraphRenderer } from "../../components/SlateEditor/plugins/paragraph/render";
+import { pastePlugin } from "../../components/SlateEditor/plugins/paste";
 import saveHotkeyPlugin from "../../components/SlateEditor/plugins/saveHotkey";
 import { sectionRenderer } from "../../components/SlateEditor/plugins/section/render";
 import { spanPlugin } from "../../components/SlateEditor/plugins/span";
@@ -75,6 +76,7 @@ const titlePlugins: SlatePlugin[] = [
   markPlugin,
   noopPlugin,
   unsupportedPlugin,
+  pastePlugin,
 ];
 
 const titleRenderers: SlatePlugin[] = [


### PR DESCRIPTION
Første utkast av et paste-plugin. Inntil videre gjør denne bare en sjekk på om den nåværende editoren støtter alle elementer en prøver å lime inn. Dersom editoren ikke støtter alt vil den heller lime inn det hele som plaintext. 

Mangler:
- Lime inn flere blokker samtidig
- Sjekke hvorvidt et mark er støttet