### PR TITLE
Make search for learningpaths better in add existing resource

### DIFF
--- a/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
+++ b/src/containers/StructurePage/plannedResource/AddExistingResource.tsx
@@ -167,8 +167,10 @@ const AddExistingResource = ({ onClose, resourceTypes, existingResourceIds, node
     page,
     language: i18n.language,
     fallback: true,
-    resourceTypes: selectedType ? [selectedType.id] : undefined,
-    contextTypes: ["standard", "learningpath"],
+    resourceTypes: selectedType && selectedType.id !== RESOURCE_TYPE_LEARNING_PATH ? [selectedType.id] : undefined,
+    contextTypes:
+      selectedType && selectedType.id === RESOURCE_TYPE_LEARNING_PATH ? ["learningpath"] : ["learningpath", "standard"],
+    resultTypes: ["learningpath", "article"],
   });
 
   const resetPastedUrlStatesWithError = (error?: string) => {


### PR DESCRIPTION
Gjør at du kan velge læringssti i nedtrekk for eksisterende ressurs, og få stier som ikkje er i struktur.