### PR TITLE
fix: Inifinite `WelcomePage` spinner when new user

### DIFF
--- a/src/containers/WelcomePage/components/ArticleStatusContent.tsx
+++ b/src/containers/WelcomePage/components/ArticleStatusContent.tsx
@@ -198,7 +198,7 @@ const ArticleStatusContent = ({
         </ControlWrapperDashboard>
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={searchQuery.isPending}
+        isLoading={searchQuery.isLoading}
         tableTitleList={tableTitles}
         tableData={tableData}
         error={error}

--- a/src/containers/WelcomePage/components/LastUsedConcepts.tsx
+++ b/src/containers/WelcomePage/components/LastUsedConcepts.tsx
@@ -23,7 +23,7 @@ import { SelectItem, SortOptionLastUsed } from "../types";
 
 interface Props {
   data: IConceptSummaryDTO[];
-  isPending: boolean;
+  isLoading: boolean;
   page: number;
   setPage: (page: number) => void;
   sortOption: string;
@@ -37,7 +37,7 @@ interface Props {
 
 const LastUsedConcepts = ({
   data,
-  isPending,
+  isLoading,
   page,
   setPage,
   sortOption,
@@ -81,7 +81,7 @@ const LastUsedConcepts = ({
         <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={isPending}
+        isLoading={isLoading}
         tableTitleList={titles}
         tableData={tableData}
         setSortOption={setSortOption}

--- a/src/containers/WelcomePage/components/LastUsedItems.tsx
+++ b/src/containers/WelcomePage/components/LastUsedItems.tsx
@@ -175,7 +175,7 @@ const LastUsedItems = ({ lastUsedResources = [], lastUsedConcepts = [] }: Props)
       <WelcomePageTabsContent value="articles">
         <LastUsedResources
           data={sortedData}
-          isPending={searchDraftsQuery.isPending}
+          isLoading={searchDraftsQuery.isLoading}
           page={page}
           setPage={setPage}
           sortOption={sortOption}
@@ -190,7 +190,7 @@ const LastUsedItems = ({ lastUsedResources = [], lastUsedConcepts = [] }: Props)
       <WelcomePageTabsContent value="concepts">
         <LastUsedConcepts
           data={sortedConceptsData}
-          isPending={searchConceptsQuery.isPending}
+          isLoading={searchConceptsQuery.isLoading}
           page={pageConcept}
           setPage={setPageConcept}
           sortOption={sortOptionConcept}

--- a/src/containers/WelcomePage/components/LastUsedResources.tsx
+++ b/src/containers/WelcomePage/components/LastUsedResources.tsx
@@ -23,7 +23,7 @@ import { SelectItem, SortOptionLastUsed } from "../types";
 
 interface Props {
   data: IArticleSummaryDTO[];
-  isPending: boolean;
+  isLoading: boolean;
   page: number;
   setPage: (page: number) => void;
   sortOption: string;
@@ -37,7 +37,7 @@ interface Props {
 
 const LastUsedResources = ({
   data = [],
-  isPending,
+  isLoading,
   page,
   setPage,
   sortOption,
@@ -78,7 +78,7 @@ const LastUsedResources = ({
         <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={isPending}
+        isLoading={isLoading}
         tableTitleList={titles}
         tableData={tableData}
         setSortOption={setSortOption}

--- a/src/containers/WelcomePage/components/Revisions.tsx
+++ b/src/containers/WelcomePage/components/Revisions.tsx
@@ -112,7 +112,7 @@ const Revisions = ({ userData }: Props) => {
     today(getLocalTimeZone()).add({ years: 1 }).toDate(getLocalTimeZone()),
   );
 
-  const { data, isPending, isError } = useSearch(
+  const { data, isLoading, isError } = useSearch(
     {
       subjects: filterSubject ? [filterSubject.value] : userData?.favoriteSubjects,
       revisionDateTo: currentDateAddYear,
@@ -271,7 +271,7 @@ const Revisions = ({ userData }: Props) => {
           </ControlWrapperDashboard>
         </StyledTopRowDashboardInfo>
         <TableComponent
-          isPending={isPending}
+          isLoading={isLoading}
           tableTitleList={tableTitles}
           tableData={tableData}
           setSortOption={setSortOption}

--- a/src/containers/WelcomePage/components/SubjectViewContent.tsx
+++ b/src/containers/WelcomePage/components/SubjectViewContent.tsx
@@ -201,7 +201,7 @@ const SubjectViewContent = ({
         </ControlWrapperDashboard>
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={isPending}
+        isLoading={isPending}
         tableTitleList={tableTitles}
         tableData={tableData.filter((el) => el.length > 0)}
         error={error}

--- a/src/containers/WelcomePage/components/TableComponent.tsx
+++ b/src/containers/WelcomePage/components/TableComponent.tsx
@@ -80,7 +80,7 @@ export interface TitleElement<T extends string> {
 interface Props<T extends string> {
   tableTitleList: TitleElement<T>[];
   tableData: FieldElement[][];
-  isPending: boolean;
+  isLoading: boolean;
   setSortOption?: (o: Prefix<"-", T>) => void;
   noResultsText?: string;
   sortOption?: string;
@@ -91,7 +91,7 @@ interface Props<T extends string> {
 const TableComponent = <T extends string>({
   tableTitleList,
   tableData = [[]],
-  isPending,
+  isLoading,
   setSortOption,
   noResultsText,
   sortOption,
@@ -142,7 +142,7 @@ const TableComponent = <T extends string>({
             ))}
           </tr>
         </thead>
-        {!isPending ? (
+        {!isLoading ? (
           <tbody>
             {tableData.map((contentRow, index) => (
               <tr key={`tablerow_${contentRow?.[0]?.id}_${index}`}>
@@ -156,7 +156,7 @@ const TableComponent = <T extends string>({
           </tbody>
         ) : null}
       </StyledTable>
-      {isPending ? (
+      {isLoading ? (
         <LoadingNoContentWrapper>
           <Spinner />
         </LoadingNoContentWrapper>

--- a/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/ConceptListTabContent.tsx
@@ -116,7 +116,7 @@ const ConceptListTabContent = ({
         </ControlWrapperDashboard>
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={isPending}
+        isLoading={isPending}
         tableTitleList={tableTitles}
         tableData={tableData}
         setSortOption={setSortOption}

--- a/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
+++ b/src/containers/WelcomePage/components/worklist/WorkListTabContent.tsx
@@ -214,7 +214,7 @@ const WorkListTabContent = ({
         </ControlWrapperDashboard>
       </StyledTopRowDashboardInfo>
       <TableComponent
-        isPending={isPending}
+        isLoading={isPending}
         tableTitleList={tableTitles}
         tableData={tableData}
         setSortOption={setSortOption}


### PR DESCRIPTION
Jeg vet ikke helt hvorfor [vi gikk over](https://github.com/NDLANO/editorial-frontend/pull/2424) til `isPending`, så kom gjerne med innspill, men dette ser ut til å fungere?
Problemet med `isPending` i denne situasjonen er at den er `true` dersom query'en er disablet.
Da ser det ut som ting står å laster for alltid selvom dataen ikke blir etterspurt.

Alternativt så kan jeg gjøre så vi fremdeles bruker `isPending`, men lage en variabel for `queryEnabled` eller lignende i tillegg også bruke `isPending && queryEnabled` for å finne ut om vi skal vise Spinner, men så vidt jeg ser så blir det helt likt?