### PR TITLE
refactor: do not disable language buttons when submitting

### DIFF
--- a/src/components/HeaderWithLanguage/HeaderActions.tsx
+++ b/src/components/HeaderWithLanguage/HeaderActions.tsx
@@ -6,7 +6,6 @@
  *
  */
 
-import { useFormikContext } from "formik";
 import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ArrowRightShortLine, ShareBoxLine, EyeFill } from "@ndla/icons";
@@ -110,7 +109,6 @@ const HeaderActions = ({
   supportedLanguages = [],
 }: Props) => {
   const { t } = useTranslation();
-  const { isSubmitting } = useFormikContext();
   const showTranslate = useIsTranslatableToNN();
 
   const editUrl = useCallback(
@@ -162,7 +160,6 @@ const HeaderActions = ({
           editUrl={editUrl}
           language={language}
           supportedLanguages={supportedLanguages}
-          isSubmitting={isSubmitting}
         />
         {!!isNewLanguage && (
           <HeaderCurrentLanguagePill key={`types_${language}`}>{t(`languages.${language}`)}</HeaderCurrentLanguagePill>

--- a/src/components/HeaderWithLanguage/HeaderSupportedLanguages.tsx
+++ b/src/components/HeaderWithLanguage/HeaderSupportedLanguages.tsx
@@ -15,11 +15,10 @@ interface Props {
   language: string;
   editUrl: (id: number, url: string) => string;
   supportedLanguages?: string[];
-  isSubmitting?: boolean;
   replace?: boolean;
 }
 
-const HeaderSupportedLanguages = ({ supportedLanguages = [], id, editUrl, isSubmitting, language, replace }: Props) => {
+const HeaderSupportedLanguages = ({ supportedLanguages = [], id, editUrl, language, replace }: Props) => {
   const { t } = useTranslation();
   return (
     <>
@@ -40,7 +39,6 @@ const HeaderSupportedLanguages = ({ supportedLanguages = [], id, editUrl, isSubm
             variant="tertiary"
             to={editUrl(id, supportedLanguage)}
             replace={replace}
-            disabled={isSubmitting}
             key={`types_${supportedLanguage}`}
           >
             {t(`languages.${supportedLanguage}`)}

--- a/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
+++ b/src/components/HeaderWithLanguage/SimpleLanguageHeader.tsx
@@ -38,7 +38,6 @@ interface Props {
   articleType: string | undefined;
   editUrl: (id: number, lang: string) => string;
   id: number;
-  isSubmitting: boolean;
   language: string;
   supportedLanguages: string[];
   title: string;
@@ -58,7 +57,6 @@ const SimpleLanguageHeader = ({
   articleType = constants.contentTypes.SUBJECT_MATERIAL,
   editUrl,
   id,
-  isSubmitting,
   language,
   supportedLanguages,
   title,
@@ -88,7 +86,6 @@ const SimpleLanguageHeader = ({
             editUrl={editUrl}
             language={language}
             supportedLanguages={supportedLanguages}
-            isSubmitting={isSubmitting}
           />
           {!!isNewLanguage && (
             <HeaderCurrentLanguagePill key={`types_${language}`}>

--- a/src/containers/EditMarkupPage/EditMarkupPage.tsx
+++ b/src/containers/EditMarkupPage/EditMarkupPage.tsx
@@ -234,7 +234,6 @@ const EditMarkupPage = () => {
           language={language}
           editUrl={toEditMarkup}
           id={draftId}
-          isSubmitting={isSubmitting}
           replace={true}
         />
       </LanguageWrapper>

--- a/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
+++ b/src/containers/EditSubjectFrontpage/components/SubjectpageForm.tsx
@@ -180,7 +180,6 @@ const SubjectpageForm = ({
               articleType={values.articleType!}
               editUrl={(_, lang: string) => toEditSubjectpage(values.elementId!, lang, values.id)}
               id={values.id!}
-              isSubmitting={isSubmitting}
               language={values.language}
               supportedLanguages={values.supportedLanguages!}
               title={values.name ?? ""}

--- a/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
+++ b/src/containers/NdlaFilm/components/NdlaFilmForm.tsx
@@ -125,7 +125,6 @@ const NdlaFilmForm = ({ filmFrontpage, selectedLanguage }: Props) => {
               articleType="filmfrontpage"
               editUrl={(_, lang) => toEditNdlaFilm(lang)}
               id={20}
-              isSubmitting={isSubmitting}
               language={selectedLanguage}
               supportedLanguages={values.supportedLanguages}
               title={values.name}


### PR DESCRIPTION
Dratt ut fra læringssti-PR. Ser egentlig ingen god grunn til å ha dette. Det finnes en million andre måter å ødelegge mens man lagrer. Ser ingen grunn til at vi kun skal blokkere denne.