### PR TITLE
Handle learningpaths same as concepts to find paths without context

### DIFF
--- a/src/phrases/phrases-en.ts
+++ b/src/phrases/phrases-en.ts
@@ -1935,6 +1935,7 @@ const phrases = {
     frontpage: "About-NDLA article",
     concept: "Concept",
     gloss: "Gloss",
+    learningpath: "Learningpath",
   },
   ndlaFilm: {
     editor: {

--- a/src/phrases/phrases-nb.ts
+++ b/src/phrases/phrases-nb.ts
@@ -1933,6 +1933,7 @@ const phrases = {
     frontpage: "Om-NDLA-artikkel",
     concept: "Forklaring",
     gloss: "Glose",
+    learningpath: "Læringssti",
   },
   ndlaFilm: {
     editor: {

--- a/src/phrases/phrases-nn.ts
+++ b/src/phrases/phrases-nn.ts
@@ -1935,6 +1935,7 @@ const phrases = {
     frontpage: "Om-NDLA-artikkel",
     concept: "Forklaring",
     gloss: "Glose",
+    learningpath: "Læringssti",
   },
   ndlaFilm: {
     editor: {

--- a/src/util/__tests__/taxonomyHelpers-test.ts
+++ b/src/util/__tests__/taxonomyHelpers-test.ts
@@ -16,6 +16,7 @@ test("taxonomy/flattenResourceTypesAndAddContextTypes flattening", () => {
     "contextTypes.frontpage": "Forsideartikkel",
     "contextTypes.concept": "Forklaring",
     "contextTypes.gloss": "Glose",
+    "contextTypes.learningpath": "Læringssti",
   };
   const t = (key: string) => types[key];
   expect(flattenResourceTypesAndAddContextTypes(resourceTypesMock as ResourceType[], t)).toEqual(

--- a/src/util/__tests__/taxonomyMocks.ts
+++ b/src/util/__tests__/taxonomyMocks.ts
@@ -218,7 +218,6 @@ export const flattenedResourceTypes = [
     typeId: "urn:resourcetype:reviewResource",
     typeName: "Vurderingsressurs",
   },
-  { id: "urn:resourcetype:learningPath", name: "Læringssti" },
   {
     id: "urn:resourcetype:featureFilm",
     name: "Spillefilm",
@@ -255,6 +254,7 @@ export const flattenedResourceTypes = [
     typeId: "urn:resourcetype:concept",
     typeName: "Forklaring",
   },
+  { id: "learningpath", name: "Læringssti" },
   { id: "topic-article", name: "Emne" },
   { id: "frontpage-article", name: "Forsideartikkel" },
   { id: "concept", name: "Forklaring" },

--- a/src/util/searchHelpers.ts
+++ b/src/util/searchHelpers.ts
@@ -24,6 +24,9 @@ const getContextTypes = (resourceType: string[] | undefined, contextTypes: strin
   if (resourceType?.includes("concept")) {
     return { contextTypes: ["concept"], resourceTypes: [] };
   }
+  if (resourceType?.includes("learningpath")) {
+    return { contextTypes: ["learningpath"], resourceTypes: [] };
+  }
 
   return { contextTypes };
 };

--- a/src/util/taxonomyHelpers.ts
+++ b/src/util/taxonomyHelpers.ts
@@ -10,6 +10,7 @@ import { groupBy, merge, sortBy, uniqBy } from "lodash-es";
 import { NodeChild, ResourceType } from "@ndla/types-taxonomy";
 import { getContentTypeFromResourceTypes } from "./resourceHelpers";
 import { ResourceWithNodeConnectionAndMeta } from "../containers/StructurePage/resourceComponents/StructureResources";
+import { RESOURCE_TYPE_LEARNING_PATH } from "../constants";
 import { FlattenedResourceType } from "../interfaces";
 import { NodeChildWithChildren } from "../modules/nodes/nodeQueries";
 
@@ -33,13 +34,14 @@ const flattenResourceTypesAndAddContextTypes = (data: ResourceType[] = [], t: (k
           id: subtype.id,
         }),
       );
-    } else {
+    } else if (type.id !== RESOURCE_TYPE_LEARNING_PATH) {
       resourceTypes.push({
         name: type.name,
         id: type.id,
       });
     }
   });
+  resourceTypes.push({ name: t("contextTypes.learningpath"), id: "learningpath" });
   resourceTypes.push({ name: t("contextTypes.topic"), id: "topic-article" });
   resourceTypes.push({
     name: t("contextTypes.frontpage"),


### PR DESCRIPTION
Fikser slik at om du velger læringssti i nedtrekk så søkes det på type og ikkje ressurstype, tilsvarende som forklaring.