### PR TITLE
refactor: simplify save logic in EditorFooter

### DIFF
--- a/src/components/SlateEditor/EditorFooter.tsx
+++ b/src/components/SlateEditor/EditorFooter.tsx
@@ -9,36 +9,28 @@
 import { useFormikContext } from "formik";
 import { memo, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useHref, useLocation } from "react-router-dom";
 import { ShareBoxLine } from "@ndla/icons";
 import { Button, FieldRoot } from "@ndla/primitives";
 import { SafeLinkButton } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import { IStatusDTO as ConceptStatus } from "@ndla/types-backend/concept-api";
-import { IStatusDTO as DraftStatus, IArticleDTO } from "@ndla/types-backend/draft-api";
 import { PUBLISHED, SAVE_DEBOUNCE_MS } from "../../constants";
 import PrioritySelect from "../../containers/FormikForm/components/PrioritySelect";
 import ResponsibleSelect from "../../containers/FormikForm/components/ResponsibleSelect";
 import StatusSelect from "../../containers/FormikForm/components/StatusSelect";
-import { hasUnpublishedConcepts } from "../../containers/FormikForm/utils";
-import { useMessages } from "../../containers/Messages/MessagesProvider";
 import { ConceptStatusStateMachineType, DraftStatusStateMachineType } from "../../interfaces";
 import { NewlyCreatedLocationState, toPreviewDraft } from "../../util/routeHelpers";
 import { FormField } from "../FormField";
-import { createEditUrl, TranslatableType, translatableTypes } from "../HeaderWithLanguage/util";
 import { PreviewResourceDialog } from "../PreviewDraft/PreviewResourceDialog";
 import SaveMultiButton from "../SaveMultiButton";
 
 interface Props {
-  article?: IArticleDTO | undefined;
+  type: "article" | "concept" | "learningpath";
   formIsDirty: boolean;
   savedToServer: boolean;
-  entityStatus?: DraftStatus;
-  showSimpleFooter: boolean;
   onSaveClick: () => void;
   statusStateMachine?: ConceptStatusStateMachineType | DraftStatusStateMachineType;
-  isArticle?: boolean;
-  isConcept: boolean;
   hideSecondaryButton: boolean;
   hasErrors?: boolean;
 }
@@ -49,6 +41,7 @@ interface FormValues {
   revision?: number;
   status: ConceptStatus;
   priority?: string;
+  supportedLanguages: string[];
 }
 
 const LinksWrapper = styled("div", {
@@ -60,47 +53,11 @@ const LinksWrapper = styled("div", {
   },
 });
 
-const StyledPageContent = styled("div", {
+const FooterWrapper = styled("div", {
   base: {
     position: "sticky",
     bottom: "4xsmall",
     zIndex: "docked",
-  },
-});
-
-const StyledSafeLinkButton = styled(SafeLinkButton, {
-  base: {
-    whiteSpace: "nowrap",
-  },
-});
-
-interface LanguageButtonProps {
-  article: IArticleDTO | undefined;
-}
-
-const LanguageButton = ({ article }: LanguageButtonProps) => {
-  const { t } = useTranslation();
-
-  if (!article) return;
-
-  const articleType = article.articleType as TranslatableType;
-  if (
-    ((article.content?.language === "nb" && article.supportedLanguages.includes("nn")) ||
-      (article.content?.language === "nn" && article.supportedLanguages.includes("nb"))) &&
-    translatableTypes.includes(articleType)
-  ) {
-    const targetLanguage = article.content.language === "nb" ? "nn" : "nb";
-
-    return (
-      <StyledSafeLinkButton variant="link" to={createEditUrl(article.id, targetLanguage, articleType)}>
-        {t(`languages.${targetLanguage}`)}
-      </StyledSafeLinkButton>
-    );
-  }
-};
-
-const ContentWrapper = styled("div", {
-  base: {
     display: "grid",
     gridTemplateColumns: "1fr repeat(3, minmax(150px, max-content)) min-content",
     justifyContent: "space-between",
@@ -121,39 +78,58 @@ const ContentWrapper = styled("div", {
   },
 });
 
+const StyledSafeLinkButton = styled(SafeLinkButton, {
+  base: {
+    whiteSpace: "nowrap",
+  },
+});
+
+interface LanguageButtonProps {
+  supportedLanguages: string[] | undefined;
+  language: string | undefined;
+}
+
+const REQUIRED_LANGUAGES = ["nb", "nn"];
+
+const LanguageButton = ({ supportedLanguages, language }: LanguageButtonProps) => {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const href = useHref(location);
+
+  if (
+    language &&
+    REQUIRED_LANGUAGES.every((lang) => supportedLanguages?.includes(lang)) &&
+    REQUIRED_LANGUAGES.includes(language)
+  ) {
+    const targetLanguage = language === "nb" ? "nn" : "nb";
+
+    return (
+      <StyledSafeLinkButton variant="link" to={href.split("/").slice(0, -1).concat(targetLanguage).join("/")}>
+        {t(`languages.${targetLanguage}`)}
+      </StyledSafeLinkButton>
+    );
+  }
+};
+
 function EditorFooter<T extends FormValues>({
-  article,
   formIsDirty,
   savedToServer,
-  entityStatus,
-  showSimpleFooter,
   onSaveClick,
   statusStateMachine,
-  isArticle,
-  isConcept,
   hideSecondaryButton,
   hasErrors,
+  type,
 }: Props) {
   const { t } = useTranslation();
-  const { values, setFieldValue, isSubmitting } = useFormikContext<T>();
-  const { createMessage } = useMessages();
+  const { values, initialValues, setFieldValue, isSubmitting } = useFormikContext<T>();
   const location = useLocation();
   const [shouldSave, setShouldSave] = useState(false);
-
-  const articleOrConcept = isArticle || isConcept;
 
   useEffect(() => {
     if (!shouldSave) return;
     onSaveClick();
     setShouldSave(false);
-    if (article && values.status.current === PUBLISHED && article.status.current !== PUBLISHED) {
-      hasUnpublishedConcepts(article).then((unpublished) => {
-        if (unpublished) {
-          createMessage({ message: t("form.unpublishedConcepts"), timeToLive: 0, severity: "warning" });
-        }
-      });
-    }
-  }, [article, createMessage, onSaveClick, shouldSave, t, values.status]);
+  }, [onSaveClick, shouldSave]);
 
   const onUpdateStatus = useCallback(
     (value: string | undefined) => {
@@ -166,71 +142,67 @@ function EditorFooter<T extends FormValues>({
   );
 
   return (
-    <StyledPageContent>
-      <ContentWrapper>
-        {!showSimpleFooter && (
-          <LinksWrapper>
-            {!!values.id && !!isConcept && (
-              <PreviewResourceDialog
-                type="concept"
-                language={values.language}
-                activateButton={<Button variant="link">{t("form.preview.button")}</Button>}
+    <FooterWrapper>
+      {!!values.id && (
+        <LinksWrapper>
+          {!!values.id && type === "concept" && (
+            <PreviewResourceDialog
+              type="concept"
+              language={values.language}
+              activateButton={<Button variant="link">{t("form.preview.button")}</Button>}
+            />
+          )}
+          {!!values.id && type === "article" && (
+            <SafeLinkButton variant="link" to={toPreviewDraft(values.id, values.language)} target="_blank">
+              {t("form.preview.button")}
+              <ShareBoxLine size="small" />
+            </SafeLinkButton>
+          )}
+          <LanguageButton language={values.language} supportedLanguages={values.supportedLanguages} />
+        </LinksWrapper>
+      )}
+      {type !== "concept" && (
+        <FormField name="priority">
+          {({ field, helpers }) => (
+            <FieldRoot>
+              <PrioritySelect priority={field.value} updatePriority={helpers.setValue} />
+            </FieldRoot>
+          )}
+        </FormField>
+      )}
+      <FormField name="responsibleId">
+        {({ field, helpers }) => (
+          <FieldRoot>
+            <ResponsibleSelect responsible={field.value} onSave={helpers.setValue} />
+          </FieldRoot>
+        )}
+      </FormField>
+      {!!values.id && (
+        <FormField name="status">
+          {({ field }) => (
+            <FieldRoot>
+              <StatusSelect
+                status={field.value}
+                updateStatus={onUpdateStatus}
+                statusStateMachine={statusStateMachine}
+                initialStatus={initialValues.status.current}
               />
-            )}
-            {!!values.id && !!isArticle && (
-              <SafeLinkButton variant="link" to={toPreviewDraft(values.id, values.language)} target="_blank">
-                {t("form.preview.button")}
-                <ShareBoxLine size="small" />
-              </SafeLinkButton>
-            )}
-            <LanguageButton article={article} />
-          </LinksWrapper>
-        )}
-        {!!isArticle && (
-          <FormField name="priority">
-            {({ field, helpers }) => (
-              <FieldRoot>
-                <PrioritySelect priority={field.value} updatePriority={helpers.setValue} />
-              </FieldRoot>
-            )}
-          </FormField>
-        )}
-        {!!articleOrConcept && (
-          <FormField name="responsibleId">
-            {({ field, helpers }) => (
-              <FieldRoot>
-                <ResponsibleSelect responsible={field.value} onSave={helpers.setValue} />
-              </FieldRoot>
-            )}
-          </FormField>
-        )}
-        {!showSimpleFooter && (
-          <FormField name="status">
-            {({ field }) => (
-              <FieldRoot>
-                <StatusSelect
-                  status={field.value}
-                  updateStatus={onUpdateStatus}
-                  statusStateMachine={statusStateMachine}
-                  entityStatus={entityStatus}
-                />
-              </FieldRoot>
-            )}
-          </FormField>
-        )}
-        <SaveMultiButton
-          isSaving={isSubmitting}
-          formIsDirty={formIsDirty}
-          showSaved={!formIsDirty && (savedToServer || !!(location.state as NewlyCreatedLocationState)?.isNewlyCreated)}
-          onClick={(saveAsNew) => {
-            setFieldValue("saveAsNew", saveAsNew);
-            setTimeout(() => setShouldSave(true), SAVE_DEBOUNCE_MS);
-          }}
-          hideSecondaryButton={hideSecondaryButton}
-          hasErrors={!!hasErrors}
-        />
-      </ContentWrapper>
-    </StyledPageContent>
+            </FieldRoot>
+          )}
+        </FormField>
+      )}
+      <SaveMultiButton
+        isSaving={isSubmitting}
+        formIsDirty={formIsDirty}
+        showSaved={!formIsDirty && (savedToServer || !!(location.state as NewlyCreatedLocationState)?.isNewlyCreated)}
+        onClick={(saveAsNew) => {
+          setFieldValue("saveAsNew", saveAsNew);
+          setTimeout(() => setShouldSave(true), SAVE_DEBOUNCE_MS);
+        }}
+        hideSecondaryButton={hideSecondaryButton}
+        hasErrors={!!hasErrors}
+      />
+    </FooterWrapper>
   );
 }
 

--- a/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
+++ b/src/containers/ArticlePage/FrontpageArticlePage/components/FrontpageArticleForm.tsx
@@ -149,16 +149,12 @@ const InternalFormFooter = ({ articleChanged, article, savedToServer, handleSubm
   return (
     <>
       <EditorFooter
-        showSimpleFooter={!article?.id}
+        type="article"
         formIsDirty={formIsDirty}
         savedToServer={savedToServer}
         onSaveClick={onSave}
-        entityStatus={article?.status}
         statusStateMachine={statusStateMachine.data}
-        isArticle
-        isConcept={false}
         hideSecondaryButton={false}
-        article={article}
       />
       <AlertDialogWrapper
         isSubmitting={isSubmitting}

--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceForm.tsx
@@ -214,16 +214,12 @@ const InternalFormFooter = ({ articleChanged, article, savedToServer, handleSubm
   return (
     <>
       <EditorFooter
-        showSimpleFooter={!article?.id}
+        type="article"
         formIsDirty={formIsDirty}
         savedToServer={savedToServer}
         onSaveClick={onSave}
-        entityStatus={article?.status}
         statusStateMachine={statusStateMachine.data}
-        isArticle
-        isConcept={false}
         hideSecondaryButton={false}
-        article={article}
       />
       <AlertDialogWrapper
         isSubmitting={isSubmitting}

--- a/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
+++ b/src/containers/ArticlePage/TopicArticlePage/components/TopicArticleForm.tsx
@@ -193,16 +193,12 @@ const InternalFormFooter = ({ articleChanged, article, savedToServer, handleSubm
   return (
     <>
       <EditorFooter
-        showSimpleFooter={!article?.id}
+        type="article"
         formIsDirty={formIsDirty}
         savedToServer={savedToServer}
         onSaveClick={onSave}
-        entityStatus={article?.status}
         statusStateMachine={statusStateMachine.data}
-        isArticle
-        isConcept={false}
         hideSecondaryButton={false}
-        article={article}
       />
       <AlertDialogWrapper
         isSubmitting={isSubmitting}

--- a/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptForm.tsx
@@ -199,13 +199,7 @@ const ConceptForm = ({
                 </FormAccordion>
               )}
             </FormAccordions>
-            <ConceptFormFooter
-              entityStatus={concept?.status}
-              conceptChanged={!!conceptChanged}
-              inDialog={inDialog}
-              savedToServer={savedToServer}
-              showSimpleFooter={!concept?.id}
-            />
+            <ConceptFormFooter conceptChanged={!!conceptChanged} inDialog={inDialog} savedToServer={savedToServer} />
           </FormWrapper>
         );
       }}

--- a/src/containers/ConceptPage/ConceptForm/ConceptFormFooter.tsx
+++ b/src/containers/ConceptPage/ConceptForm/ConceptFormFooter.tsx
@@ -10,7 +10,6 @@ import { useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
 import { Button, DialogCloseTrigger, FieldRoot } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
-import { IStatusDTO } from "@ndla/types-backend/concept-api";
 import { FormField } from "../../../components/FormField";
 import { FormActionsContainer } from "../../../components/FormikForm";
 import SaveButton from "../../../components/SaveButton";
@@ -24,11 +23,9 @@ import { AlertDialogWrapper } from "../../FormikForm";
 import { ConceptFormValues } from "../conceptInterfaces";
 
 interface Props {
-  entityStatus?: IStatusDTO;
   conceptChanged: boolean;
   inDialog?: boolean;
   savedToServer: boolean;
-  showSimpleFooter: boolean;
 }
 
 const StyledFormActionsContainer = styled(FormActionsContainer, {
@@ -37,7 +34,7 @@ const StyledFormActionsContainer = styled(FormActionsContainer, {
   },
 });
 
-const ConceptFormFooter = ({ entityStatus, conceptChanged, inDialog, savedToServer, showSimpleFooter }: Props) => {
+const ConceptFormFooter = ({ conceptChanged, inDialog, savedToServer }: Props) => {
   const { t } = useTranslation();
   const formikContext = useFormikContext<ConceptFormValues>();
   const conceptStateMachine = useConceptStateMachine();
@@ -61,7 +58,7 @@ const ConceptFormFooter = ({ entityStatus, conceptChanged, inDialog, savedToServ
                 status={field.value}
                 updateStatus={(value) => helpers.setValue({ current: value })}
                 statusStateMachine={conceptStateMachine.data}
-                entityStatus={entityStatus ?? field.value}
+                initialStatus={initialValues.status?.current ?? field.value?.current}
               />
             </FieldRoot>
           )}
@@ -95,14 +92,12 @@ const ConceptFormFooter = ({ entityStatus, conceptChanged, inDialog, savedToServ
   return (
     <>
       <EditorFooter
+        type="concept"
         formIsDirty={formIsDirty}
         savedToServer={savedToServer}
-        entityStatus={entityStatus}
         statusStateMachine={conceptStateMachine.data}
-        showSimpleFooter={showSimpleFooter}
         onSaveClick={submitForm}
         hideSecondaryButton
-        isConcept
         hasErrors={isSubmitting || !formIsDirty || disableSave}
       />
       <AlertDialogWrapper

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -27,6 +27,7 @@ import { RelatedContent } from "../../interfaces";
 import { useLicenses } from "../../modules/draft/draftQueries";
 import { NdlaErrorPayload } from "../../util/resolveJsonOrRejectWithError";
 import { useMessages } from "../Messages/MessagesProvider";
+import { hasUnpublishedConcepts } from "./utils";
 
 export type SlateCommentType = Omit<ICommentDTO, "content"> & { content: Descendant[] };
 
@@ -153,6 +154,14 @@ export function useArticleFormHooks<T extends ArticleFormType>({
         setSavedToServer(true);
         const newInitialValues = getInitialValues(savedArticle, articleLanguage, ndlaId);
         formikHelpers.resetForm({ values: newInitialValues });
+
+        if (newStatus === PUBLISHED && newStatus !== initialStatus) {
+          const unpublishedConcepts = await hasUnpublishedConcepts(savedArticle);
+          if (unpublishedConcepts) {
+            createMessage({ message: t("form.unpublishedConcepts"), timeToLive: 0, severity: "warning" });
+          }
+        }
+
         if (rules) {
           const newInitialWarnings = getWarnings(newInitialValues, rules, t, [], savedArticle);
           formikHelpers.setStatus({ warnings: newInitialWarnings });

--- a/src/containers/FormikForm/components/StatusSelect.tsx
+++ b/src/containers/FormikForm/components/StatusSelect.tsx
@@ -20,7 +20,7 @@ interface Props {
   status: DraftStatus | undefined;
   updateStatus: (s: string | undefined) => void;
   statusStateMachine?: ConceptStatusStateMachineType | DraftStatusStateMachineType;
-  entityStatus: DraftStatus | undefined;
+  initialStatus: string | undefined;
 }
 
 const StyledSelectValueText = styled(SelectValueText, {
@@ -49,20 +49,20 @@ interface StatusItem {
 
 const positioning = { sameWidth: true };
 
-const StatusSelect = ({ status, updateStatus, statusStateMachine, entityStatus }: Props) => {
+const StatusSelect = ({ status, updateStatus, statusStateMachine, initialStatus }: Props) => {
   const { t } = useTranslation();
 
   const collection = useMemo(() => {
     const items =
-      statusStateMachine && entityStatus
-        ? statusStateMachine[entityStatus.current].map((status) => ({
+      statusStateMachine && initialStatus
+        ? statusStateMachine[initialStatus].map((status) => ({
             label: t(`form.status.actions.${status}`),
             status,
           }))
         : [];
 
     return createListCollection({ items, itemToValue: (item) => item.status, itemToString: (item) => item.label });
-  }, [entityStatus, statusStateMachine, t]);
+  }, [initialStatus, statusStateMachine, t]);
 
   const value = useMemo(() => (status ? [status.current] : []), [status]);
 
@@ -75,7 +75,7 @@ const StatusSelect = ({ status, updateStatus, statusStateMachine, entityStatus }
 
   return (
     <StyledSelectRoot
-      key={status === undefined ? entityStatus?.current : undefined}
+      key={status === undefined ? initialStatus : undefined}
       collection={collection}
       positioning={positioning}
       data-testid="status-select"
@@ -85,7 +85,7 @@ const StatusSelect = ({ status, updateStatus, statusStateMachine, entityStatus }
       <SelectLabel srOnly>{t("searchForm.types.status")}</SelectLabel>
       <StyledGenericSelectTrigger>
         <StyledSelectValueText
-          placeholder={entityStatus?.current === PUBLISHED ? t("form.status.published") : t("searchForm.types.status")}
+          placeholder={initialStatus === PUBLISHED ? t("form.status.published") : t("searchForm.types.status")}
         />
       </StyledGenericSelectTrigger>
       <SelectContent>

--- a/src/containers/GlossPage/components/GlossForm.tsx
+++ b/src/containers/GlossPage/components/GlossForm.tsx
@@ -173,13 +173,7 @@ export const GlossForm = ({
               <CopyrightFieldGroup enableLicenseNA={true} />
             </FormAccordion>
           </FormAccordions>
-          <ConceptFormFooter
-            entityStatus={concept?.status}
-            conceptChanged={!!conceptChanged}
-            inDialog={inDialog}
-            savedToServer={savedToServer}
-            showSimpleFooter={!concept?.id}
-          />
+          <ConceptFormFooter conceptChanged={!!conceptChanged} inDialog={inDialog} savedToServer={savedToServer} />
         </FormWrapper>
       )}
     </Formik>


### PR DESCRIPTION
Lukter litt på å bruke denne til læringsstier, men logikken der inne er ikke så pen. Formik oppdaterer skjema-verdier asynkront uten å gi oss noen måte å sjekke om verdien er satt ennå. Dette er i det minste litt penere enn det som var der før.

Lener meg også mer på status-overganger i backend, samt at jeg varsler oftere om hvorvidt artikkelen inneholder en upublisert forklaring.