### PR TITLE
Fix file ending stripping.

### DIFF
--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -79,7 +79,7 @@ const FileUploader = ({ onFileSave, close }: Props) => {
         newFiles.map((file, i) => ({
           path: file.path,
           type: file.extension.substring(1),
-          title: values.files[i].name.replace(/\..*/, ""),
+          title: values.files[i].name.substring(0, values.files[i].name.lastIndexOf(".")),
         })),
       );
     } catch (err) {


### PR DESCRIPTION
https://trello.com/c/d05GpVIb/1400-opplasting-av-filer-med-punktum-i-filnavn

Fjener alt etter siste punktum i stedet for etter første punktum.
Kunne kanskje også splitta på "." og fjerna siste ledd før join med "." igjen.