### PR TITLE
fix: save article after taxonomy update

### DIFF
--- a/src/containers/ArticlePage/articleTransformers.ts
+++ b/src/containers/ArticlePage/articleTransformers.ts
@@ -149,7 +149,7 @@ export const learningResourceFormTypeToDraftApiType = (
     ? { id: article.metaImageId, alt: article.metaImageAlt ?? "" }
     : nullOrUndefined(article.metaImageId);
   return {
-    revision: 0,
+    revision: article.revision ?? 0,
     articleType: "standard",
     content: blockContentToHTML(article.content),
     copyright: {

--- a/src/containers/FormikForm/articleFormHooks.ts
+++ b/src/containers/FormikForm/articleFormHooks.ts
@@ -111,7 +111,7 @@ export function useArticleFormHooks<T extends ArticleFormType>({
   ndlaId,
   articleRevisionHistory,
 }: HooksInputObject<T>) {
-  const { id, revision } = article ?? {};
+  const { id } = article ?? {};
   const formikRef: any = useRef<any>(null);
   const { createMessage, applicationError } = useMessages();
   const { data: licenses } = useLicenses({ placeholderData: [] });
@@ -145,7 +145,7 @@ export function useArticleFormHooks<T extends ArticleFormType>({
       try {
         savedArticle = await updateArticle({
           ...newArticle,
-          revision: revision || newArticle.revision,
+          revision: values.revision || article?.revision || newArticle.revision,
           ...(statusChange ? { status: newStatus } : {}),
         });
 
@@ -200,7 +200,7 @@ export function useArticleFormHooks<T extends ArticleFormType>({
       initialValues,
       licenses,
       ndlaId,
-      revision,
+      article?.revision,
       rules,
       t,
       updateArticle,


### PR DESCRIPTION
Denne er det nok lurt å teste nøye. Jeg er litt usikker på hva konsekvensene av å oppdatere revisjonsnummeret er.

Oppdaterer revisjon etter at taksonomi har blitt endret. Dette fikser feilemeldingen om at editoren har endret HTML. Vi sitter fortsatt igjen med problemet om at den nyeste versjonsloggen ikke dukker opp i versjonslisten.