### PR TITLE
Prevents dialogclose for image-dialogs

### DIFF
--- a/e2e/specs/blockpicker_learning_resource.spec.ts
+++ b/e2e/specs/blockpicker_learning_resource.spec.ts
@@ -107,10 +107,10 @@ test("opens and closes audio", async ({ page }) => {
 test("opens and closes file", async ({ page }) => {
   await page.getByTestId("create-file").click();
   await expect(
-    page.getByRole("dialog").filter({ hasText: "Dra og slipp eller trykk for å laste opp fil(er)" }),
+    page.getByRole("alertdialog").filter({ hasText: "Dra og slipp eller trykk for å laste opp fil(er)" }),
   ).toBeVisible();
-  await page.getByRole("dialog").getByRole("button", { name: "Avbryt" }).click();
-  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await page.getByRole("alertdialog").getByRole("button", { name: "Avbryt" }).click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
 });
 
 test("opens and closes url", async ({ page }) => {

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -83,7 +83,7 @@ export const CloneImageDialog = ({ imageId }: Props) => {
   );
 
   return (
-    <DialogRoot open={open} onOpenChange={onOpenChange}>
+    <DialogRoot context="alert" role="alertdialog" open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         <Button size="small" variant="tertiary" loading={cloneImage.isPending}>
           {t("form.workflow.saveAsNew")}

--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -83,7 +83,7 @@ export const CloneImageDialog = ({ imageId }: Props) => {
   );
 
   return (
-    <DialogRoot context="alert" role="alertdialog" open={open} onOpenChange={onOpenChange}>
+    <DialogRoot role="alertdialog" open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         <Button size="small" variant="tertiary" loading={cloneImage.isPending}>
           {t("form.workflow.saveAsNew")}

--- a/src/components/MetaImagePicker.tsx
+++ b/src/components/MetaImagePicker.tsx
@@ -43,13 +43,7 @@ export const MetaImagePicker = ({ imageSearch, imageForm, children }: Props) => 
 
   const onClose = useCallback(() => setOpen(false), []);
   return (
-    <DialogRoot
-      context="alert"
-      role="alertdialog"
-      size="large"
-      open={open}
-      onOpenChange={(details) => setOpen(details.open)}
-    >
+    <DialogRoot role="alertdialog" size="large" open={open} onOpenChange={(details) => setOpen(details.open)}>
       {children}
       <DialogContent>
         <DialogHeader>

--- a/src/components/MetaImagePicker.tsx
+++ b/src/components/MetaImagePicker.tsx
@@ -43,7 +43,13 @@ export const MetaImagePicker = ({ imageSearch, imageForm, children }: Props) => 
 
   const onClose = useCallback(() => setOpen(false), []);
   return (
-    <DialogRoot size="large" open={open} onOpenChange={(details) => setOpen(details.open)}>
+    <DialogRoot
+      context="alert"
+      role="alertdialog"
+      size="large"
+      open={open}
+      onOpenChange={(details) => setOpen(details.open)}
+    >
       {children}
       <DialogContent>
         <DialogHeader>

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
@@ -113,7 +113,6 @@ const SlateVisualElementPicker = ({
 
   return (
     <DialogRoot
-      context="alert"
       role="alertdialog"
       size="large"
       open={isOpen}

--- a/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
+++ b/src/components/SlateEditor/plugins/blockPicker/SlateVisualElementPicker.tsx
@@ -113,6 +113,8 @@ const SlateVisualElementPicker = ({
 
   return (
     <DialogRoot
+      context="alert"
+      role="alertdialog"
       size="large"
       open={isOpen}
       onOpenChange={(details) => {


### PR DESCRIPTION
https://trello.com/c/79rWHmeJ/1471-modal-kan-lukkes-uten-lagring-advarsel-med-tapt-data-som-resultat-mulig-%C3%A5-unng%C3%A5