### PR TITLE
Make sure only unique ids is used for concept search

### DIFF
--- a/src/containers/FormikForm/utils.ts
+++ b/src/containers/FormikForm/utils.ts
@@ -45,7 +45,7 @@ export const hasUnpublishedConcepts = async (article: IArticleDTO | undefined) =
   const parsedContent = parser.parseFromString(article.content.content, "text/html");
   const concepts = parsedContent.querySelectorAll('[data-resource="concept"]');
   const conceptIds = Array.from(concepts).map((el) => el.getAttribute("data-content-id"));
-  const convertedIds = conceptIds.filter((id) => !!id).map(Number);
+  const convertedIds = Array.from(new Set(conceptIds.filter((id) => !!id).map(Number)));
 
   if (!convertedIds.length) return false;
 


### PR DESCRIPTION
Dersom samme forklaring er satt inn fleire gonger i samme artikkel vil antall parameter være fleire enn antall svar, og dermed vil du få melding om upubliserte forklaringer. Dette omgår problemet ved å sikre at kun unike ids sendes.