### PR TITLE
fix: put `/get_brightcove_token` behind auth

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -62,17 +62,17 @@ router.post("/format-html", async (req, res) => {
   res.status(OK).json({ html });
 });
 
-router.get("/get_brightcove_token", (_, res) => {
+const jwtMiddleware = auth({
+  audience: "ndla_system",
+  issuerBaseURL: `https://${config.auth0BrowserDomain}/`,
+});
+
+router.get("/get_brightcove_token", jwtMiddleware, (_, res) => {
   getBrightcoveToken()
     .then((token) => {
       res.send(token);
     })
     .catch((err) => res.status(INTERNAL_SERVER_ERROR).send(err.message));
-});
-
-const jwtMiddleware = auth({
-  audience: "ndla_system",
-  issuerBaseURL: `https://${config.auth0BrowserDomain}/`,
 });
 
 router.get("/get_note_users", jwtMiddleware, async (req, res) => {

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -121,7 +121,7 @@ export const fetchReAuthorized = async (url: string, config: FetchConfigType = {
   fetchWithAuthorization(url, config, true);
 
 export const fetchBrightcoveAccessToken = () =>
-  fetch("/get_brightcove_token").then((r) => resolveJsonOrRejectWithError<BrightcoveAccessToken>(r));
+  fetchAuthorized("/get_brightcove_token").then((r) => resolveJsonOrRejectWithError<BrightcoveAccessToken>(r));
 
 export const setBrightcoveAccessTokenInLocalStorage = (brightcoveAccessToken: BrightcoveAccessToken) => {
   localStorage.setItem("brightcove_access_token", brightcoveAccessToken.access_token);

--- a/src/util/apiHelpers.ts
+++ b/src/util/apiHelpers.ts
@@ -120,8 +120,19 @@ export const fetchAuthorized = (url: string, config: FetchConfigType = {}) =>
 export const fetchReAuthorized = async (url: string, config: FetchConfigType = {}) =>
   fetchWithAuthorization(url, config, true);
 
-export const fetchBrightcoveAccessToken = () =>
-  fetchAuthorized("/get_brightcove_token").then((r) => resolveJsonOrRejectWithError<BrightcoveAccessToken>(r));
+let inFlightBrightcoveToken: Promise<BrightcoveAccessToken> | null = null;
+
+export const fetchBrightcoveAccessToken = (): Promise<BrightcoveAccessToken> => {
+  if (inFlightBrightcoveToken) return inFlightBrightcoveToken;
+
+  inFlightBrightcoveToken = fetchAuthorized("/get_brightcove_token")
+    .then((r) => resolveJsonOrRejectWithError<BrightcoveAccessToken>(r))
+    .finally(() => {
+      inFlightBrightcoveToken = null;
+    });
+
+  return inFlightBrightcoveToken;
+};
 
 export const setBrightcoveAccessTokenInLocalStorage = (brightcoveAccessToken: BrightcoveAccessToken) => {
   localStorage.setItem("brightcove_access_token", brightcoveAccessToken.access_token);


### PR DESCRIPTION
Denne har vært åpen siden [2017](https://github.com/NDLANO/editorial-frontend/commit/f31e6b068d584628c9cad6de507fd551ee481443), men den burde vel helst ligge bak auth.

Fikser også så vi kun fetcher 1 brightcove token selvom man har flere concurrent requests.