### PR TITLE
fix: properly resolve types when linking during dev

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noEmit": false,
     "sourceMap": true,
     "skipLibCheck": true,
+    "preserveSymlinks": true,
     "lib": ["es2023", "esnext.asynciterable", "dom"],
     "types": ["vitest/globals", "node", "@testing-library/jest-dom"],
     "paths": {


### PR DESCRIPTION
Dette fikser at vi får en million typefeil når man linker inn med frontend-packages