### PR TITLE
Only check dirty if something to compare

### DIFF
--- a/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
+++ b/src/containers/ArticlePage/LearningResourcePage/components/LearningResourceContent.tsx
@@ -130,7 +130,9 @@ const ContentField = ({ articleId, articleLanguage }: ContentFieldProps) => {
   const onInitialNormalized = useCallback(
     (value: Descendant[]) => {
       if (
-        isFormikFormDirty({ values: { ...values, content: value }, initialValues, dirty: true }) ||
+        (!!values &&
+          !!initialValues &&
+          isFormikFormDirty({ values: { ...values, content: value }, initialValues, dirty: true })) ||
         findNodesByType(value, UNSUPPORTED_ELEMENT_TYPE).length
       ) {
         setShowAlert(true);


### PR DESCRIPTION
Om du kopierer artikkel, og så legger den inn i taksonomi for så å endre feks en kommentar og så klikker lagre får du beskjed om at artikkelen er endra av editor. Det skjer fordi callback trigges med values og initialValues begge satt til undefined. Endringa er at begge må ha verdi for at det skal gi meining å sammenligne dei.