### PR TITLE
refactor: do not store image file meta in form fields

### DIFF
--- a/src/components/HeaderWithLanguage/CloneImageDialog.tsx
+++ b/src/components/HeaderWithLanguage/CloneImageDialog.tsx
@@ -17,6 +17,7 @@ import {
   DialogTrigger,
   Text,
 } from "@ndla/primitives";
+import { ImageMetaInformationV3DTO } from "@ndla/types-backend/image-api";
 import { Formik, useFormikContext } from "formik";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,6 +34,7 @@ import validateFormik from "../formikValidationSchema";
 
 interface Props {
   imageId: number;
+  image: ImageMetaInformationV3DTO | undefined;
 }
 
 interface FormikValuesType extends Partial<ImageFormikType> {
@@ -44,7 +46,7 @@ const initialValues: FormikValuesType = {
   imageFile: undefined,
 };
 
-export const CloneImageDialog = ({ imageId }: Props) => {
+export const CloneImageDialog = ({ imageId, image }: Props) => {
   const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
   const { createMessage, applicationError } = useMessages();
@@ -105,7 +107,7 @@ export const CloneImageDialog = ({ imageId }: Props) => {
                 return (
                   <Form>
                     <Text>{t("imageForm.copyDescription")}</Text>
-                    <ImageUploadFormElement language={i18n.language} />
+                    <ImageUploadFormElement language={i18n.language} image={image} />
                     <FormActionsContainer>
                       <Button disabled={!dirty || !isValid} loading={cloneImage.isPending} onClick={submitForm}>
                         {t("save")}

--- a/src/containers/ImageUploader/components/ImageContent.tsx
+++ b/src/containers/ImageUploader/components/ImageContent.tsx
@@ -9,6 +9,7 @@
 import { FileListLine } from "@ndla/icons";
 import { Button, FieldLabel, FieldRoot, FieldErrorMessage, FieldTextArea, DialogTrigger } from "@ndla/primitives";
 import { HStack } from "@ndla/styled-system/jsx";
+import { ImageMetaInformationV3DTO } from "@ndla/types-backend/image-api";
 import { useField, useFormikContext } from "formik";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -36,13 +37,20 @@ const readImageText = (imageBlob: Blob): Promise<string> =>
 
 interface Props {
   language: string;
+  image: ImageMetaInformationV3DTO | undefined;
 }
 
-const ImageContent = ({ language }: Props) => {
+const isValidContentType = (image: ImageMetaInformationV3DTO | undefined, file: Blob | string | undefined) => {
+  const contentType = image?.image.contentType ?? (typeof file === "string" ? undefined : file?.type);
+  if (!contentType) return false;
+  return !!contentType.match(IMAGE_TYPE_REGEX);
+};
+
+const ImageContent = ({ language, image }: Props) => {
   const { t } = useTranslation();
   const { userPermissions } = useSession();
   const { values } = useFormikContext<ImageFormikType>();
-  const [image, setImage] = useState<AltTextVariables["image"] | undefined>(undefined);
+  const [imageInformation, setImageInformation] = useState<AltTextVariables["image"] | undefined>(undefined);
   const [altTextField, altTextMeta, altTextHelpers] = useField("alttext");
 
   useEffect(() => {
@@ -54,7 +62,7 @@ const ImageContent = ({ language }: Props) => {
         if (typeof values.imageFile === "string") {
           // We use the timestamp to avoid caching of the `imageFile` url in the browser
           const timestamp = new Date().getTime();
-          const result = await fetch(values.filepath || `${values.imageFile}?width=1500&ts=${timestamp}`);
+          const result = await fetch(`${values.imageFile}?width=1500&ts=${timestamp}`);
           imageBlob = await result.blob();
         } else {
           imageBlob = values.imageFile;
@@ -68,16 +76,16 @@ const ImageContent = ({ language }: Props) => {
         const imageText = await readImageText(imageBlob);
         // All images from the filereader is appended with a data identifier string. https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
         const base64 = imageText.replace(IMAGE_IDENTIFIER_REGEX, "");
-        setImage({ base64, fileType: imageBlob.type });
+        setImageInformation({ base64, fileType: imageBlob.type });
       }
     };
     getImagePromptVariables();
-  }, [values.imageFile, values.filepath, altTextHelpers, t]);
+  }, [values.imageFile, altTextHelpers, t]);
 
   return (
     <FormContent>
       <TitleField hideToolbar />
-      <ImageUploadFormElement language={language} />
+      <ImageUploadFormElement language={language} image={image} />
       <FormField name="caption">
         {({ field, meta }) => (
           <FieldRoot invalid={!!meta.error}>
@@ -90,11 +98,13 @@ const ImageContent = ({ language }: Props) => {
       <FieldRoot invalid={!!altTextMeta.error}>
         <HStack justify="space-between">
           <FieldLabel>{t("form.image.alt.label")}</FieldLabel>
-          {userPermissions?.includes(AI_ACCESS_SCOPE) && !!values.contentType?.match(IMAGE_TYPE_REGEX) && !!image ? (
+          {userPermissions?.includes(AI_ACCESS_SCOPE) &&
+          isValidContentType(image, values.imageFile) &&
+          !!imageInformation ? (
             <AiPromptDialog
               promptVariables={{
                 type: "altText",
-                image,
+                image: imageInformation,
               }}
               language={language}
               maxTokens={2000}

--- a/src/containers/ImageUploader/components/ImageForm.tsx
+++ b/src/containers/ImageUploader/components/ImageForm.tsx
@@ -217,7 +217,7 @@ const ImageForm = <TImage extends ImageMetaInformationV3DTO | undefined = undefi
                 hasError={hasError(["title", "imageFile", "caption", "alttext"])}
               >
                 <StyledPageContent variant="content">
-                  <ImageContent language={language} />
+                  <ImageContent language={language} image={image} />
                 </StyledPageContent>
               </FormAccordion>
               <FormAccordion

--- a/src/containers/ImageUploader/components/ImageFormHeader.tsx
+++ b/src/containers/ImageUploader/components/ImageFormHeader.tsx
@@ -49,7 +49,7 @@ export const ImageFormHeader = ({ image, language }: Props) => {
         <FormHeaderHeadingContainer>
           <Badge>{t("contentTypes.image")}</Badge>
           <FormHeaderHeading contentType="image">{image?.title.title}</FormHeaderHeading>
-          {!!parsedId && <CloneImageDialog imageId={parsedId} />}
+          {!!parsedId && <CloneImageDialog imageId={parsedId} image={image} />}
         </FormHeaderHeadingContainer>
         {!isNewLanguage && (
           <FormHeaderStatusWrapper>

--- a/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
+++ b/src/containers/ImageUploader/components/ImageUploadFormElement.tsx
@@ -21,9 +21,10 @@ import {
 } from "@ndla/primitives";
 import { SafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
-import { useFormikContext } from "formik";
+import { ImageDimensionsDTO, ImageMetaInformationV3DTO } from "@ndla/types-backend/image-api";
+import { useField } from "formik";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FormField } from "../../../components/FormField";
 import { MAX_IMAGE_UPLOAD_SIZE } from "../../../constants";
 import { ImageFormikType } from "../imageTransformers";
 
@@ -49,122 +50,132 @@ const ImageContentWrapper = styled("div", {
 
 interface Props {
   language: string;
+  image: ImageMetaInformationV3DTO | undefined;
 }
 
-export const ImageUploadFormElement = ({ language }: Props) => {
-  const { t } = useTranslation();
-  const formikContext = useFormikContext<ImageFormikType>();
-  const { values, setValues, setFieldValue } = formikContext;
+interface ImageMeta {
+  contentType: string;
+  fileSize: number;
+  dimensions?: ImageDimensionsDTO;
+  originalDate?: string;
+  url: string;
+}
 
-  // We use the timestamp to avoid caching of the `imageFile` url in the browser
-  const timestamp = new Date().getTime();
-  const imgSrc = values.filepath || `${values.imageFile}?width=800&ts=${timestamp}`;
+const getImageMeta = async (
+  image: ImageMetaInformationV3DTO | undefined,
+  file: Blob | undefined,
+): Promise<ImageMeta | undefined> => {
+  if (image) {
+    return {
+      contentType: image.image.contentType,
+      fileSize: image.image.size,
+      dimensions: image.image.dimensions,
+      originalDate: image.image.originalDate,
+      // We use the timestamp to avoid caching of the `imageFile` url in the browser
+      url: `${image.image.imageUrl}?width=800&ts=${new Date().getTime()}`,
+    };
+  } else if (file) {
+    const bitmap = await createImageBitmap(file);
+    return {
+      contentType: file.type,
+      fileSize: file.size,
+      dimensions: bitmap,
+      url: URL.createObjectURL(file),
+    };
+  }
+  return undefined;
+};
+
+export const ImageUploadFormElement = ({ language, image }: Props) => {
+  const { t } = useTranslation();
+  const [imageMeta, setImageMeta] = useState<ImageMeta | undefined>(undefined);
+  const [field, meta, helpers] = useField<ImageFormikType["imageFile"]>("imageFile");
+
+  useEffect(() => {
+    getImageMeta(image, typeof field.value === "string" ? undefined : field.value).then((meta) => setImageMeta(meta));
+  }, [image, field.value]);
 
   return (
     <ImageContentWrapper>
-      {!values.imageFile && (
-        <FormField name="imageFile">
-          {({ helpers, meta }) => (
-            <FieldRoot required invalid={!!meta.error}>
-              <FileUploadRoot
-                accept={["image/gif", "image/png", "image/jpeg", "image/svg+xml"]}
-                onFileAccept={(details) => {
-                  const file = details.files?.[0];
-                  if (!file) return;
-                  // TODO: Make consumers handle field values themselves
-                  //       https://github.com/NDLANO/editorial-frontend/pull/2891#discussion_r1991020617
-                  setValues((values) => ({
-                    ...values,
-                    imageFile: file,
-                    contentType: file.type,
-                    fileSize: file.size,
-                    inactive: false,
-                    filepath: URL.createObjectURL(file),
-                  }));
-                  Promise.resolve(
-                    createImageBitmap(file as Blob).then((image) => {
-                      setFieldValue("imageDimensions", image);
-                    }),
-                  );
-                }}
-                maxFileSize={MAX_IMAGE_UPLOAD_SIZE}
-                onFileReject={(details) => {
-                  // Bug in formik's setError function requiring setTimeout to make it work,
-                  // as discussed here: https://github.com/jaredpalmer/formik/discussions/3870
-                  const fileErrors = details.files?.[0]?.errors;
-                  if (!fileErrors) return;
-                  if (fileErrors.includes("FILE_TOO_LARGE")) {
-                    const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t(
-                      "form.image.fileUpload.tooLargeError",
-                    )}`;
-                    setTimeout(() => {
-                      helpers.setError(errorMessage);
-                    }, 0);
-                    return;
-                  }
-                  if (fileErrors.includes("FILE_INVALID_TYPE")) {
-                    const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t(
-                      "form.image.fileUpload.fileTypeInvalidError",
-                    )}`;
-                    setTimeout(() => {
-                      helpers.setError(errorMessage);
-                    }, 0);
-                    return;
-                  }
-                  setTimeout(() => {
-                    helpers.setError(t("form.image.fileUpload.genericError"));
-                  }, 0);
-                }}
-              >
-                <FileUploadDropzone>
-                  <FileUploadLabel>{t("form.image.fileUpload.description")}</FileUploadLabel>
-                  <FileUploadTrigger asChild>
-                    <Button>
-                      <UploadCloudLine />
-                      {t("form.image.fileUpload.button")}
-                    </Button>
-                  </FileUploadTrigger>
-                </FileUploadDropzone>
-                <FileUploadHiddenInput />
-              </FileUploadRoot>
-              <FieldErrorMessage>{meta.error}</FieldErrorMessage>
-            </FieldRoot>
-          )}
-        </FormField>
+      {!field.value && (
+        <FieldRoot required invalid={!!meta.error}>
+          <FileUploadRoot
+            accept={["image/gif", "image/png", "image/jpeg", "image/svg+xml"]}
+            onFileAccept={(details) => {
+              const file = details.files?.[0];
+              if (!file) return;
+              // TODO: Make consumers handle field values themselves
+              //       https://github.com/NDLANO/editorial-frontend/pull/2891#discussion_r1991020617
+              helpers.setValue(file);
+            }}
+            maxFileSize={MAX_IMAGE_UPLOAD_SIZE}
+            onFileReject={(details) => {
+              // Bug in formik's setError function requiring setTimeout to make it work,
+              // as discussed here: https://github.com/jaredpalmer/formik/discussions/3870
+              const fileErrors = details.files?.[0]?.errors;
+              if (!fileErrors) return;
+              if (fileErrors.includes("FILE_TOO_LARGE")) {
+                const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t(
+                  "form.image.fileUpload.tooLargeError",
+                )}`;
+                setTimeout(() => {
+                  helpers.setError(errorMessage);
+                }, 0);
+                return;
+              }
+              if (fileErrors.includes("FILE_INVALID_TYPE")) {
+                const errorMessage = `${t("form.image.fileUpload.genericError")}: ${t(
+                  "form.image.fileUpload.fileTypeInvalidError",
+                )}`;
+                setTimeout(() => {
+                  helpers.setError(errorMessage);
+                }, 0);
+                return;
+              }
+              setTimeout(() => {
+                helpers.setError(t("form.image.fileUpload.genericError"));
+              }, 0);
+            }}
+          >
+            <FileUploadDropzone>
+              <FileUploadLabel>{t("form.image.fileUpload.description")}</FileUploadLabel>
+              <FileUploadTrigger asChild>
+                <Button>
+                  <UploadCloudLine />
+                  {t("form.image.fileUpload.button")}
+                </Button>
+              </FileUploadTrigger>
+            </FileUploadDropzone>
+            <FileUploadHiddenInput />
+          </FileUploadRoot>
+          <FieldErrorMessage>{meta.error}</FieldErrorMessage>
+        </FieldRoot>
       )}
-      {!!values.imageFile && (
+      {!!field.value && (
         <StyledIconButton
           aria-label={t("form.image.removeImage")}
           title={t("form.image.removeImage")}
           variant="danger"
-          onClick={() =>
-            setValues((values) => ({
-              ...values,
-              imageFile: undefined,
-              contentType: undefined,
-              fileSize: undefined,
-              filepath: undefined,
-            }))
-          }
+          onClick={() => helpers.setValue(undefined)}
           size="small"
         >
           <DeleteBinLine />
         </StyledIconButton>
       )}
-      {!!values.imageFile && (
+      {!!imageMeta && (
         <>
-          {typeof values.imageFile === "string" ? (
-            <SafeLink target="_blank" to={values.imageFile}>
-              <StyledImg src={imgSrc} alt="" srcSet="" />
+          {image ? (
+            <SafeLink target="_blank" to={image.image.imageUrl}>
+              <StyledImg src={imageMeta.url} alt="" srcSet="" />
             </SafeLink>
           ) : (
-            <StyledImg src={imgSrc} alt="" srcSet="" />
+            <StyledImg src={imageMeta.url} alt="" srcSet="" />
           )}
           <ImageMeta
-            contentType={values.contentType ?? ""}
-            fileSize={values.fileSize ?? 0}
-            imageDimensions={values.imageDimensions}
-            originalDate={values.originalDate}
+            contentType={imageMeta.contentType}
+            fileSize={imageMeta.fileSize}
+            imageDimensions={imageMeta.dimensions}
+            originalDate={imageMeta.originalDate}
             locale={language}
           />
         </>

--- a/src/containers/ImageUploader/imageTransformers.ts
+++ b/src/containers/ImageUploader/imageTransformers.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { ImageMetaInformationV3DTO, AuthorDTO, ImageDimensionsDTO } from "@ndla/types-backend/image-api";
+import { ImageMetaInformationV3DTO, AuthorDTO } from "@ndla/types-backend/image-api";
 import { Descendant } from "slate";
 import { plainTextToEditorValue } from "../../util/articleContentConverter";
 
@@ -17,6 +17,7 @@ export interface ImageFormikType {
   title: Descendant[];
   alttext: string;
   caption: string;
+  /** If undefined, we're creating an image. If string, we're editing an existing image. If blob, the currently active image hasn't been uploaded yet. */
   imageFile?: string | Blob;
   tags: string[];
   creators: AuthorDTO[];
@@ -26,12 +27,7 @@ export interface ImageFormikType {
   origin: string;
   license?: string;
   modelReleased: string;
-  filepath?: string;
-  contentType?: string;
-  fileSize?: number;
-  imageDimensions?: ImageDimensionsDTO;
   inactive: boolean;
-  originalDate?: string;
 }
 
 export const imageApiTypeToFormType = (
@@ -54,10 +50,6 @@ export const imageApiTypeToFormType = (
     origin: image?.copyright.origin ?? "",
     license: image?.copyright.license.license !== "unknown" ? image?.copyright.license.license : undefined,
     modelReleased: image?.modelRelease ?? "not-set",
-    contentType: image?.image.contentType,
-    fileSize: image?.image.size,
-    imageDimensions: image?.image.dimensions,
     inactive: image?.inactive ?? false,
-    originalDate: image?.image.originalDate,
   };
 };


### PR DESCRIPTION
Det er unødvendig å lagre denne dataen i skjemaet. Vi kan heller regne det ut der vi trenger det.