### PR TITLE
Hide firstPublished sort

### DIFF
--- a/src/containers/SearchPage/ContentSearch.tsx
+++ b/src/containers/SearchPage/ContentSearch.tsx
@@ -36,7 +36,7 @@ const SORT_TYPES: SortType[] = [
   "relevance",
   "title",
   "lastUpdated",
-  "firstPublished",
+  //"firstPublished",
   "revisionDate",
   "favorited",
   "published",


### PR DESCRIPTION
Datagrunnlaget kan virke som om noen gamle artikler er førstegangspubliserte før i år. 