### PR TITLE
Support metaimage save

### DIFF
--- a/src/containers/LearningpathPage/metadata/LearningpathMetaDataForm.tsx
+++ b/src/containers/LearningpathPage/metadata/LearningpathMetaDataForm.tsx
@@ -58,6 +58,7 @@ interface LearningpathMetaDataFormValues {
   title: string;
   description: string;
   coverPhotoUrl?: string;
+  coverPhotoMetaUrl?: string;
   tags: string[];
   // This field is only used for error checking in revisions
   revisionError?: string;
@@ -81,6 +82,7 @@ const learningpathApiTypeToFormType = (
     title: learningpath?.title.title ?? "",
     description: learningpath?.description.description ?? "",
     coverPhotoUrl: learningpath?.coverPhoto?.url,
+    coverPhotoMetaUrl: learningpath?.coverPhoto?.metaUrl,
     tags: learningpath?.tags.tags ?? [],
     revisionMeta: learningpath?.revisions ?? [],
   };
@@ -94,7 +96,7 @@ const learningpathFormTypeToNewApiType = (
     language,
     title: values.title,
     description: values.description,
-    coverPhotoMetaUrl: values.coverPhotoUrl,
+    coverPhotoMetaUrl: values.coverPhotoMetaUrl,
     tags: values.tags,
   };
 };
@@ -110,7 +112,7 @@ const learningpathFormTypeToApiType = (
     language,
     title: values.title,
     description: values.description,
-    coverPhotoMetaUrl: values.coverPhotoUrl,
+    coverPhotoMetaUrl: values.coverPhotoMetaUrl,
     tags: values.tags,
   };
 };


### PR DESCRIPTION
Funker ikkje alltid å lagre læringsstier med metabilde fra stier. Feks https://ed.test.ndla.no/learningpath/1088/edit/nb