### PR TITLE
fix: only fall back to normal-text if several blocks are selected

### DIFF
--- a/src/components/SlateEditor/plugins/toolbar/ToolbarTextOptions.tsx
+++ b/src/components/SlateEditor/plugins/toolbar/ToolbarTextOptions.tsx
@@ -52,7 +52,7 @@ const getTextValue = (editor: Editor): TextType => {
     return acc;
   }, new Set<TextType>());
 
-  if (textTypes.size === 1) {
+  if (textTypes.size === 1 || !editor.selectionElements.multipleBlocksOnSameLevel) {
     return textTypes.values().next().value!;
   }
   return "normal-text";


### PR DESCRIPTION
Fixes https://github.com/ndlano/issues/issues/4353
Husker ikke helt konteksten for https://github.com/NDLANO/editorial-frontend/pull/3251, men tror det hadde å gjøre med selection på tvers av blokker på samme nivå. Før #3251 viste vi tekst-typen på elementet som var først i selection. #3251 endret det til å vise normal-text dersom vi hadde valgt flere ulike tekst-blokker. Denne PR'en endrer så vi kun faller tilbake til normal-text dersom man har valgt flere blokker som ikke er inne i hverandre, og som er forskjellige tekst-typer.